### PR TITLE
fix: set tracing to no-op if not set in values

### DIFF
--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -84,7 +84,7 @@ observability:
     health:
       port: 8081
     trace:
-      endpoint: jaeger-collector.observability.svc.cluster.local:4317
+      endpoint: ""
       sampleRate: "1000000"
   csiProvisioner:
     log:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -119,7 +119,7 @@ func main() {
 	flag.IntVar(&apiBurst, "kube-api-burst", 30,
 		"Burst to use while communicating with the kubernetes apiserver. Defaults to 30.")
 	flag.StringVar(&traceAddr, "trace-address", "",
-		"The address to send traces to. localhost:4317 if not set.")
+		"The address to send traces to. Disables tracing if not set.")
 	flag.IntVar(&traceSampleRate, "trace-sample-rate", 0,
 		"Sample rate per million. 0 to disable tracing, 1000000 to trace everything.")
 	flag.StringVar(&traceServiceID, "trace-service-id", "",

--- a/internal/pkg/telemetry/otel_test.go
+++ b/internal/pkg/telemetry/otel_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"k8s.io/component-base/tracing"
+)
+
+func TestInitTracing(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      config
+		expectedErr error
+		validate    func(t *testing.T, tp tracing.TracerProvider)
+	}{
+		{
+			name: "without endpoint creates noop provider",
+			config: config{
+				endpoint:        "",
+				traceSampleRate: 1,
+			},
+			validate: func(t *testing.T, tp tracing.TracerProvider) {
+				if !reflect.DeepEqual(tp, tracing.NewNoopTracerProvider()) {
+					t.Fatalf("expected noop tracer provider, got %v", tp)
+				}
+			},
+		},
+		{
+			name: "without traceSampleRate as zero creates noop provider",
+			config: config{
+				endpoint:        "jaeger-collector.observability.svc.cluster.local:4317",
+				traceSampleRate: 0,
+			},
+			validate: func(t *testing.T, tp tracing.TracerProvider) {
+				if !reflect.DeepEqual(tp, tracing.NewNoopTracerProvider()) {
+					t.Fatalf("expected noop tracer provider, got %v", tp)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tp, err := InitTracing(context.Background(), tt.config)
+			if !errors.Is(err, tt.expectedErr) {
+				t.Fatalf("InitTracing() error = %v, wantErr %v", err, tt.expectedErr)
+			}
+			if tt.validate != nil {
+				tt.validate(t, tp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of OpenTelemetry tracing configuration and improve test coverage. The updates include making tracing optional based on configuration, refining user-facing messaging, and adding unit tests to validate the behavior of the tracing initialization logic.

Fixes #54

### Enhancements to tracing configuration:

* [`charts/latest/values.yaml`](diffhunk://#diff-d29b314008db700bde7facdb68fc5dcd58008824558728002e8d9b436fb0fc04L87-R87): Updated the default `trace.endpoint` to an empty string (`""`) to indicate that tracing is disabled by default.
* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L122-R122): Clarified the flag description for `--trace-address` to specify that tracing is disabled if the address is not set.
* [`internal/pkg/telemetry/otel.go`](diffhunk://#diff-f20f9cd4bd2a1eb9d384ef9088ee7e557fcd4bfb9ded62e1c6e3d2d63436d0a1L56-R68): Modified `InitTracing` to conditionally configure the tracing provider based on the presence of a valid endpoint and a non-zero sample rate. If these conditions are not met, a no-op tracer provider is used.

### Test coverage improvements:

* [`internal/pkg/telemetry/otel_test.go`](diffhunk://#diff-dd68fb6d30990ffa14c95efc0b61db0de7d03306d33f61a5ef1136b85a40fe67R1-R60): Added unit tests for `InitTracing` to verify that a no-op tracer provider is created when tracing is disabled (e.g., when the endpoint is empty or the sample rate is zero).