### PR TITLE
ci(precommit): add kubeconform linter for helm chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   - id: check-yaml
     args:
     - --allow-multiple-documents
-    exclude: ^dist/charts|charts/latest # chart templates are not valid yaml
+    exclude: charts/latest/templates # chart templates are not valid yaml
   - id: check-xml
   - id: check-json
 - repo: https://github.com/golangci/golangci-lint
@@ -50,4 +50,10 @@ repos:
     entry: make add-copyright
     language: system
     files: ^.*\.(go|sh|mk|py)$
+    pass_filenames: false
+  - id: kubeconform-lint
+    name: Lint Helm Chart
+    entry: make kubeconform-lint
+    language: system
+    files: ^charts/latest
     pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,10 @@ run-markdownlint: $(NODE)
 add-copyright:
 	./hack/add_copyright.sh
 
+.PHONY: kubeconform-lint
+kubeconform-lint: kubeconform-helm ## Lint all Kubernetes manifests using kubeconform.
+	$(HELM) kubeconform --verbose --summary --strict charts/latest
+
 .PHONY: single
 single: kind ## Create a single node kind cluster.
 	if $(KIND) get clusters | grep -q kind; then \
@@ -511,6 +515,17 @@ jaeger-port-forward: ## Port forward the jaeger pod to localhost as a background
 ginkgo: $(GINKGO)
 $(GINKGO): $(LOCALBIN)
 	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
+
+
+KUBECONFORM_HELM_REPO ?= https://github.com/jtyr/kubeconform-helm
+KUBECONFORM_HELM_VERSION ?= v0.1.17
+.PHONY: kubeconform-helm
+kubeconform-helm: helm
+	@if ! $(HELM) plugin list | grep -q kubeconform; then \
+		$(HELM) plugin install $(KUBECONFORM_HELM_REPO) --version $(KUBECONFORM_HELM_VERSION); \
+	else \
+		echo "kubeconform-helm plugin already installed."; \
+	fi
 
 hadolint: $(HADOLINT)
 HADOLINT ?= $(LOCALBIN)/hadolint


### PR DESCRIPTION
This PR adds kubeconform lint on the helm chart. This will help us catch issues like invalid keys and bad indentation on kubenetes resources which might not trigger errors

### Updates to `.pre-commit-config.yaml`:

* Modified the `exclude` pattern for the `check-yaml` hook to target `charts/latest/templates` instead of the previous pattern, ensuring more precise YAML validation.
* Added a new pre-commit hook, `kubeconform-lint`, to lint Helm charts, specifying its configuration and file targeting rules.

### Additions to `Makefile`:

* Introduced a new `kubeconform-lint` target that uses the `kubeconform` Helm plugin to lint Kubernetes manifests with strict validation and detailed output.
* Added a `kubeconform-helm` target to manage the installation of the `kubeconform` Helm plugin, including support for specifying a custom repository and version.