### PR TITLE
feat(pipeline): add CG pipeline

### DIFF
--- a/.pipelines/component-governance-detection.yaml
+++ b/.pipelines/component-governance-detection.yaml
@@ -1,0 +1,14 @@
+# This pipeline hosted in ADO will use the auto-injected component detection build task to detect possible incidents
+# and report alerts related to OSS consumed by this repository.
+trigger:
+  branches:
+    include:
+    - main
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - bash: |
+      echo "This task is used to trigger code base scan."
+    displayName: ADO Task


### PR DESCRIPTION
Inspired by:
https://github.com/Azure/fleet/blob/a819c6f598d7fe09826293ccd9aace90e7b06eba/.pipeline/component-governance-detection.yaml

I didn't want to just trigger on go.mod or go.sum since we might have other dependencies