### PR TITLE
fix: non-aligned pv sizes failed to provision

### DIFF
--- a/internal/csi/controller/controller.go
+++ b/internal/csi/controller/controller.go
@@ -86,6 +86,16 @@ func (cs *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// Validate capacity.
+	capacity := req.GetCapacityRange().GetRequiredBytes()
+	limit := req.GetCapacityRange().GetLimitBytes()
+	if capacity < 0 || limit < 0 {
+		return nil, status.Error(codes.InvalidArgument, "cannot have negative capacity")
+	}
+	if limit > 0 && capacity > limit {
+		return nil, status.Error(codes.InvalidArgument, "capacity cannot exceed limit")
+	}
+
 	// Fetch PVC to be used as reference object in events.
 	var pvc *corev1.PersistentVolumeClaim
 	if req.Parameters[core.PVCNameParam] != "" && req.Parameters[core.PVCNamespaceParam] != "" {

--- a/internal/csi/controller/controller_test.go
+++ b/internal/csi/controller/controller_test.go
@@ -256,6 +256,76 @@ func TestServer_CreateVolume(t *testing.T) {
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
 						},
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errCode: codes.InvalidArgument,
+		},
+		{
+			name: "invalid volume capacity request",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: -1, // Invalid capacity
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errCode: codes.InvalidArgument,
+		},
+		{
+			name: "invalid volume capacity limit",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1024 * 1024 * 1024, // Valid capacity
+					LimitBytes:    -1,                 // Invalid limit
+				},
+
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errCode: codes.InvalidArgument,
+		},
+		{
+			name: "invalid volume capacity limit lower than requested",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1024 * 1024 * 1024, // Valid capacity
+					LimitBytes:    1024,               // Lower than requested
+				},
+
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
 					},
 				},
 			},

--- a/internal/csi/core/fake.go
+++ b/internal/csi/core/fake.go
@@ -85,7 +85,7 @@ func (f *Fake) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRe
 	}, nil
 }
 
-func (f *Fake) NodeEnsureVolume(ctx context.Context, volumeId string, params map[string]string) error {
+func (f *Fake) NodeEnsureVolume(ctx context.Context, volumeId string, capacity int64, limit int64) error {
 	if f.Err != nil {
 		return f.Err
 	}

--- a/internal/csi/core/interfaces.go
+++ b/internal/csi/core/interfaces.go
@@ -55,7 +55,7 @@ type NodeInterface interface {
 	GetNodeDriverCapabilities() []*csi.NodeServiceCapability
 	GetNodeDevicePath(volumeId string) (string, error)
 	NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error)
-	NodeEnsureVolume(ctx context.Context, volumeId string, params map[string]string) error
+	NodeEnsureVolume(ctx context.Context, volumeId string, capacity int64, limit int64) error
 	GetVolumeName(volumeId string) (string, error)
 	// NodeStage(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error)
 	// NodeUnstage(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error)

--- a/internal/csi/core/lvm/controller_test.go
+++ b/internal/csi/core/lvm/controller_test.go
@@ -6,17 +6,269 @@ package lvm_test
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"local-csi-driver/internal/csi/core/lvm"
 	lvmMgr "local-csi-driver/internal/pkg/lvm"
 	"local-csi-driver/internal/pkg/probe"
+	"local-csi-driver/internal/pkg/tracing"
 )
 
 const (
 	testVolumeGroup = "test-vg"
 )
+
+func TestLVM_Create(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		req     *csi.CreateVolumeRequest
+		want    *csi.Volume
+		wantErr bool
+	}{
+		{
+			name: "empty params",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1024 * 1024 * 1024, // 1 GiB
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Block{
+							Block: &csi.VolumeCapability_BlockVolume{},
+						},
+					},
+				},
+				Parameters: map[string]string{},
+			},
+			want: &csi.Volume{
+				VolumeId:      "containerstorage#test-volume",
+				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
+				VolumeContext: map[string]string{
+					"local.csi.azure.com/vg":       "containerstorage",
+					"local.csi.azure.com/capacity": "1073741824",
+					"local.csi.azure.com/limit":    "0",
+				},
+				AccessibleTopology: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.local.csi.azure.com/node": "nodename",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom volume group",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1024 * 1024 * 1024, // 1 GiB
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Block{
+							Block: &csi.VolumeCapability_BlockVolume{},
+						},
+					},
+				},
+				Parameters: map[string]string{
+					"local.csi.azure.com/vg": testVolumeGroup,
+				},
+			},
+			want: &csi.Volume{
+				VolumeId:      testVolumeGroup + "#test-volume",
+				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
+				VolumeContext: map[string]string{
+					"local.csi.azure.com/vg":       testVolumeGroup,
+					"local.csi.azure.com/capacity": "1073741824",
+					"local.csi.azure.com/limit":    "0",
+				},
+				AccessibleTopology: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.local.csi.azure.com/node": "nodename",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty params",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1024 * 1024 * 1024, // 1 GiB
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Block{
+							Block: &csi.VolumeCapability_BlockVolume{},
+						},
+					},
+				},
+				Parameters: map[string]string{},
+			},
+			want: &csi.Volume{
+				VolumeId:      "containerstorage#test-volume",
+				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
+				VolumeContext: map[string]string{
+					"local.csi.azure.com/vg":       "containerstorage",
+					"local.csi.azure.com/capacity": "1073741824",
+					"local.csi.azure.com/limit":    "0",
+				},
+				AccessibleTopology: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.local.csi.azure.com/node": "nodename",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "non-aligned capacity",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1919999279104, // 1831054Mi
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Block{
+							Block: &csi.VolumeCapability_BlockVolume{},
+						},
+					},
+				},
+				Parameters: map[string]string{},
+			},
+			want: &csi.Volume{
+				VolumeId:      "containerstorage#test-volume",
+				CapacityBytes: 1919999279104, // 1831054Mi
+				VolumeContext: map[string]string{
+					"local.csi.azure.com/vg":       "containerstorage",
+					"local.csi.azure.com/capacity": "1919999279104",
+					"local.csi.azure.com/limit":    "0",
+				},
+				AccessibleTopology: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.local.csi.azure.com/node": "nodename",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with limit",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1024 * 1024 * 1024,     // 1 GiB
+					LimitBytes:    2 * 1024 * 1024 * 1024, // 2 GiB
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Block{
+							Block: &csi.VolumeCapability_BlockVolume{},
+						},
+					},
+				},
+				Parameters: map[string]string{},
+			},
+			want: &csi.Volume{
+				VolumeId:      "containerstorage#test-volume",
+				CapacityBytes: 1073741824, // 1 GiB
+				VolumeContext: map[string]string{
+					"local.csi.azure.com/vg":       "containerstorage",
+					"local.csi.azure.com/capacity": "1073741824",
+					"local.csi.azure.com/limit":    "2147483648",
+				},
+				AccessibleTopology: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.local.csi.azure.com/node": "nodename",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with limit lower than request", // Validation that prevents this is in the controller.
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 2 * 1024 * 1024 * 1024, // 2 GiB
+					LimitBytes:    1024 * 1024 * 1024,     // 1 GiB
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Block{
+							Block: &csi.VolumeCapability_BlockVolume{},
+						},
+					},
+				},
+				Parameters: map[string]string{},
+			},
+			want: &csi.Volume{
+				VolumeId:      "containerstorage#test-volume",
+				CapacityBytes: 2147483648, // 2 GiB
+				VolumeContext: map[string]string{
+					"local.csi.azure.com/vg":       "containerstorage",
+					"local.csi.azure.com/capacity": "2147483648",
+					"local.csi.azure.com/limit":    "1073741824",
+				},
+				AccessibleTopology: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.local.csi.azure.com/node": "nodename",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := fake.NewClientBuilder().
+				WithScheme(runtime.NewScheme()).
+				Build()
+			tp := tracing.NewNoopTracerProvider()
+			p := probe.NewFake([]string{"device1", "device2"}, nil)
+			lvmMgr := lvmMgr.NewFake()
+
+			l, err := lvm.New(c, "podname", "nodename", "default", p, lvmMgr, tp)
+			if err != nil {
+				t.Fatalf("failed to create LVM instance: %v", err)
+			}
+			got, err := l.Create(context.Background(), tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LVM.Create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LVM.Create()\ngot:\n%v\nwant:\n%v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestAvailableCapacity(t *testing.T) {
 	t.Parallel()

--- a/internal/csi/core/lvm/controller_test.go
+++ b/internal/csi/core/lvm/controller_test.go
@@ -207,7 +207,7 @@ func TestLVM_Create(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "with limit lower than request", // Validation that prevents this is in the controller.
+			name: "with limit lower than request",
 			req: &csi.CreateVolumeRequest{
 				Name: "test-volume",
 				CapacityRange: &csi.CapacityRange{
@@ -223,23 +223,8 @@ func TestLVM_Create(t *testing.T) {
 				},
 				Parameters: map[string]string{},
 			},
-			want: &csi.Volume{
-				VolumeId:      "containerstorage#test-volume",
-				CapacityBytes: 2147483648, // 2 GiB
-				VolumeContext: map[string]string{
-					"local.csi.azure.com/vg":       "containerstorage",
-					"local.csi.azure.com/capacity": "2147483648",
-					"local.csi.azure.com/limit":    "1073741824",
-				},
-				AccessibleTopology: []*csi.Topology{
-					{
-						Segments: map[string]string{
-							"topology.local.csi.azure.com/node": "nodename",
-						},
-					},
-				},
-			},
-			wantErr: false,
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/csi/core/lvm/node.go
+++ b/internal/csi/core/lvm/node.go
@@ -125,6 +125,6 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 
 // NodeEnsureVolume ensures that the volume exists on the node.
 // It will create the volume if it does not exist.
-func (l *LVM) NodeEnsureVolume(ctx context.Context, volumeId string, params map[string]string) error {
-	return l.EnsureVolume(ctx, volumeId, params)
+func (l *LVM) NodeEnsureVolume(ctx context.Context, volumeId string, capacity int64, limit int64) error {
+	return l.EnsureVolume(ctx, volumeId, capacity, limit)
 }

--- a/internal/csi/node/node.go
+++ b/internal/csi/node/node.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/volume"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +25,7 @@ import (
 
 	"local-csi-driver/internal/csi/capability"
 	"local-csi-driver/internal/csi/core"
+	"local-csi-driver/internal/csi/core/lvm"
 	"local-csi-driver/internal/csi/mounter"
 	"local-csi-driver/internal/pkg/events"
 )
@@ -418,7 +420,16 @@ func (ns *Server) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeR
 	if pv.Spec.CSI != nil && pv.Spec.CSI.VolumeAttributes != nil {
 		// Call volume manager to ensure the volume exists. Re-creating empty
 		// volumes is acceptable for local volumes.
-		if err := ns.volume.NodeEnsureVolume(ctx, req.GetVolumeId(), pv.Spec.CSI.VolumeAttributes); err != nil {
+
+		// Get the capacity request from the PV attributes.
+		capacityBytes, limitBytes, err := getCapacityAndLimit(pv.Spec.CSI.VolumeAttributes)
+		if err != nil {
+			log.Error(err, "failed to get capacity and limit from pv attributes")
+			span.SetStatus(otcodes.Error, "failed to get capacity and limit from pv attributes")
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		if err := ns.volume.NodeEnsureVolume(ctx, req.GetVolumeId(), capacityBytes, limitBytes); err != nil {
 			log.Error(err, "failed to publish volume")
 			span.SetStatus(otcodes.Error, "failed to publish volume")
 			span.RecordError(err)
@@ -471,6 +482,31 @@ func (ns *Server) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeR
 	log.V(2).Info("mounted")
 	span.SetStatus(otcodes.Ok, "mounted")
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// getCapacityAndLimit retrieves the capacity and limit from the PV attributes.
+func getCapacityAndLimit(attrs map[string]string) (capacityBytes, limitBytes int64, err error) {
+	c, ok := attrs[lvm.CapacityParam]
+	if !ok {
+		return 0, 0, fmt.Errorf("volume request size is missing in pv attributes - recovery impossible")
+	}
+	if len(c) > 0 {
+		capacity, err := resource.ParseQuantity(attrs[lvm.CapacityParam])
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to parse volume request size from pv attribute %s=%s: %w", lvm.CapacityParam, attrs[lvm.CapacityParam], err)
+		}
+		capacityBytes = capacity.Value()
+	}
+
+	if l, ok := attrs[lvm.LimitParam]; ok && len(l) > 0 {
+		limit, err := resource.ParseQuantity(l)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to parse volume limit size from pv attribute %s=%s: %w", lvm.LimitParam, attrs[lvm.LimitParam], err)
+		}
+		limitBytes = limit.Value()
+	}
+
+	return capacityBytes, limitBytes, nil
 }
 
 func (ns *Server) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {

--- a/internal/csi/node/node.go
+++ b/internal/csi/node/node.go
@@ -488,7 +488,7 @@ func (ns *Server) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeR
 func getCapacityAndLimit(attrs map[string]string) (capacityBytes, limitBytes int64, err error) {
 	c, ok := attrs[lvm.CapacityParam]
 	if !ok {
-		return 0, 0, fmt.Errorf("volume request size is missing in pv attributes - recovery impossible")
+		return 0, 0, fmt.Errorf("volume request size is missing in pv attribute %s - recovery impossible", lvm.CapacityParam)
 	}
 	if len(c) > 0 {
 		capacity, err := resource.ParseQuantity(attrs[lvm.CapacityParam])

--- a/internal/pkg/lvm/fake.go
+++ b/internal/pkg/lvm/fake.go
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"context"
+	"strconv"
+)
+
+type Fake struct {
+	PVs map[string]PhysicalVolume
+	VGs map[string]VolumeGroup
+	LVs map[string]LogicalVolume
+	Err error
+}
+
+// Construct a new fakelvm2 client.
+func NewFake() *Fake {
+	return &Fake{
+		PVs: make(map[string]PhysicalVolume),
+		VGs: make(map[string]VolumeGroup),
+		LVs: make(map[string]LogicalVolume),
+		Err: nil,
+	}
+}
+
+// IsSupported returns true if LVM is supported on the current node.
+func (f *Fake) IsSupported() bool {
+	return true
+}
+
+// CreatePhysicalVolume creates a PV for each block device.
+func (f *Fake) CreatePhysicalVolume(ctx context.Context, opts CreatePVOptions) error {
+	pv := PhysicalVolume{
+		Name: opts.Name,
+	}
+	f.PVs[opts.Name] = pv
+	return nil
+}
+
+// RemovePhysicalVolume removes PVs for each block device.
+func (f *Fake) RemovePhysicalVolume(ctx context.Context, opts RemovePVOptions) error {
+	delete(f.PVs, opts.Name)
+	return nil
+}
+
+// GetPhysicalVolume returns the list of PVs.
+func (f *Fake) ListPhysicalVolumes(ctx context.Context, opts *ListPVOptions) ([]PhysicalVolume, error) {
+	pvs := []PhysicalVolume{}
+	for _, pv := range f.PVs {
+		pvs = append(pvs, pv)
+	}
+	return pvs, nil
+}
+
+// ListPhysicalVolumes returns named PV.
+func (f *Fake) GetPhysicalVolume(ctx context.Context, pvName string) (*PhysicalVolume, error) {
+	pv, ok := f.PVs[pvName]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &pv, nil
+}
+
+// CreateVolumeGroup Creates a VG on the PVs.
+func (f *Fake) CreateVolumeGroup(ctx context.Context, opts CreateVGOptions) error {
+	vg := VolumeGroup{
+		Name: opts.Name,
+	}
+	f.VGs[opts.Name] = vg
+	return nil
+}
+
+// ListVolumeGroups list the specified VGs.
+func (f *Fake) ListVolumeGroups(ctx context.Context, opts *ListVGOptions) ([]VolumeGroup, error) {
+	vgs := []VolumeGroup{}
+	for _, vg := range f.VGs {
+		vgs = append(vgs, vg)
+	}
+	return vgs, nil
+}
+
+// GetVolumeGroups returns named VG.
+func (f *Fake) GetVolumeGroup(ctx context.Context, vgName string) (*VolumeGroup, error) {
+	vg, ok := f.VGs[vgName]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &vg, nil
+}
+
+// RemoveVolumeGroup removes a VG.
+func (f *Fake) RemoveVolumeGroup(ctx context.Context, opts RemoveVGOptions) error {
+	delete(f.VGs, opts.Name)
+	return nil
+}
+
+// CreateLogicalVolume creates an LV on a VG.
+func (f *Fake) CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) error {
+	lv := LogicalVolume{
+		Name: opts.Name,
+	}
+	f.LVs[opts.Name] = lv
+	return nil
+}
+
+// RemoveLogicalVolume removes a LV from a VG.
+func (f *Fake) RemoveLogicalVolume(ctx context.Context, opts RemoveLVOptions) error {
+	delete(f.LVs, opts.Name)
+	return nil
+}
+
+// ListLogicalVolumes lists the specified LVs.
+func (f *Fake) ListLogicalVolumes(ctx context.Context, opts *ListLVOptions) ([]LogicalVolume, error) {
+	lvs := []LogicalVolume{}
+	for _, lv := range f.LVs {
+		lvs = append(lvs, lv)
+	}
+	return lvs, nil
+}
+
+// GetLogicalVolumes returns named LV.
+func (f *Fake) GetLogicalVolume(ctx context.Context, vgName string, lvName string) (*LogicalVolume, error) {
+	lv, ok := f.LVs[lvName]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &lv, nil
+}
+
+// ExtendLogicalVolume extends the LV to the specified size.
+func (f *Fake) ExtendLogicalVolume(ctx context.Context, opts ExtendLVOptions) error {
+	lv, ok := f.LVs[opts.Name]
+	if !ok {
+		return ErrNotFound
+	}
+	size, err := strconv.ParseInt(opts.Size, 10, 64)
+	if err != nil {
+		return err
+	}
+	lv.Size = Int64String(size)
+	f.LVs[opts.Name] = lv
+	return nil
+}

--- a/internal/pkg/probe/fake.go
+++ b/internal/pkg/probe/fake.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package probe
+
+import (
+	"context"
+
+	logr "github.com/go-logr/logr"
+
+	"local-csi-driver/internal/pkg/block"
+)
+
+type Fake struct {
+	Devices []string
+	Err     error
+}
+
+// NewFake creates a new fake probe.
+func NewFake(devices []string, err error) *Fake {
+	return &Fake{
+		Devices: devices,
+		Err:     err,
+	}
+}
+
+// ScanDevices returns the list of devices or an error if no devices are found.
+func (f *Fake) ScanDevices(ctx context.Context, log logr.Logger) ([]string, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
+	if len(f.Devices) == 0 {
+		return nil, ErrNoDevicesFound
+	}
+	return f.Devices, nil
+}
+
+// GetDevices returns a list of devices.
+func (f *Fake) GetDevices(ctx context.Context) (*block.DeviceList, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
+	devices := []block.Device{}
+	for _, path := range f.Devices {
+		devices = append(devices, block.Device{Path: path})
+	}
+	return &block.DeviceList{Devices: devices}, nil
+}

--- a/internal/pkg/sys/utils.go
+++ b/internal/pkg/sys/utils.go
@@ -7,8 +7,6 @@ package sys
 import (
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 	"syscall"
 
 	"k8s.io/utils/exec"
@@ -22,7 +20,6 @@ const (
 type Utils interface {
 	IsBlockDevice(path string) (bool, error)
 	IsBlkDevUnformatted(device string) (bool, error)
-	StringToUInt64(sizeStr string) (uint64, error)
 }
 
 // sys is a concrete implementation of the Utils interface.
@@ -92,56 +89,4 @@ func (s *sys) IsBlkDevUnformatted(blockDev string) (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-// parseSize parses a size string (e.g., "16.00g") and returns the size in bytes
-// Not used at the moment, will be required during vgStatus implementation when
-// we change the size to uint64.
-func (s *sys) StringToUInt64(sizeStr string) (uint64, error) {
-	sizeStr = strings.ToLower(sizeStr)
-	var multiplier uint64 = 1
-	switch {
-	case strings.HasSuffix(sizeStr, "k"):
-		multiplier = 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "k")
-	case strings.HasSuffix(sizeStr, "m"):
-		multiplier = 1024 * 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "m")
-	case strings.HasSuffix(sizeStr, "g"):
-		multiplier = 1024 * 1024 * 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "g")
-	case strings.HasSuffix(sizeStr, "t"):
-		multiplier = 1024 * 1024 * 1024 * 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "t")
-	}
-	size, err := strconv.ParseFloat(sizeStr, 64)
-	if err != nil {
-		return 0, err
-	}
-	return uint64(size * float64(multiplier)), nil
-}
-
-// parseSize parses a size string (e.g., "16.00g") and returns the size in bytes.
-func (s *sys) StringToInt(sizeStr string) (uint64, error) {
-	sizeStr = strings.ToLower(sizeStr)
-	var multiplier uint64 = 1
-	switch {
-	case strings.HasSuffix(sizeStr, "k"):
-		multiplier = 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "k")
-	case strings.HasSuffix(sizeStr, "m"):
-		multiplier = 1024 * 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "m")
-	case strings.HasSuffix(sizeStr, "g"):
-		multiplier = 1024 * 1024 * 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "g")
-	case strings.HasSuffix(sizeStr, "t"):
-		multiplier = 1024 * 1024 * 1024 * 1024
-		sizeStr = strings.TrimSuffix(sizeStr, "t")
-	}
-	size, err := strconv.ParseFloat(sizeStr, 64)
-	if err != nil {
-		return 0, err
-	}
-	return uint64(size * float64(multiplier)), nil
 }


### PR DESCRIPTION
Fixes an issue where a non-aligned PV size would cause volume create to fail. The main change is to use bytes internally instead of converting to MiB. Where conversion from string is required, uses the k8s Quantity library. Logs show bytes, but we should consider converting to more human-readable formats for events and errors. We can add this later.

Input that failed:

```yaml
      volumes:
        - name: pvc0
          ephemeral:
            volumeClaimTemplate:
              spec:
                accessModes:
                  - ReadWriteOnce
                resources:
                  requests:
                    storage: 1831054Mi
                storageClassName: local
```
For "storage: 1831054Mi", the PVC is in "Bound" status but pod stays in "ContainerCreating" status. There is a "Volume size mismatch" error in the output "kubectl describe pod/pvc ..." commands.

## AI Summary

This pull request introduces changes to improve volume creation and validation in the CSI driver. Key updates include enhancements to capacity validation logic, refactoring of volume group parameters, and expanded unit tests to cover edge cases. The changes aim to ensure better handling of volume capacities and limits, improve code clarity, and strengthen test coverage.

### Volume Creation and Validation Enhancements:
* Added validation for negative capacity and limits in `CreateVolume` to prevent invalid volume requests. Validation ensures requested capacity does not exceed the limit. (`internal/csi/controller/controller.go`, [internal/csi/controller/controller.goR89-R98](diffhunk://#diff-22fa5d5f84a2eb3319543e24d6b43ab31cdd3e433e6d56003b5e45a047ea1189R89-R98))
* Updated the `EnsureVolume` method to accept explicit `capacity` and `limit` parameters instead of relying on a generic map, improving clarity and type safety. (`internal/csi/core/lvm/controller.go`, [[1]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L93-R98); `internal/csi/core/interfaces.go`, [[2]](diffhunk://#diff-b1b9729c8b117e9aa4ef2f9563cb31d039add5143915f53f9e818c7f22e880b4L58-R58)

### Refactoring of Volume Group Parameters:
* Replaced `VolumeGroupNameParam` with `VolumeGroupParam` for consistency and alignment with other parameters. Updated references across multiple files. (`internal/csi/core/lvm/controller.go`, [[1]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L62-R81) [[2]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L235-R233) [[3]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L264-R259) [[4]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L386-R386)
* Removed unused constants like `SizeMiBKey` and refactored volume context parameters to include `CapacityParam` and `LimitParam`. (`internal/csi/core/lvm/lvm.go`, [[1]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afR70-R84) [[2]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL376-R386)

### Test Coverage Improvements:
* Expanded unit tests for `CreateVolume` to cover scenarios like invalid capacity, limits lower than requested, and non-aligned capacities. (`internal/csi/controller/controller_test.go`, [[1]](diffhunk://#diff-7874fe955b69ac6fa1a0ea7eb99a3285b0fdaca900cd5b36567553a57c95bd29R259-R328); `internal/csi/core/lvm/controller_test.go`, [[2]](diffhunk://#diff-5060a8629f8bb63873dee9181ae9568fa1ab4fdcd4bbc7596e9ef1d14089cc19R9-R272)

### Code Cleanup:
* Removed unused imports and constants to streamline the codebase. (`internal/csi/core/lvm/controller.go`, [[1]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L18-L23); `internal/csi/core/lvm/lvm.go`, [[2]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL21) [[3]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL33-R33) [[4]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL53-L62)