### PR TITLE
fix: verbosity flag should work with logr

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 	"k8s.io/utils/exec"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -57,7 +56,7 @@ const (
 
 var (
 	scheme = runtime.NewScheme()
-	log    = ctrl.Log.WithName("setup")
+	log    = ctrl.Log
 )
 
 func init() {
@@ -117,14 +116,17 @@ func main() {
 		"The service id to set in traces that identifies this service instance.")
 	flag.BoolVar(&printVersionAndExit, "version", false, "Print version and exit")
 	flag.BoolVar(&eventRecorderEnabled, "event-recorder-enabled", true, "If enabled, the driver will use the event recorder to record events. This is useful for debugging and monitoring purposes.")
-	// Initialize klog flags
-	klog.InitFlags(flag.CommandLine)
 
-	// Parse flags
+	// Initialize logger flagsconfig.
+	logConfig := textlogger.NewConfig(textlogger.VerbosityFlagName("v"))
+	logConfig.AddFlags(flag.CommandLine)
+
+	// Parse flags.
 	flag.Parse()
 
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+	ctrl.SetLogger(textlogger.NewLogger(logConfig))
 
+	// Log version set by build process.
 	version.Log(log)
 	if printVersionAndExit {
 		return

--- a/internal/csi/server/controller.go
+++ b/internal/csi/server/controller.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"local-csi-driver/internal/pkg/telemetry"
 )
@@ -69,6 +69,8 @@ func NewControllerServer(endpoint string, driver ControllerService, t telemetry.
 //
 // The server will stop when the provided context is canceled.
 func (s *ControllerServer) Start(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
 	listener, err := net.Listen(s.proto, s.addr)
 	if err != nil {
 		return fmt.Errorf("failed to create listener on %s://%s: %w", s.proto, s.addr, err)
@@ -90,7 +92,7 @@ func (s *ControllerServer) Start(ctx context.Context) error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		klog.InfoS("listening for connections", "endpoint", listener.Addr())
+		log.V(2).Info("listening for connections", "endpoint", listener.Addr())
 		errCh <- server.Serve(listener)
 		close(errCh)
 	}()

--- a/internal/csi/server/node.go
+++ b/internal/csi/server/node.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"local-csi-driver/internal/pkg/telemetry"
 )
@@ -65,6 +65,8 @@ func NewNodeServer(endpoint string, driver NodeService, t telemetry.Provider) (*
 //
 // The server will stop when the provided context is canceled.
 func (s *NodeServer) Start(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
 	listener, err := net.Listen(s.proto, s.addr)
 	if err != nil {
 		return fmt.Errorf("failed to create listener on %s://%s: %w", s.proto, s.addr, err)
@@ -81,7 +83,7 @@ func (s *NodeServer) Start(ctx context.Context) error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		klog.InfoS("listening for connections", "endpoint", listener.Addr())
+		log.V(2).Info("listening for connections", "endpoint", listener.Addr())
 		errCh <- server.Serve(listener)
 		close(errCh)
 	}()

--- a/internal/pkg/tracing/provider.go
+++ b/internal/pkg/tracing/provider.go
@@ -15,7 +15,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"k8s.io/component-base/tracing"
 	tracingv1 "k8s.io/component-base/tracing/api/v1"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -39,12 +39,14 @@ var (
 //
 // The provider is stored globally and can be retrieved with GetTracerProvider.
 func New(ctx context.Context, service string, id string, endpoint string, sampleRate int) (tracing.TracerProvider, error) {
+	log := log.FromContext(ctx)
+
 	if endpoint == "" {
-		klog.InfoS("--trace-address not set, tracing disabled")
+		log.V(2).Info("--trace-address not set, tracing disabled")
 		tp = tracing.NewNoopTracerProvider()
 		return tp, nil
 	}
-	klog.InfoS("setting up trace exporter", "endpoint", endpoint, "rate", sampleRate)
+	log.V(2).Info("setting up trace exporter", "endpoint", endpoint, "rate", sampleRate)
 
 	opts := []otlptracegrpc.Option{}
 	rate := int32(sampleRate)


### PR DESCRIPTION
The `--v` verbosity flag was only working with klog, which we migrated away from. This PR removes the remaining klog references and ensures that the verbosity flag works with logr.

There's a couple places where klog is still used since we can't pass in the context to get the logr logger.