### PR TITLE
test: add get storageclass after create to make sure it is available …

### DIFF
--- a/internal/webhook/pvc/handler_test.go
+++ b/internal/webhook/pvc/handler_test.go
@@ -75,6 +75,7 @@ var _ = Describe("When PVC controller is running", Serial, func() {
 			By("Creating a non-acstor storage class")
 			sc = GenStorageClass(testStorageClassName, "disk.csi.azure.com", nil)
 			Expect(k8sClient.Create(ctx, sc)).Should(Succeed())
+			Eventually(storageClassExists(sc.Name)).Should(Succeed(), "StorageClass %s should exist before proceeding", sc.Name)
 
 			By("Creating a pvc")
 			pvc = GenPVC(testStorageClassName, Namespace, "1Gi")
@@ -87,6 +88,7 @@ var _ = Describe("When PVC controller is running", Serial, func() {
 			By("Creating an acstor storage class")
 			sc = GenStorageClass(testStorageClassName, DriverName, nil)
 			Expect(k8sClient.Create(ctx, sc)).Should(Succeed())
+			Eventually(storageClassExists(sc.Name)).Should(Succeed(), "StorageClass %s should exist before proceeding", sc.Name)
 			By("Creating a pvc")
 			pvc = GenPVC(testStorageClassName, Namespace, "1Gi")
 			err := k8sClient.Create(ctx, pvc)
@@ -101,6 +103,7 @@ var _ = Describe("When PVC controller is running", Serial, func() {
 			By("Creating an acstor storage class")
 			sc = GenStorageClass(testStorageClassName, DriverName, nil)
 			Expect(k8sClient.Create(ctx, sc)).Should(Succeed())
+			Eventually(storageClassExists(sc.Name)).Should(Succeed(), "StorageClass %s should exist before proceeding", sc.Name)
 			By("Creating a pvc")
 			pvc = GenPVC(testStorageClassName, Namespace, "1Gi")
 			err := k8sClient.Create(ctx, pvc)
@@ -114,6 +117,8 @@ var _ = Describe("When PVC controller is running", Serial, func() {
 			By("Creating an acstor storage class")
 			sc = GenStorageClass(testStorageClassName, DriverName, nil)
 			Expect(k8sClient.Create(ctx, sc)).Should(Succeed())
+			Eventually(storageClassExists(sc.Name)).Should(Succeed(), "StorageClass %s should exist before proceeding", sc.Name)
+
 			By("Creating a pvc with owner of Kind Pod")
 			pvc = GenPVC(testStorageClassName, Namespace, "1Gi")
 			pvc.SetOwnerReferences([]metav1.OwnerReference{
@@ -133,6 +138,7 @@ var _ = Describe("When PVC controller is running", Serial, func() {
 			By("Creating an acstor storage class")
 			sc = GenStorageClass(testStorageClassName, DriverName, nil)
 			Expect(k8sClient.Create(ctx, sc)).Should(Succeed())
+			Eventually(storageClassExists(sc.Name)).Should(Succeed(), "StorageClass %s should exist before proceeding", sc.Name)
 			By("Creating a pvc with annotation of accept-ephemeral-storage")
 			pvc = GenPVC(testStorageClassName, Namespace, "1Gi")
 			pvc.SetAnnotations(map[string]string{
@@ -171,5 +177,12 @@ func GenPVC(scName, namespace, requestStorage string) *corev1.PersistentVolumeCl
 			StorageClassName: &scName,
 			VolumeName:       uuid.NewString(),
 		},
+	}
+}
+
+func storageClassExists(name string) func() error {
+	sc := &storagev1.StorageClass{}
+	return func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: name}, sc)
 	}
 }


### PR DESCRIPTION
Fix flake in this unit test build:

https://github.com/Azure/local-csi-driver/actions/runs/15687301808/job/44193597641#step:6:690


This pull request enhances the `internal/webhook/pvc/handler_test.go` file by adding a verification step to ensure that a `StorageClass` exists before proceeding with further operations in the tests. The changes improve the reliability of the test suite by introducing a helper function and integrating it into multiple test cases.

### Enhancements to test reliability:

* Added a new helper function `storageClassExists` to verify the existence of a `StorageClass` by querying the Kubernetes client. This function returns an error if the `StorageClass` is not found. (`[internal/webhook/pvc/handler_test.goR182-R188](diffhunk://#diff-f058591b476e908ecf9c1ab1bbe666313e926e8214207f66cf3e6f87b12fd1e5R182-R188)`)

* Integrated the `storageClassExists` function into various test cases to ensure the `StorageClass` is present before proceeding with PVC creation:
  - Verified existence of a non-ACStor `StorageClass` before creating a PVC. (`[internal/webhook/pvc/handler_test.goR78](diffhunk://#diff-f058591b476e908ecf9c1ab1bbe666313e926e8214207f66cf3e6f87b12fd1e5R78)`)
  - Verified existence of ACStor `StorageClass` in multiple test cases, including scenarios with owner references and annotations. (`[[1]](diffhunk://#diff-f058591b476e908ecf9c1ab1bbe666313e926e8214207f66cf3e6f87b12fd1e5R91)`, `[[2]](diffhunk://#diff-f058591b476e908ecf9c1ab1bbe666313e926e8214207f66cf3e6f87b12fd1e5R106)`, `[[3]](diffhunk://#diff-f058591b476e908ecf9c1ab1bbe666313e926e8214207f66cf3e6f87b12fd1e5R120-R121)`, `[[4]](diffhunk://#diff-f058591b476e908ecf9c1ab1bbe666313e926e8214207f66cf3e6f87b12fd1e5R141)`)…for webhook