### PR TITLE
refactor: remove controller-gen

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,7 +43,6 @@ import (
 	"local-csi-driver/internal/pkg/version"
 	"local-csi-driver/internal/webhook/hyperconverged"
 	"local-csi-driver/internal/webhook/pvc"
-	// +kubebuilder:scaffold:imports
 )
 
 const (
@@ -62,8 +61,6 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	// +kubebuilder:scaffold:scheme
 }
 
 //nolint:gocyclo
@@ -315,8 +312,6 @@ func main() {
 	if err != nil {
 		logAndExit(err, "unable to setup volume client with manager")
 	}
-
-	// +kubebuilder:scaffold:builder
 
 	recorder := events.NewNoopRecorder()
 	if eventRecorderEnabled {

--- a/deploy/template/cluster.bicep
+++ b/deploy/template/cluster.bicep
@@ -78,7 +78,6 @@ resource aks 'Microsoft.ContainerService/managedClusters@2023-08-01' = {
     name: 'Base'
     tier: 'Standard'
   }
-  tags: resourceGroup().tags
   properties: {
     nodeResourceGroup: '${resourceGroup().name}-node-rg'
     dnsPrefix: '${resourceGroup().name}-dns'

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,10 +96,8 @@ To build the Helm chart, run:
 make helm-build
 ```
 
-This will create a Helm chart in the `dist` directory. You can then use this
-chart to deploy the project to your Kubernetes cluster. We build the chart using
-[kubebuilder] and [helmify] to convert the Kustomize resources into a Helm
-chart.
+This will package a helm chart for the project and place it in the `dist`
+directory.
 
 ## Deploying the project
 
@@ -262,8 +260,6 @@ breaks the tests, please refer to the
 [pre-commit]: https://pre-commit.com
 [golangci-lint]: https://github.com/golangci/golangci-lint
 [golangci-lint documentation]: https://golangci-lint.run/usage/configuration
-[kubebuilder]: https://github.com/kubernetes-sigs/kubebuilder
-[helmify]: https://github.com/arttor/helmify
 [bicep]: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep
 [kind]: https://kind.sigs.k8s.io
 [external E2E tests]: https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,2 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.

--- a/internal/csi/controller/controller.go
+++ b/internal/csi/controller/controller.go
@@ -46,21 +46,6 @@ type Server struct {
 // Server must implement the csi.ControllerServer interface.
 var _ csi.ControllerServer = &Server{}
 
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims/status,verbs=update;patch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=csidrivers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=csinodes,verbs=get;list;watch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments/status,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=csistoragecapacities,verbs=get;list;watch;update;patch;create;delete
-// +kubebuilder:rbac:groups=apps;extensions,resources=replicasets,verbs=get;list;watch
-// +kubebuilder:rbac:groups=apps;extensions,resources=daemonsets,verbs=get;list;watch
-
 func New(volume core.ControllerInterface, caps []*csi.ControllerServiceCapability, modes []*csi.VolumeCapability_AccessMode, mounter mounter.Interface, k8sClient client.Client, nodeID, selectedNodeAnnotation string, selectedInitialNodeParam string, removePvNodeAffinity bool, recorder record.EventRecorder, tp trace.TracerProvider) *Server {
 	return &Server{
 		caps:                     caps,

--- a/internal/csi/server/controller.go
+++ b/internal/csi/server/controller.go
@@ -36,8 +36,6 @@ type ControllerServer struct {
 	tp     trace.TracerProvider
 }
 
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=csidrivers,verbs=get;list;watch;create;update;patch;delete
-
 // NewControllerServer creates a new CSI server for running in the manager.
 //
 // The server will listen on the provided endpoint and use the provided driver

--- a/internal/webhook/hyperconverged/suite_test.go
+++ b/internal/webhook/hyperconverged/suite_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	// +kubebuilder:scaffold:imports
 )
 
 const (

--- a/internal/webhook/pvc/suite_test.go
+++ b/internal/webhook/pvc/suite_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	// +kubebuilder:scaffold:imports
 )
 
 const (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -60,8 +60,6 @@ var _ = Describe("Local CSI Driver", Label("e2e"), Ordered, func() {
 			}
 			Eventually(verifyCAInjection).Should(Succeed())
 		})
-
-		// +kubebuilder:scaffold:e2e-webhooks-checks
 	})
 
 	// TODO: these tests require diskpools and storagepools to be created on cluster prior to running.

--- a/test/pkg/common/common.go
+++ b/test/pkg/common/common.go
@@ -81,11 +81,6 @@ func Setup(ctx context.Context, namespace string) {
 		image = defaultImage
 	}
 
-	By("generating files")
-	cmd = exec.CommandContext(ctx, "make", "generate")
-	_, err = utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to run make generate")
-
 	isKindClusterCreated = kind.IsClusterCreated()
 
 	if createCluster && isKindClusterCreated {

--- a/test/scale/scale.go
+++ b/test/scale/scale.go
@@ -44,7 +44,6 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 }
 


### PR DESCRIPTION
This pull request removes the generation of Kubernetes manifests and scaffolding code from the `Makefile` and associated files, simplifying the build and test processes. The most significant changes include the removal of `controller-gen` and related targets, the cleanup of associated RBAC annotations, and the elimination of scaffolding markers.

### Build and Test Process Simplifications:
* Removed `manifests` and `generate` targets from the `Makefile`, along with their associated commands for generating Kubernetes manifests and DeepCopy methods. This also removes the dependency on `controller-gen`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L81-L91) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L450-L454)
* Updated various `Makefile` targets (e.g., `test`, `e2e`, `build`, `run`, `docker-build`, `helm-build`, `deploy`, etc.) to no longer depend on `manifests` or `generate`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L105-R94) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L122-R111) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L191-R188) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L251-R240) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L312-R301) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L365-R362)

### Code Cleanup:
* Removed unused `controller-gen` binary and version definitions from the `Makefile`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L409) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L426)
* Deleted RBAC annotations from `internal/csi/controller/controller.go` and `internal/csi/server/controller.go`. [[1]](diffhunk://#diff-22fa5d5f84a2eb3319543e24d6b43ab31cdd3e433e6d56003b5e45a047ea1189L49-L63) [[2]](diffhunk://#diff-03ae0edaba170c348f3a5a78d0838d314c6f4004ba2890540a46f68befc80b90L39-L40)
* Eliminated scaffolding markers (e.g., `+kubebuilder:scaffold`) from various files, including `cmd/main.go`, test files, and others. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L46) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L65-L66) [[3]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L319-L320) [[4]](diffhunk://#diff-170e326409df7756124abfb40010ed46e2bd5465b649d7a341614b8ca5b43496L32) [[5]](diffhunk://#diff-e5638fc054d4e8e5e88b2235391f3074ea525be6c8ac099a7e6df028fb56e39bL32) [[6]](diffhunk://#diff-d5d12b6ea07b0a78c9ad1987e1486c565ecf16839f77a93e91b09475cf6c0e99L63-L64) [[7]](diffhunk://#diff-1b0436930bfc1ab5b8f88d950b83df5e030c18463f211b00bd9eb7b4ca430505L47)

### Licensing Update:
* Removed the license header from `hack/boilerplate.go.txt`.

### Test Setup Adjustments:
* Updated `test/pkg/common/common.go` to remove the steps for generating manifests and files during test setup.