### PR TITLE
refactor: helm values refactoring

### DIFF
--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -32,8 +32,25 @@ spec:
                 operator: In
                 values:
                 - linux
+
       containers:
-      - args: {{- toYaml .Values.daemonset.driver.args | nindent 8 }}
+
+      - name: driver
+        args:
+        - --node-name=$(NODE_NAME)
+        - --pod-name=$(POD_NAME)
+        - --namespace=$(POD_NAMESPACE)
+        - --csi-bind-address=unix:///csi/csi.sock
+        - --worker-threads={{ .Values.scalability.driver.workerThreads }}
+        - --kube-api-qps={{ .Values.scalability.driver.kubeApi.qps }}
+        - --kube-api-burst={{ .Values.scalability.driver.kubeApi.burst }}
+        - --metrics-bind-address=:{{ .Values.observability.driver.metrics.port }}
+        - --metrics-secure=false
+        - --health-probe-bind-address=:{{ .Values.observability.driver.health.port }}
+        - --trace-address={{ .Values.observability.driver.trace.endpoint }}
+        - --trace-sample-rate={{ .Values.observability.driver.trace.sampleRate }}
+        - --trace-service-id=$(POD_NAME)
+        - --v={{ .Values.observability.driver.log.level }}
         {{- if or .Values.webhook.ephemeral.enabled .Values.webhook.hyperconverged.enabled }}
         - --webhook-service-name={{ .Values.name }}-webhook-service
         {{- end }}
@@ -72,29 +89,32 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: driver
+            port: health
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: driver
         ports:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        - containerPort: 8080
+        - containerPort: {{ .Values.observability.driver.metrics.port }}
           name: metrics
           protocol: TCP
-        - containerPort: 8081
-          name: driver
+        - containerPort: {{ .Values.observability.driver.health.port }}
+          name: health
           protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
-            port: driver
+            port: health
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources: {{- toYaml .Values.daemonset.driver.resources | nindent 10 }}
-        securityContext: {{- toYaml .Values.daemonset.driver.containerSecurityContext | nindent
-          10 }}
+        resources: {{- toYaml .Values.resources.driver | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
         terminationMessagePath: /tmp/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -113,7 +133,24 @@ spec:
         - mountPath: /var/lib/kubelet/
           mountPropagation: Bidirectional
           name: mountpoint-dir
-      - args: {{- toYaml .Values.daemonset.csiProvisioner.args | nindent 8 }}
+
+      - name: csi-provisioner
+        args:
+        - --csi-address=/csi/csi.sock
+        - --node-deployment
+        - --http-endpoint=:{{ .Values.observability.csiProvisioner.http.port }}
+        - --retry-interval-start=1s
+        - --retry-interval-max=30s
+        - --worker-threads={{ .Values.scalability.csiProvisioner.workerThreads }}
+        - --kube-api-qps={{ .Values.scalability.csiProvisioner.kubeApi.qps }}
+        - --kube-api-burst={{ .Values.scalability.csiProvisioner.kubeApi.burst }}
+        - --extra-create-metadata
+        - --feature-gates=Topology=true
+        - --strict-topology=true
+        - --enable-capacity
+        - --capacity-ownerref-level=1
+        - --capacity-poll-interval=15s
+        - --v={{ .Values.observability.csiProvisioner.log.level }}
         env:
         - name: NAMESPACE
           valueFrom:
@@ -142,19 +179,23 @@ spec:
           tcpSocket:
             port: provisioner
           timeoutSeconds: 10
-        name: csi-provisioner
         ports:
-        - containerPort: 8090
+        - containerPort: {{ .Values.observability.csiProvisioner.http.port }}
           name: provisioner
           protocol: TCP
-        resources: {{- toYaml .Values.daemonset.csiProvisioner.resources | nindent 10 }}
+        resources: {{- toYaml .Values.resources.csiProvisioner | nindent 10 }}
         volumeMounts:
         - mountPath: /csi
           name: csi-socket-dir
-      - args: {{- toYaml .Values.daemonset.lvmResizer.args | nindent 8 }}
+
+      - name: csi-resizer
+        args:
+        - --csi-address=/csi/csi.sock
+        - --timeout=240s
+        - --handle-volume-inuse-error=true
+        - --http-endpoint=:{{ .Values.observability.csiResizer.http.port }}
+        - --v={{ .Values.observability.csiResizer.log.level }}
         env:
-        - name: ADDRESS
-          value: {{ quote .Values.daemonset.lvmResizer.env.address }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -167,16 +208,21 @@ spec:
         image: "{{ .Values.image.csiResizer.repository }}:{{ .Values.image.csiResizer.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.image.csiResizer.pullPolicy }}
-        name: csi-resizer
         ports:
-        - containerPort: 29756
+        - containerPort: {{ .Values.observability.csiResizer.http.port }}
           name: resizer
           protocol: TCP
-        resources: {{- toYaml .Values.daemonset.lvmResizer.resources | nindent 10 }}
+        resources: {{- toYaml .Values.resources.csiResizer | nindent 10 }}
         volumeMounts:
         - mountPath: /csi
           name: csi-socket-dir
-      - args: {{- toYaml .Values.daemonset.csiRegistrar.args | nindent 8 }}
+
+      - name: csi-registrar
+        args:
+        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/local.csi.azure.com/csi.sock
+        - --http-endpoint=:{{ .Values.observability.nodeDriverRegistrar.http.port }}
+        - --v={{ .Values.observability.nodeDriverRegistrar.log.level }}
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
@@ -194,21 +240,23 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 20
           timeoutSeconds: 5
-        name: csi-registrar
         ports:
-        - containerPort: 8091
+        - containerPort: {{ .Values.observability.nodeDriverRegistrar.http.port }}
           name: registrar
           protocol: TCP
-        resources: {{- toYaml .Values.daemonset.csiRegistrar.resources | nindent 10 }}
+        resources: {{- toYaml .Values.resources.nodeDriverRegistrar | nindent 10 }}
         volumeMounts:
         - mountPath: /csi
           name: csi-socket-dir
         - mountPath: /registration
           name: registration-dir
+
       hostPID: true
       nodeSelector: {{- toYaml .Values.daemonset.nodeSelector | nindent 8 }}
       priorityClassName: system-node-critical
-      securityContext: {{- toYaml .Values.daemonset.podSecurityContext | nindent 8 }}
+      securityContext:
+        seccompProfile:
+          type: Unconfined
       serviceAccountName: {{ .Values.name }}-node
       terminationGracePeriodSeconds: 60
       tolerations:
@@ -231,7 +279,7 @@ spec:
           type: DirectoryOrCreate
         name: k8s-cfg
       - hostPath:
-          path: /var/lib/kubelet/plugins/cns.io/
+          path: /var/lib/kubelet/plugins/local.csi.azure.com/
           type: DirectoryOrCreate
         name: csi-socket-dir
       - hostPath:

--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -5,23 +5,16 @@ image:
   baseRepo: mcr.microsoft.com
   driver:
     repository: /acstor/local-csi-driver
+    # When the tag is unset (recommended), the chart version is used as the tag.
     tag:
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: /oss/v2/kubernetes-csi/csi-provisioner
     tag: v5.2.0
     pullPolicy: IfNotPresent
-  csiAttacher:
-    repository: /oss/v2/kubernetes-csi/csi-attacher
-    tag: v4.8.1
-    pullPolicy: IfNotPresent
   csiResizer:
     repository: /oss/v2/kubernetes-csi/csi-resizer
     tag: v1.13.2
-    pullPolicy: IfNotPresent
-  livenessProbe:
-    repository: /oss/v2/kubernetes-csi/livenessprobe
-    tag: v2.15.0
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: /oss/v2/kubernetes-csi/csi-node-driver-registrar
@@ -29,101 +22,14 @@ image:
     pullPolicy: IfNotPresent
 
 kubernetesClusterDomain: cluster.local
+
+# DaemonSet configuration.
 daemonset:
-  csiProvisioner:
-    args:
-    - --v=2
-    - --csi-address=/csi/lvm.sock
-    - --node-deployment
-    - --http-endpoint=:8090
-    - --retry-interval-start=1s
-    - --retry-interval-max=30s
-    - --worker-threads=100
-    - --kube-api-qps=100
-    - --kube-api-burst=200
-    - --extra-create-metadata
-    - --feature-gates=Topology=true
-    - --strict-topology=true
-    - --enable-capacity
-    - --capacity-ownerref-level=1
-    - --capacity-poll-interval=15s
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  csiRegistrar:
-    args:
-    - --v=2
-    - --csi-address=/csi/lvm.sock
-    - --kubelet-registration-path=/var/lib/kubelet/plugins/cns.io/lvm.sock
-    - --http-endpoint=:8091
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  driver:
-    args:
-    - --nodeName=$(NODE_NAME)
-    - --podName=$(POD_NAME)
-    - --namespace=$(POD_NAMESPACE)
-    - --csi-bind-address=unix:///csi/lvm.sock
-    - --metrics-bind-address=:8080
-    - --health-probe-bind-address=:8081
-    - --worker-threads=100
-    - --kube-api-qps=100
-    - --kube-api-burst=200
-    - --trace-address=jaeger-collector.observability.svc.cluster.local:4317
-    - --trace-sample-rate=1000000
-    - --trace-service-id=$(POD_NAME)
-    - --metrics-secure=false
-    - --v=2
-    containerSecurityContext:
-      allowPrivilegeEscalation: true
-      capabilities:
-        add:
-        - SYS_ADMIN
-      privileged: true
-    image:
-      repository: localcsidriver.azurecr.io/local-csi-driver/driver
-      # When unset, uses the chart version as the tag.
-      tag:
-    imagePullPolicy: Always
-    resources:
-      limits:
-        cpu: 500m
-        memory: 600Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  lvmResizer:
-    args:
-    - --v=2
-    - --csi-address=/csi/lvm.sock
-    - --timeout=240s
-    - --handle-volume-inuse-error=true
-    - --http-endpoint=0.0.0.0:29756
-    env:
-      address: /csi/lvm.sock
-    resources:
-      limits:
-        memory: 500Mi
-      requests:
-        cpu: 10m
-        memory: 20Mi
   nodeSelector: {}
-  podSecurityContext:
-    seccompProfile:
-      type: Unconfined
   serviceAccount:
     annotations: {}
 
-# webhook configuration.
+# Webhook configuration.
 webhook:
   ephemeral:
     # Enables the ephemeral PVC validation webhook, which enforces that PVCs are
@@ -140,3 +46,71 @@ webhook:
       protocol: TCP
       targetPort: 9443
     type: ClusterIP
+
+# Resource configuration.
+resources:
+  driver:
+    limits:
+      memory: 600Mi
+    requests:
+      cpu: 10m
+      memory: 60Mi
+  csiProvisioner:
+    limits:
+      memory: 100Mi
+    requests:
+      cpu: 10m
+      memory: 20Mi
+  csiResizer:
+    limits:
+      memory: 500Mi
+    requests:
+      cpu: 10m
+      memory: 20Mi
+  nodeDriverRegistrar:
+    limits:
+      memory: 100Mi
+    requests:
+      cpu: 10m
+      memory: 20Mi
+
+# Observability and health configuration.
+observability:
+  driver:
+    log:
+      level: 2
+    metrics:
+      port: 8080
+    health:
+      port: 8081
+    trace:
+      endpoint: jaeger-collector.observability.svc.cluster.local:4317
+      sampleRate: "1000000"
+  csiProvisioner:
+    log:
+      level: 2
+    http:
+      port: 8090
+  csiResizer:
+    log:
+      level: 2
+    http:
+      port: 8091
+  nodeDriverRegistrar:
+    log:
+      level: 2
+    http:
+      port: 8092
+
+# Scalability tuning.
+scalability:
+  driver:
+    workerThreads: 100
+    kubeApi:
+      qps: 100
+      burst: 200
+  csiProvisioner:
+    workerThreads: 100
+    kubeApi:
+      qps: 100
+      burst: 200

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,9 +87,9 @@ func main() {
 	var tlsOpts []func(*tls.Config)
 	var printVersionAndExit bool
 	var eventRecorderEnabled bool
-	flag.StringVar(&nodeName, "nodeName", "",
+	flag.StringVar(&nodeName, "node-name", "",
 		"The name of the node this agent is running on.")
-	flag.StringVar(&podName, "podName", "",
+	flag.StringVar(&podName, "pod-name", "",
 		"The name of the pod this agent is running on.")
 	flag.StringVar(&namespace, "namespace", "default",
 		"The namespace to use for creating objects.")

--- a/test/sanity/fixtures/socat-patch.yaml
+++ b/test/sanity/fixtures/socat-patch.yaml
@@ -19,13 +19,13 @@ spec:
         - mountPath: /shared
           name: shared-dir
       containers:
-      - name: socat-lvm
+      - name: socat-csi
         image: mcr.microsoft.com/azurelinux/base/core:3.0
         command:
           - /shared/usr/bin/socat
         args:
           - tcp-listen:10000,fork,reuseaddr
-          - unix-connect:/csi/lvm.sock
+          - unix-connect:/csi/csi.sock
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Re-arranges the helm values so we only expose vars that can be changed. Previously, we couldn't easily change anything that is set in a command argument. Now, they can be modified individually. Halm values are now grouped by function.

There are still some improvements to be made (e.g. remove unused env vars), but this is the bulk of the changes.