### PR TITLE
ci(dependabot): update dependabot configuration to group changes toge…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,25 +3,53 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 2
     commit-message:
-      prefix: "chore"
+      prefix: "ci"
+      include: "scope"
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
-    open-pull-requests-limit: 1
+      interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "build"
+      include: "scope"
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
-    open-pull-requests-limit: 2
+      interval: "daily"
+    groups:
+      gomod-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
 
   - package-ecosystem: pip
     directory: /.github/workflows
     schedule:
-      interval: daily
+      interval: "daily"
+    groups:
+      pip:
+        patterns:
+          - "*"
     open-pull-requests-limit: 2
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to enhance Dependabot configuration for better control over dependency updates. The changes include adjustments to update intervals, grouping of dependencies, and improvements to commit message formatting.

### Dependabot Configuration Updates:

* **Update Intervals and Limits:**
  - Changed the update interval for `github-actions`, `docker`, `gomod`, and `pip` ecosystems to `"daily"`.
  - Increased the `open-pull-requests-limit` for `github-actions` and `docker` to 2, and for `gomod` to 5.

* **Dependency Grouping:**
  - Introduced groups for each ecosystem (`github-actions`, `docker`, `gomod`, and `pip`) with patterns or update types to better organize dependency updates. For example, `gomod` updates are now grouped into `minor` and `patch` types.

* **Commit Message Formatting:**
  - Updated the commit message prefix for `github-actions` to `"ci"` and for `docker`, `gomod`, and `pip` to `"build"`. Added the `include: "scope"` option to all commit messages for more descriptive commit messages.