### PR TITLE
fix: fix GetCapacity call when no disks are available

### DIFF
--- a/internal/csi/core/lvm/controller_test.go
+++ b/internal/csi/core/lvm/controller_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	lvmMgr "local-csi-driver/internal/pkg/lvm"
+	"local-csi-driver/internal/pkg/probe"
+)
+
+const (
+	testVolumeGroup = "test-vg"
+)
+
+func TestAvailableCapacity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		vgName      string
+		expectLvm   func(*lvmMgr.MockManager)
+		expectProbe func(*probe.Mock)
+		expectedCap int64
+		expectedErr error
+	}{
+		{
+			name:   "no devices found",
+			vgName: testVolumeGroup,
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetVolumeGroup(gomock.Any(), testVolumeGroup).Return(nil, lvmMgr.ErrNotFound)
+			},
+			expectProbe: func(p *probe.Mock) {
+				p.EXPECT().ScanDevices(gomock.Any(), gomock.Any()).Return(nil, probe.ErrNoDevicesFound)
+			},
+			expectedCap: 0,
+		},
+		{
+			name:   "no devices matching filter",
+			vgName: testVolumeGroup,
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetVolumeGroup(gomock.Any(), testVolumeGroup).Return(nil, lvmMgr.ErrNotFound)
+			},
+			expectProbe: func(p *probe.Mock) {
+				p.EXPECT().ScanDevices(gomock.Any(), gomock.Any()).Return(nil, probe.ErrNoDevicesMatchingFilter)
+			},
+			expectedCap: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			l, p, m, err := initTestLVM(gomock.NewController(t))
+			if err != nil {
+				t.Fatalf("failed to initialize LVM: %v", err)
+			}
+			if tt.expectLvm != nil {
+				tt.expectLvm(m)
+			}
+			if tt.expectProbe != nil {
+				tt.expectProbe(p)
+			}
+			cap, err := l.AvailableCapacity(context.Background(), tt.vgName)
+			if !errors.Is(err, tt.expectedErr) {
+				t.Errorf("EnsureVolume() error = %v, expectErr %v", err, tt.expectedErr)
+			}
+			if cap != tt.expectedCap {
+				t.Errorf("EnsureVolume() cap = %d, expectCap %d", cap, tt.expectedCap)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This pull request introduces error handling improvements in the `AvailableCapacity` method and adds unit tests to validate the changes. The key updates include handling specific probe errors gracefully and creating tests to ensure these scenarios are covered.

Fixes #55

### Error handling improvements:
* [`internal/csi/core/lvm/controller.go`](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575R302-R305): Updated the `AvailableCapacity` method to handle `probe.ErrNoDevicesFound` and `probe.ErrNoDevicesMatchingFilter` explicitly, returning a capacity of `0` and setting the span status to `Ok` in these cases.

### Unit tests:
* [`internal/csi/core/lvm/controller_test.go`](diffhunk://#diff-5060a8629f8bb63873dee9181ae9568fa1ab4fdcd4bbc7596e9ef1d14089cc19R1-R78): Added a new test suite for the `AvailableCapacity` method with test cases for scenarios where no devices are found or no devices match the filter. These tests use mocks to simulate the behavior of the `probe` and `lvm` components.

### Dependency updates:
* [`internal/csi/core/lvm/controller.go`](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575R26): Imported the `probe` package to support the new error handling logic.