### PR TITLE
ci: push tag to ACR when tag is pushed

### DIFF
--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -1,0 +1,131 @@
+name: Build and Push on Tag
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-preview.[0-9]+'
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  REGISTRY: "localcsidriver.azurecr.io"
+  REPO_BASE: "local-csi-driver"
+
+jobs:
+  build-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      TAG: ${{ steps.set-tag.outputs.tag }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Check out the code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set tag from ref
+        id: set-tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Using tag: ${TAG}"
+
+  build-docker:
+    needs: build-vars
+    runs-on: ubuntu-latest
+    environment: pull-request
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Check out the code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Azure CLI Login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: az acr login -n ${{ env.REGISTRY }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        id: setup-buildx
+
+      - name: Set build date
+        id: build-date
+        run: echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - name: Docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_BASE }}/driver:${{ needs.build-vars.outputs.TAG }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_ID=${{ github.run_id }}
+            VERSION=${{ needs.build-vars.outputs.TAG }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.build-date.outputs.date }}
+
+  build-helm:
+    needs: build-vars
+    runs-on: ubuntu-latest
+    environment: pull-request
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Check out the code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Azure CLI Login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: az acr login -n ${{ env.REGISTRY }}
+
+      - name: Build and push Helm chart
+        run: |
+          make helm-login REGISTRY=${{ env.REGISTRY }}
+          make helm-build REGISTRY=${{ env.REGISTRY }} REPO_BASE=${{ env.REPO_BASE }} TAG="${{ needs.build-vars.outputs.TAG }}"
+          make helm-push REGISTRY=${{ env.REGISTRY }} REPO_BASE=${{ env.REPO_BASE }} TAG="${{ needs.build-vars.outputs.TAG }}"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -105,6 +105,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_ID=${{ github.run_id }}
+            VERSION=${{ needs.vars.outputs.TAG }}
             GIT_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ steps.build-date.outputs.date }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY cmd/ cmd/
 COPY internal/ internal/
 
+ARG VERSION
 ARG GIT_COMMIT
 ARG BUILD_DATE
 ARG BUILD_ID
@@ -33,6 +34,7 @@ ARG BUILD_ID
 # and binary shipped on it will have the same platform.
 #
 ARG LDFLAGS="\
+    -X local-csi-driver/internal/pkg/version.version=${VERSION} \
     -X local-csi-driver/internal/pkg/version.gitCommit=${GIT_COMMIT} \
     -X local-csi-driver/internal/pkg/version.buildDate=${BUILD_DATE} \
     -X local-csi-driver/internal/pkg/version.buildId=${BUILD_ID}"

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -16,6 +16,7 @@ import (
 // These are set during build time via -ldflags.
 var (
 	buildId   = "N/A"
+	version   = "N/A"
 	gitCommit = "N/A"
 	buildDate = "N/A"
 )
@@ -23,6 +24,7 @@ var (
 // Info holds the version information.
 type Info struct {
 	BuildId   string
+	Version   string
 	GitCommit string
 	BuildDate string
 	GoVersion string
@@ -34,6 +36,7 @@ type Info struct {
 func GetInfo() Info {
 	return Info{
 		BuildId:   buildId,
+		Version:   version,
 		GitCommit: gitCommit,
 		BuildDate: buildDate,
 		GoVersion: runtime.Version(),
@@ -46,6 +49,7 @@ func Log(log logr.Logger) {
 	info := GetInfo()
 	log.Info("version info",
 		"buildId", info.BuildId,
+		"version", info.Version,
 		"gitCommit", info.GitCommit,
 		"buildDate", info.BuildDate,
 		"goVersion", info.GoVersion,
@@ -58,7 +62,8 @@ func Log(log logr.Logger) {
 func (i Info) Detect(context.Context) (*resource.Resource, error) {
 	return resource.NewWithAttributes(
 		"",
-		attribute.String("service.version", i.GitCommit),
+		attribute.String("service.version", i.Version),
+		attribute.String("service.gitCommit", i.GitCommit),
 		attribute.String("service.buildId", i.BuildId),
 		attribute.String("service.buildDate", i.BuildDate),
 	), nil

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -15,6 +15,7 @@ func TestGetVersion(t *testing.T) {
 
 	expected := Info{
 		BuildId:   "N/A",
+		Version:   "N/A",
 		GitCommit: "N/A",
 		BuildDate: "N/A",
 		GoVersion: runtime.Version(),


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the build and push process when a tag is pushed to the repository. The workflow includes steps for building Docker images and Helm charts, ensuring better automation and consistency in the release process.

### Automation for build and push on tag:

* [`.github/workflows/push-tag.yml`](diffhunk://#diff-8ce7c62dac099f45644da6624b48d6626102231ce06e3b75933e0d2d0d6eeeb4R1-R130): Added a new workflow named "Build and Push on Tag" triggered by specific tag patterns. It includes jobs for building Docker images and Helm charts, with steps for setting up dependencies, logging into Azure and ACR, and pushing artifacts.