### PR TITLE
refactor: move docker and helm build into template, update repos to r…

### DIFF
--- a/.github/workflows/docker-build-template.yml
+++ b/.github/workflows/docker-build-template.yml
@@ -1,0 +1,101 @@
+name: Docker Build Template
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        description: 'Container registry URL'
+        required: true
+        type: string
+      repo_base:
+        description: 'Repository base path'
+        required: true
+        type: string
+      version:
+        description: 'Version tag for the image'
+        required: true
+        type: string
+      tags:
+        description: 'Image tags (YAML array)'
+        required: true
+        type: string
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    environment: pull-request
+    strategy:
+      matrix:
+        image:
+          - name: local-csi-driver
+            dockerfile: Dockerfile
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Check out the code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Azure CLI Login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: az acr login -n ${{ inputs.registry }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Set build date
+        id: build-date
+        run: echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - name: Set image tags
+        id: set-tags
+        run: |
+          tags=()
+          while IFS= read -r tag; do
+            if [[ -z "$tag" ]]; then
+              continue
+            fi
+            tags+=("${{ inputs.registry }}/${{ inputs.repo_base }}/${{ matrix.image.name }}:${tag}")
+          done <<< "${{ inputs.tags }}"
+
+          echo "tags=${tags[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          push: true
+          tags: ${{ steps.set-tags.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_ID=${{ github.run_id }}
+            VERSION=${{ inputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.build-date.outputs.date }}

--- a/.github/workflows/helm-build-template.yml
+++ b/.github/workflows/helm-build-template.yml
@@ -1,0 +1,77 @@
+name: Helm Build Template
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        description: 'Container registry URL'
+        required: true
+        type: string
+      repo_base:
+        description: 'Repository base path'
+        required: true
+        type: string
+      tags:
+        description: 'Helm chart tags (YAML array)'
+        required: true
+        type: string
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-helm:
+    runs-on: ubuntu-latest
+    environment: pull-request
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Check out the code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Azure CLI Login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: az acr login -n ${{ inputs.registry }}
+
+      - name: Build and push Helm chart
+        run: |
+          # Login to Helm registry
+          make helm-login REGISTRY=${{ inputs.registry }}
+
+          # Build chart for each tag
+          while IFS= read -r tag; do
+            if [[ -z "${tag}" ]]; then
+              continue
+            fi
+            echo "Building and pushing Helm chart for tag: ${tag}"
+            make helm-build REGISTRY=${{ inputs.registry }} REPO_BASE=${{ inputs.repo_base }} TAG="${tag}"
+            make helm-push REGISTRY=${{ inputs.registry }} REPO_BASE=${{ inputs.repo_base }} TAG="${tag}"
+            echo "✓ Completed Helm chart: ${tag}"
+          done <<< "${{ inputs.tags }}"
+
+          echo "Helm charts built and pushed successfully"

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -10,10 +10,6 @@ permissions:
   contents: read
   id-token: write
 
-env:
-  REGISTRY: "localcsidriver.azurecr.io"
-  REPO_BASE: "local-csi-driver"
-
 jobs:
   build-vars:
     runs-on: ubuntu-latest
@@ -39,93 +35,27 @@ jobs:
 
   build-docker:
     needs: build-vars
-    runs-on: ubuntu-latest
-    environment: pull-request
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: audit
+    uses: ./.github/workflows/docker-build-template.yml
+    with:
+      registry: "localcsidriver.azurecr.io"
+      repo_base: "acstor"
+      version: ${{ needs.build-vars.outputs.TAG }}
+      tags: ${{ needs.build-vars.outputs.TAG }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Check out the code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
 
-      - name: Azure CLI Login
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: ACR login
-        run: az acr login -n ${{ env.REGISTRY }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        id: setup-buildx
-
-      - name: Set build date
-        id: build-date
-        run: echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
-
-      - name: Docker build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPO_BASE }}/driver:${{ needs.build-vars.outputs.TAG }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILD_ID=${{ github.run_id }}
-            VERSION=${{ needs.build-vars.outputs.TAG }}
-            GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ steps.build-date.outputs.date }}
 
   build-helm:
-    needs: build-vars
-    runs-on: ubuntu-latest
-    environment: pull-request
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: audit
-
-      - name: Check out the code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-
-      - name: Azure CLI Login
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: ACR login
-        run: az acr login -n ${{ env.REGISTRY }}
-
-      - name: Build and push Helm chart
-        run: |
-          make helm-login REGISTRY=${{ env.REGISTRY }}
-          make helm-build REGISTRY=${{ env.REGISTRY }} REPO_BASE=${{ env.REPO_BASE }} TAG="${{ needs.build-vars.outputs.TAG }}"
-          make helm-push REGISTRY=${{ env.REGISTRY }} REPO_BASE=${{ env.REPO_BASE }} TAG="${{ needs.build-vars.outputs.TAG }}"
+    needs: [build-vars]
+    uses: ./.github/workflows/helm-build-template.yml
+    with:
+      registry: "localcsidriver.azurecr.io"
+      repo_base: "acstor"
+      tags: ${{ needs.build-vars.outputs.TAG }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -21,7 +21,7 @@ env:
   PATCH: "1"
   PYTHON_VERSION: "3.x"
   REGISTRY: "localcsidriver.azurecr.io"
-  REPO_BASE: "local-csi-driver"
+  REPO_BASE: "acstor"
 
 jobs:
   vars:
@@ -42,116 +42,34 @@ jobs:
           # Create tag in format MAJOR.MINOR.PATCH-REF
           TAG="${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}-${SHORT_SHA}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Generated tag: ${TAG}"
   build-docker:
     needs: vars
-    runs-on: ubuntu-latest
-    environment: pull-request
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: audit
-
-      - name: Check out the code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-
-      - name: Azure CLI Login
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: ACR login
-        run: az acr login -n ${{ env.REGISTRY }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        id: setup-buildx
-
-      - name: Set build date
-        id: build-date
-        run: echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
-
-      - name: Set Docker tags
-        id: docker-tags
-        run: |
-          TAGS="${{ env.REGISTRY }}/${{ env.REPO_BASE }}/driver:${{ needs.vars.outputs.TAG }}"
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.REPO_BASE }}/driver:${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}-latest"
-          fi
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
-
-      - name: Docker build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILD_ID=${{ github.run_id }}
-            VERSION=${{ needs.vars.outputs.TAG }}
-            GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ steps.build-date.outputs.date }}
+    uses: ./.github/workflows/docker-build-template.yml
+    with:
+      registry: "localcsidriver.azurecr.io"
+      repo_base: "acstor"
+      version: ${{ needs.vars.outputs.TAG }}
+      tags: |
+        ${{ needs.vars.outputs.TAG }}
+        ${{ github.ref == 'refs/heads/main' && '${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}-latest' || '' }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   build-helm:
     needs: vars
-    runs-on: ubuntu-latest
-    environment: pull-request
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: audit
-
-      - name: Check out the code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-
-      - name: Azure CLI Login
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: ACR login
-        run: az acr login -n ${{ env.REGISTRY }}
-
-      - name: Build and push Helm chart
-        run: |
-          TAGS=()
-          TAGS+=("${{ needs.vars.outputs.TAG }}")
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            TAGS+=("${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}-latest")
-          fi
-          make helm-login REGISTRY=${{ env.REGISTRY }}
-          for tag in "${TAGS[@]}"; do
-            make helm-build REGISTRY=${{ env.REGISTRY }} REPO_BASE=${{ env.REPO_BASE }} TAG="$tag"
-            make helm-push REGISTRY=${{ env.REGISTRY }} REPO_BASE=${{ env.REPO_BASE }} TAG="$tag"
-          done
+    uses: ./.github/workflows/helm-build-template.yml
+    with:
+      registry: "localcsidriver.azurecr.io"
+      repo_base: "acstor"
+      tags: |
+        ${{ needs.vars.outputs.TAG }}
+        ${{ github.ref == 'refs/heads/main' && '${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}-latest' || '' }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   e2e-test:
     needs: [build-docker, build-helm, vars]

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ REGISTRY ?= docker.io
 
 # REPO_BASE is used in the Dockerfile and will be set to empty when run in the
 # pipelines. Set default for empty string, not just undefined.
-REPO_BASE := $(if $(REPO_BASE),$(REPO_BASE),local-csi-driver)
-REPO ?= $(REPO_BASE)/driver
+REPO_BASE := $(if $(REPO_BASE),$(REPO_BASE),acstor)
+REPO ?= $(REPO_BASE)/local-csi-driver
 
 COMMIT_HASH ?= $(shell git describe --always --dirty)
 TAG ?= 0.0.0-$(COMMIT_HASH)
 IMG ?= $(REGISTRY)/$(REPO):$(TAG)
-CHART_IMG ?= $(REGISTRY)/$(REPO_BASE)/local-csi-driver
+CHART_REPO ?= $(REGISTRY)/$(REPO_BASE)/charts
+CHART_IMG ?= $(CHART_REPO)/local-csi-driver
 
 SKIP_CREATE_CLUSTER ?= false
 ADDITIONAL_GINKGO_FLAGS ?=
@@ -260,7 +261,7 @@ helm-login: helm ## Log in to the ACR Helm registry.
 
 .PHONY: helm-push
 helm-push: helm helm-build ## Push the Helm chart to the Helm repository.
-	$(HELM) push dist/local-csi-driver-$(TAG).tgz oci://$(REGISTRY)/$(REPO_BASE)
+	$(HELM) push dist/local-csi-driver-$(TAG).tgz oci://$(CHART_REPO)
 
 ##@ Deployment
 


### PR DESCRIPTION
This pull request introduces reusable GitHub Actions workflow templates for building Docker images and Helm charts, along with refactoring existing workflows to use these templates. Additionally, it updates the `Makefile` to align with the new repository structure and registry configuration.

Getting environment secrets to work in the called workflow was tricky. I read this here to help:
https://github.com/orgs/community/discussions/25238#discussioncomment-3247035

### Workflow Template Additions:
* [`.github/workflows/docker-build-template.yml`](diffhunk://#diff-8585e106f027c5bf26e870d6d479ed8753277911f6252b9acd86610020ef19e7R1-R101): Added a reusable workflow for building and pushing Docker images, including steps for setting up QEMU, Docker Buildx, and Azure CLI login.
* [`.github/workflows/helm-build-template.yml`](diffhunk://#diff-97b60bb74b34261dda2a37d80b818b0e2c08d19620a569b2490d4e3ce1ee2096R1-R77): Added a reusable workflow for building and pushing Helm charts, with steps for Helm registry login and chart processing.

### Workflow Refactoring:
* [`.github/workflows/push-tag.yml`](diffhunk://#diff-8ce7c62dac099f45644da6624b48d6626102231ce06e3b75933e0d2d0d6eeeb4L13-L16): Replaced inline Docker and Helm build steps with calls to the new reusable workflow templates, reducing duplication and streamlining configuration. [[1]](diffhunk://#diff-8ce7c62dac099f45644da6624b48d6626102231ce06e3b75933e0d2d0d6eeeb4L13-L16) [[2]](diffhunk://#diff-8ce7c62dac099f45644da6624b48d6626102231ce06e3b75933e0d2d0d6eeeb4L42-R61)
* [`.github/workflows/test-e2e.yml`](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becL23-L24): Updated the E2E test workflow to use the reusable Docker and Helm build templates, ensuring consistency across workflows. [[1]](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becL23-L24) [[2]](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becL45-R70)

### Makefile Updates:
* Updated `REPO_BASE` to `acstor` and restructured `CHART_REPO` for Helm chart storage. Adjusted related targets to reflect these changes. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R16) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L263-R264)…eflect naming changes