### PR TITLE
fix(chart): default drive image should use .Chart.Version, default to…

### DIFF
--- a/charts/latest/Chart.yaml
+++ b/charts/latest/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 description: Local CSI Driver Helm chart for Kubernetes
 name: local-csi-driver
 type: application
-version: 0.0.0
+version: 0.0.1-latest

--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -81,9 +81,9 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         {{- if hasPrefix "/" .Values.image.driver.repository }}
-        image: "{{ .Values.image.baseRepo }}{{ .Values.image.driver.repository }}:{{ .Values.image.driver.tag | default .Chart.AppVersion}}"
+        image: "{{ .Values.image.baseRepo }}{{ .Values.image.driver.repository }}:{{ .Values.image.driver.tag | default .Chart.Version }}"
         {{- else }}
-        image: "{{ .Values.image.driver.repository }}:{{ .Values.image.driver.tag | default .Chart.AppVersion}}"
+        image: "{{ .Values.image.driver.repository }}:{{ .Values.image.driver.tag | default .Chart.Version }}"
         {{- end }}
         imagePullPolicy: {{ .Values.image.driver.pullPolicy }}
         livenessProbe:

--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -4,7 +4,7 @@ name: csi-local
 image:
   baseRepo: mcr.microsoft.com
   driver:
-    repository: /acstor/local-csi-driver
+    repository: localcsidriver.azurecr.io/acstor/local-csi-driver
     # When the tag is unset (recommended), the chart version is used as the tag.
     tag:
     pullPolicy: IfNotPresent

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,7 +21,7 @@ To install Helm, please follow the official [Helm installation guide](https://he
 To install local-csi-driver using Helm:
 
    ```sh
-   helm install local-csi-driver oci://localcsidriver.azurecr.io/local-csi-driver/local-csi-driver --version 0.0.1-latest --namespace kube-system --wait --atomic
+   helm install local-csi-driver oci://localcsidriver.azurecr.io/acstor/charts/local-csi-driver --version 0.0.1-latest --namespace kube-system --wait --atomic
    ```
 
 Only one instance of local-csi-driver can be installed per cluster.


### PR DESCRIPTION
This pull request updates the Helm chart for the Local CSI Driver to improve versioning consistency and update the image repository. The main changes include updating the chart version, aligning image tag defaults with the chart version, and switching the image base repository to a new Azure container registry.

### Versioning Updates:
* [`charts/latest/Chart.yaml`](diffhunk://#diff-79af528f4c117c8be9d05725bedf4846fb917c9261f646940af478105c5e3966L6-R6): Updated the chart version from `0.0.0` to `0.0.1-latest` to reflect the latest release.
* [`charts/latest/templates/daemonset.yaml`](diffhunk://#diff-fcc631e58f1d911bbb1909e7edef4d9a41a03bae29c7467d6ac83b83a062b6f0L84-R86): Changed the default image tag fallback from `.Chart.AppVersion` to `.Chart.Version` for better alignment with the chart's versioning system.

### Repository Update:
* [`charts/latest/values.yaml`](diffhunk://#diff-d29b314008db700bde7facdb68fc5dcd58008824558728002e8d9b436fb0fc04L5-R5): Updated the `baseRepo` for the driver image from `mcr.microsoft.com` to `localcsidriver.azurecr.io` to use the new Azure container registry.… ACR