### PR TITLE
chore: fix linter install to binary build, add debug info from pre-co…

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,4 +75,4 @@ jobs:
 
       - name: Run pre-commit hooks
         run: |
-          pre-commit run --all-files
+          pre-commit run --all-files --verbose --show-diff-on-failure

--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,9 @@ $(KIND): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	@[ -f "$(GOLANGCI_LINT)" ] || { \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION); \
+	}
 
 .PHONY: go-junit-report
 go-junit-report: $(GO_JUNIT_REPORT) ## Download go-junit-report locally if necessary.


### PR DESCRIPTION
It is not recommended to install golangci-lint with "go install." This change fixes that by installing by different method:
https://github.com/golangci/golangci-lint/issues/5563#issuecomment-2729874830

I also enabled --verbose and --show-diff-on-failure flag to help debug issues in pipeline