### PR TITLE
ci: fix tags format for multiple tags in docker build

### DIFF
--- a/.github/workflows/docker-build-template.yml
+++ b/.github/workflows/docker-build-template.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Set image tags
         id: set-tags
         run: |
+          set -eou pipefail
           tags=()
           while IFS= read -r tag; do
             if [[ -z "$tag" ]]; then
@@ -82,7 +83,7 @@ jobs:
             tags+=("${{ inputs.registry }}/${{ inputs.repo_base }}/${{ matrix.image.name }}:${tag}")
           done <<< "${{ inputs.tags }}"
 
-          echo "tags=${tags[*]}" >> "$GITHUB_OUTPUT"
+          echo "tags=$(IFS=,; echo "${tags[*]}")" >> "$GITHUB_OUTPUT"
 
       - name: Docker build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0


### PR DESCRIPTION
The docker build "tags" expects either a CSV or YAML list. This fixes it by making tags from setup part CSV. 

Tricky to test since this part only triggers on main. 

This pull request introduces two improvements to the `.github/workflows/docker-build-template.yml` file to enhance the reliability and formatting of the Docker build workflow.

Workflow reliability:

* Added `set -eou pipefail` to the `Set image tags` step, ensuring the script exits on errors, undefined variables, or failed pipeline commands.

Output formatting:

* Modified the `tags` output to use a comma-separated format instead of space-separated, improving compatibility with downstream tools and workflows.