### PR TITLE
feat: add issue template for admin access

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,2 @@
 [codespell]
-ignore-words-list = aks,AKS,Aks,NotIn
+ignore-words-list = aks,AKS,Aks,NotIn,requestors

--- a/.github/ISSUE_TEMPLATE/jit-access.yml
+++ b/.github/ISSUE_TEMPLATE/jit-access.yml
@@ -1,0 +1,28 @@
+name: Temporary administrator access request
+description: Request for temporary repository administrator access to this repository, a.k.a Just-in-Time (JIT) access.
+title: "JIT Request"
+labels: ["jit"]
+assignees:
+  - gimsvc_microsoft
+  -
+body:
+  - type: markdown
+    attributes:
+      value: |
+        :closed_lock_with_key: Permanent repository administrator access is not allowed as per Microsoft security policy. You can use this form to request for temporary administrator access to this repository.
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: Describe the actions that you will perform with your temporary administrator access.
+      placeholder: I need to create secrets.
+    validations:
+      required: true
+  - type: dropdown
+    id: duration
+    attributes:
+      label: Duration (hours)
+      description: How long do you need access for? The duration you select is in hours.
+      options:
+        - 1
+        - 2

--- a/.github/policies/jit.yml
+++ b/.github/policies/jit.yml
@@ -1,0 +1,19 @@
+name: JIT_Access
+description: Policy for admin JIT for repos in this org
+
+resource: repository
+
+configuration:
+    jitAccess:
+        enabled: true
+        maxHours: 2
+        approvers:
+            role: maintain
+            users:
+                - ganesan23
+                - croomes
+                - jmclong
+                - landreasyan
+        requestors:
+            role: write
+            users:


### PR DESCRIPTION
By default, no user or team has Admin role to any Organization or Repository in our Microsoft Enterprise. This allows us to operate more safely with a "least required privilege" access model. That said, there are always situations where teams need temporary access to the Admin role so they can configure something they need such as Webhooks or Secrets. 

To request admin access, the user will simply create an Issue within the repository and choose the Temporary administrator access request Issue Template.