### PR TITLE
chore: update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*  @croomes @ganesan23 @Azure/azure-container-storage-maintainers
+*  @croomes @jmclong @landreasyan @Azure/azure-container-storage-maintainers
 /.github/CODEOWNERS @croomes @ganesan23


### PR DESCRIPTION
Adds Joshua & Lana to the auto-assigned reviewers, and removes Ganesan. Anyone in @Azure/azure-container-storage-maintainers (including Ganesan) can still approve PRs - they just don't get auto-assigned automatically.