### PR TITLE
feat: remove azure from provisioner name

### DIFF
--- a/charts/latest/templates/NOTES.txt
+++ b/charts/latest/templates/NOTES.txt
@@ -12,8 +12,8 @@ kind: StorageClass
 metadata:
   name: local
 parameters:
-  local.csi.azure.com/vg: containerstorage
-provisioner: local.csi.azure.com
+  localdisk.csi.acstor.io/vg: containerstorage
+provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -215,7 +215,7 @@ spec:
       - name: csi-registrar
         args:
         - --csi-address=/csi/csi.sock
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/local.csi.azure.com/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/localdisk.csi.acstor.io/csi.sock
         - --http-endpoint=:{{ .Values.observability.nodeDriverRegistrar.http.port }}
         - --v={{ .Values.observability.nodeDriverRegistrar.log.level }}
         env:
@@ -268,7 +268,7 @@ spec:
           type: DirectoryOrCreate
         name: k8s-cfg
       - hostPath:
-          path: /var/lib/kubelet/plugins/local.csi.azure.com/
+          path: /var/lib/kubelet/plugins/localdisk.csi.acstor.io/
           type: DirectoryOrCreate
         name: csi-socket-dir
       - hostPath:

--- a/charts/latest/templates/webhook-config-ephemeral.yaml
+++ b/charts/latest/templates/webhook-config-ephemeral.yaml
@@ -14,7 +14,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /validate-pvc
   failurePolicy: Ignore
-  name: ephemeral.local.csi.azure.com
+  name: ephemeral.localdisk.csi.acstor.io
   rules:
   - apiGroups:
     - ""

--- a/charts/latest/templates/webhook-config-hyperconverged.yaml
+++ b/charts/latest/templates/webhook-config-hyperconverged.yaml
@@ -14,7 +14,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /mutate-pod
   failurePolicy: Ignore
-  name: hyperconverged.local.csi.azure.com
+  name: hyperconverged.localdisk.csi.acstor.io
   rules:
   - apiGroups:
     - ""

--- a/docs/design/disk-selection.md
+++ b/docs/design/disk-selection.md
@@ -25,16 +25,16 @@ want and excludes those they do not want.
 ## Design
 
 Currently, we allow customization of the volume group name through the
-StorageClass parameter `local.csi.azure.com/vg`. For example:
+StorageClass parameter `localdisk.csi.acstor.io/vg`. For example:
 
 ```yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local
-provisioner: local.csi.azure.com
+provisioner: localdisk.csi.acstor.io
 parameters:
-  local.csi.azure.com/vg: containerstorage
+  localdisk.csi.acstor.io/vg: containerstorage
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ```
@@ -42,11 +42,11 @@ volumeBindingMode: WaitForFirstConsumer
 We will add three new parameters to the storage class to allow users to
 customize the disk selection:
 
-- `local.csi.azure.com/disk-path-prefixes`: The prefix of the disk path. For
+- `localdisk.csi.acstor.io/disk-path-prefixes`: The prefix of the disk path. For
   example, `/dev/nvme`.
-- `local.csi.azure.com/disk-models`: The model of the disk. For example,
+- `localdisk.csi.acstor.io/disk-models`: The model of the disk. For example,
   `Microsoft NVMe Direct Disk`.
-- `local.csi.azure.com/disk-types`: The type of the disk. For example, `disk`.
+- `localdisk.csi.acstor.io/disk-types`: The type of the disk. For example, `disk`.
 
 These parameters will be used to filter the disks that are selected for
 provisioning. The driver will only select disks that match all of the
@@ -55,16 +55,16 @@ default value. **The user is not required to specify any of the parameters.** Ou
 defaults will work for NVMe disks found on Azure VMs.
 
 Comma-separated values will be supported for the parameters. For example, if
-the user specifies `local.csi.azure.com/disk-path-prefixes: /dev/nvme,/dev/sda`,
+the user specifies `localdisk.csi.acstor.io/disk-path-prefixes: /dev/nvme,/dev/sda`,
 the driver will select disks that have either `/dev/nvme` or `/dev/sda` as the
 path prefix.
 
 | Parameter                                   | Description                 | Default Value                                              |
 |----------------------------------------------|----------------------------|------------------------------------------------------------|
-| `local.csi.azure.com/vg`                     | Name of the volume group   | `containerstorage`                                         |
-| `local.csi.azure.com/disk-path-prefixes`     | Prefix of the disk path    | `/dev/nvme`                                                |
-| `local.csi.azure.com/disk-models`            | Model of the disk          | `Microsoft NVMe Direct Disk,Microsoft NVMe Direct Disk v2` |
-| `local.csi.azure.com/disk-types`             | Type of the disk           | `disk`                                                     |
+| `localdisk.csi.acstor.io/vg`                     | Name of the volume group   | `containerstorage`                                         |
+| `localdisk.csi.acstor.io/disk-path-prefixes`     | Prefix of the disk path    | `/dev/nvme`                                                |
+| `localdisk.csi.acstor.io/disk-models`            | Model of the disk          | `Microsoft NVMe Direct Disk,Microsoft NVMe Direct Disk v2` |
+| `localdisk.csi.acstor.io/disk-types`             | Type of the disk           | `disk`                                                     |
 
 Example with all parameters:
 
@@ -73,12 +73,12 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local
-provisioner: local.csi.azure.com
+provisioner: localdisk.csi.acstor.io
 parameters:
-  local.csi.azure.com/vg: containerstorage
-  local.csi.azure.com/disk-path-prefixes: /dev/nvme,/dev/sda
-  local.csi.azure.com/disk-models: Microsoft NVMe Direct Disk,Microsoft NVMe Direct Disk v2
-  local.csi.azure.com/disk-types: disk
+  localdisk.csi.acstor.io/vg: containerstorage
+  localdisk.csi.acstor.io/disk-path-prefixes: /dev/nvme,/dev/sda
+  localdisk.csi.acstor.io/disk-models: Microsoft NVMe Direct Disk,Microsoft NVMe Direct Disk v2
+  localdisk.csi.acstor.io/disk-types: disk
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ```
@@ -101,13 +101,13 @@ volumeBindingMode: WaitForFirstConsumer
 - If a user creates two storage classes with the same VG name, but different
   disk selection parameters, we would just use the VG that was created first.
   We would document this behavior.
-- We would likely want to change the parameters, especially the default `local.csi.azure.com/disk-models`
-  parameter, to adjust it for new disk types. This would be a bit strange because
-  storageclasses are meant to be immutable once created. This can present a puzzle
-  if we pass along the default values as values in `VolumeContext` and used those
-  in the non-ephemeral, annotated case. We would not be able to schedule to PV to
-  the new node. We would need to keep track of the default parameters in our code
-  instead.
+- We would likely want to change the parameters, especially the default
+  `localdisk.csi.acstor.io/disk-models` parameter, to adjust it for new disk
+  types. This would be a bit strange because storageclasses are meant to be
+  immutable once created. This can present a puzzle if we pass along the default
+  values as values in `VolumeContext` and used those in the non-ephemeral,
+  annotated case. We would not be able to schedule to PV to the new node. We
+  would need to keep track of the default parameters in our code instead.
 
 ## Related Documentation
 

--- a/docs/design/webhooks.md
+++ b/docs/design/webhooks.md
@@ -8,7 +8,7 @@ potential user errors.
 1. **Validation Webhook**: This webhook validates PersistentVolumeClaim (PVC)
 resources to ensure that only generic ephemeral storage is utilized, unless the
 user explicitly permits the creation of persistent volumes via the
-**"local.csi.azure.com/accept-ephemeral-storage"** annotation. This process
+**"localdisk.csi.acstor.io/accept-ephemeral-storage"** annotation. This process
 ensures that users understand that the provisioned volumes will share the
 lifecycle of the node, and true persistence cannot be guaranteed.
 
@@ -40,7 +40,7 @@ lifecycle of the pod, rendering them unable to outlive the node on which they
 reside.
 
 To provide flexibility, users can opt to create persistent volumes by including
-the annotation `local.csi.azure.com/accept-ephemeral-storage: "true"` in their
+the annotation `localdisk.csi.acstor.io/accept-ephemeral-storage: "true"` in their
 PersistentVolumeClaims (PVCs). This annotation signifies that the user
 acknowledges the potential risks of data loss associated with local storage and
 accepts the consequences of its use.
@@ -53,7 +53,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: my-pvc
   annotations:
-    local.csi.azure.com/accept-ephemeral-storage: "true" # Optional, allows creation of persistent volumes
+    localdisk.csi.acstor.io/accept-ephemeral-storage: "true" # Optional, allows creation of persistent volumes
 spec:
   accessModes:
     - ReadWriteOnce
@@ -105,15 +105,15 @@ spec:
     kind: PersistentVolumeClaim
     [...]
   csi:
-    driver: local.csi.azure.com
+    driver: localdisk.csi.acstor.io
     volumeAttributes:
-      local.csi.azure.com/selected-initial-node: nvme-node-0
+      localdisk.csi.acstor.io/selected-initial-node: nvme-node-0
     volumeHandle: containerstorage#pvc-d6efb13d-707f-4876-8622-ea7bf2399c14
   nodeAffinity:
     required:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: topology.local.csi.azure.com/node
+            - key: topology.localdisk.csi.acstor.io/node
               operator: In
               values:
                 - nvme-node-0
@@ -126,7 +126,7 @@ spec:
 
 When the webhook is enabled, instead of setting node affinity on the
 PersistentVolume (PV), the driver adds a
-`local.csi.azure.com/selected-initial-node` parameter to the volume context of
+`localdisk.csi.acstor.io/selected-initial-node` parameter to the volume context of
 the PV. This parameter is later used by the mutation webhook to modify the
 workload Pods to include preferred node affinity rules to the specified node
 ensuring that the workload and the PV are scheduled on the same node.
@@ -135,7 +135,7 @@ In the event of a node deletion, the workload Pods can be seamlessly rescheduled
 to a different node. During this process, the PersistentVolume (PV) will be
 reprovisioned on the new node as a blank volume, enabling the workload to
 continue functioning and writing new data. When such failovers occur, the PV
-resources will be annotated with `"local.csi.azure.com/selected-node"`
+resources will be annotated with `"localdisk.csi.acstor.io/selected-node"`
 information, which will later be used by the hyperconverged webhook to update
 the node affinity of the workload on future failovers.
 
@@ -146,7 +146,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   annotations:
-    local.csi.azure.com/selected-node: nvme-node-1
+    localdisk.csi.acstor.io/selected-node: nvme-node-1
   finalizers:
     - external-provisioner.volume.kubernetes.io/finalizer
     - kubernetes.io/pv-protection
@@ -162,9 +162,9 @@ spec:
     kind: PersistentVolumeClaim
     [...]
   csi:
-    driver: local.csi.azure.com
+    driver: localdisk.csi.acstor.io
     volumeAttributes:
-      local.csi.azure.com/selected-initial-node: nvme-node-0
+      localdisk.csi.acstor.io/selected-initial-node: nvme-node-0
       [...]
     volumeHandle: containerstorage#pvc-d6efb13d-707f-4876-8622-ea7bf2399c14
   persistentVolumeReclaimPolicy: Delete

--- a/docs/development.md
+++ b/docs/development.md
@@ -133,8 +133,8 @@ For more details on the bicep template and available parameters, refer to the
 
 ### To Deploy
 
-Build and push the Docker image and Helm chart to your registry
-and Helm repository, respectively. You can do this with:
+Build and push the Docker image and Helm chart to your registry and Helm
+repository, respectively. You can do this with:
 
 ```sh
 REGISTRY=<registry> make docker-build helm-build docker-push helm-push
@@ -148,8 +148,8 @@ REGISTRY=<registry> make docker-build helm-build docker-push helm-push helm-inst
 ```
 
 This will build the Docker image, push it to the specified registry, build the
-Helm chart, push it to the specified Helm repository, and install the project
-to your Kubernetes cluster.
+Helm chart, push it to the specified Helm repository, and install the project to
+your Kubernetes cluster.
 
 ### To Uninstall
 
@@ -163,17 +163,17 @@ This will remove the project from your cluster.
 
 ## Testing the project
 
-The project has a number of tests that can be run to ensure that the project
-is working correctly. The tests are divided into categories: unit tests,
-E2E tests, External E2E tests, and sanity tests. The tests are written in Go.
+The project has a number of tests that can be run to ensure that the project is
+working correctly. The tests are divided into categories: unit tests, E2E tests,
+External E2E tests, and sanity tests. The tests are written in Go.
 
-Generally, if something can be tested with a unit test, it should be. If something
-is too complex to test with a unit test, it should be tested with an E2E test.
-The sanity and external E2E tests are conformance tests provided by the
-Kubernetes community to test CSI drivers. For more details on the tests, refer
-to the [test/README.md](./test/README.md) file. Unit tests can be found in the
-[test/README.md](./test/README.md) file. Unit tests can be found throughout the
-project, but other tests are located in the `test` directory.
+Generally, if something can be tested with a unit test, it should be. If
+something is too complex to test with a unit test, it should be tested with an
+E2E test. The sanity and external E2E tests are conformance tests provided by
+the Kubernetes community to test CSI drivers. For more details on the tests,
+refer to the [test/README.md](./test/README.md) file. Unit tests can be found in
+the [test/README.md](./test/README.md) file. Unit tests can be found throughout
+the project, but other tests are located in the `test` directory.
 
 ### Unit tests
 
@@ -196,8 +196,9 @@ REGISTRY=<registry>.azurecr.io make docker-build helm-build docker-push helm-pus
 
 Those tests that are part of e2e suite are run in the cluster. The tests are
 written in Go and use the Ginkgo testing framework. The tests are located in the
-`test/e2e` directory. By default, the test-e2e test target will include tests that
-we can run in a `kind` cluster. If you have a real AKS cluster, you can run the tests
+`test/e2e` directory. By default, the test-e2e test target will include tests
+that we can run in a `kind` cluster. If you have a real AKS cluster, you can run
+the tests
 
 ```sh
 REGISTRY=<registry>.azurecr.io make docker-build helm-build docker-push helm-push test-e2e-aks
@@ -214,8 +215,8 @@ with:
 make single
 ```
 
-Note: Most of the tests are skipped in this mode, as they require a real aks cluster
-to run.
+Note: Most of the tests are skipped in this mode, as they require a real aks
+cluster to run.
 
 ### External E2E Tests
 
@@ -228,14 +229,14 @@ REGISTRY=<registry>.azurecr.io make docker-build helm-build docker-push helm-pus
 
 This will run the external E2E tests in the cluster using the AKS cluster. The
 tests are written in Go and use the Ginkgo testing framework. There are two
-kinds of tests, the `lvm` and `lvm-annoation` tests.
+kinds of tests, the `lvm` and `lvm-annotation` tests.
 
 The `lvm` tests only run the generic ephemeral volume tests, which is the only
 kind of volume permitted by default by the driver. The `lvm-annotation` tests
 run all the tests specified by the external tests.
 
 It uses [`kyverno`][kyverno] to add the
-`local.csi.azure.com/accept-ephemeral-storage: "true"` annotation to the
+`localdisk.csi.acstor.io/accept-ephemeral-storage: "true"` annotation to the
 persistent volume claim. This allows the tests to test the
 "accept-ephemeral-storage" mode of the driver. The tests are located in the
 `test/e2e/external` directory.

--- a/docs/fixing-cve.md
+++ b/docs/fixing-cve.md
@@ -5,10 +5,10 @@ Exposures) in go modules used by the local-csi-driver project.
 
 ## Steps to Fix CVE in Go Modules
 
-1. **Identify the CVE**: Determine which CVE needs to be fixed. This can be
-   done by checking the project's dependencies for known vulnerabilities. Check
-   to see what version the CVE affects and if there is a patch available. If
-   there is no patch available, you may need to wait for the upstream project to
+1. **Identify the CVE**: Determine which CVE needs to be fixed. This can be done
+   by checking the project's dependencies for known vulnerabilities. Check to
+   see what version the CVE affects and if there is a patch available. If there
+   is no patch available, you may need to wait for the upstream project to
    release a fix.
 
 2. **Update direct dependencies**: If the CVE affects a direct dependency,
@@ -43,9 +43,9 @@ Exposures) in go modules used by the local-csi-driver project.
     k8s.io/kubernetes@v1.33.1 github.com/google/cadvisor@v0.52.1
     ```
 
-    In this case, cadvisor is a dependency of the latest kubernetes module. Furthermore,
-    cadvisor has not fixed this issue in the latest version, so we need to
-    replace the modules in the `go.mod` file with a patch version that
+    In this case, cadvisor is a dependency of the latest kubernetes module.
+    Furthermore, cadvisor has not fixed this issue in the latest version, so we
+    need to replace the modules in the `go.mod` file with a patch version that
     contains the fix. This can be done by adding a `replace` directive in the
     `go.mod` file:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,7 @@
 # Troubleshooting Guide
 
-This guide provides troubleshooting steps for common issues with the local-csi-driver.
+This guide provides troubleshooting steps for common issues with the
+local-csi-driver.
 
 ## Collecting Diagnostic Information
 
@@ -15,8 +16,8 @@ To generate a support bundle:
 make get-support-bundle
 ```
 
-This will create a support bundle in the `support-bundles` directory.
-You can specify a specific time range with:
+This will create a support bundle in the `support-bundles` directory. You can
+specify a specific time range with:
 
 ```sh
 SUPPORT_BUNDLE_SINCE_TIME="2023-06-01T00:00:00Z" make get-support-bundle
@@ -24,8 +25,8 @@ SUPPORT_BUNDLE_SINCE_TIME="2023-06-01T00:00:00Z" make get-support-bundle
 
 ### Checking Logs
 
-Logs are essential for troubleshooting. You can view logs for the local-csi-driver
-components using kubectl:
+Logs are essential for troubleshooting. You can view logs for the
+local-csi-driver components using kubectl:
 
 ```sh
 # View logs
@@ -34,7 +35,8 @@ kubectl logs -n kube-system daemonsets/csi-local-node --prefix --all-containers
 
 ### Checking Kubernetes Events
 
-Kubernetes events provide valuable information about what's happening in the cluster:
+Kubernetes events provide valuable information about what's happening in the
+cluster:
 
 ```sh
 # View all events in the namespace
@@ -130,8 +132,8 @@ If you're using a non-ephemeral volume and encounter issues:
 2. The annotation should include:
 
    ```yaml
-   local.csi.azure.com/accept-ephemeral-storage: "true"
+   localdisk.csi.acstor.io/accept-ephemeral-storage: "true"
    ```
 
-   Make sure that you understand the implications of using ephemeral storage,
-   as data may be lost if the node is deleted or the pod is moved to another node.
+   Make sure that you understand the implications of using ephemeral storage, as
+   data may be lost if the node is deleted or the pod is moved to another node.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -26,7 +26,8 @@ To install local-csi-driver using Helm:
 
 Only one instance of local-csi-driver can be installed per cluster.
 
-Helm chart values are documented in: [Helm chart README](./charts/latest/README.md).
+Helm chart values are documented in: [Helm chart
+README](./charts/latest/README.md).
 
 ## Creating a StorageClass
 
@@ -38,8 +39,8 @@ kind: StorageClass
 metadata:
   name: local
 parameters:
-  local.csi.azure.com/vg: containerstorage
-provisioner: local.csi.azure.com
+  localdisk.csi.acstor.io/vg: containerstorage
+provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
@@ -113,9 +114,9 @@ kubectl apply -f statefulset.yaml
 By default, the local-csi-driver only permits the use of generic ephemeral
 volumes. If you want to use a persistent volume claim that is not linked to the
 lifecycle of the pod, you need to add the
-`local.csi.azure.com/accept-ephemeral-storage: "true"` annotation to the
-PersistentVolumeClaim. Note: The data on the volume is local to the node and will
-be lost if the node is deleted or the pod is moved to another node.
+`localdisk.csi.acstor.io/accept-ephemeral-storage: "true"` annotation to the
+PersistentVolumeClaim. Note: The data on the volume is local to the node and
+will be lost if the node is deleted or the pod is moved to another node.
 
 ```yaml
 ---
@@ -155,7 +156,7 @@ spec:
     - metadata:
         name: persistent-storage
         annotations:
-          local.csi.azure.com/accept-ephemeral-storage: "true"
+          localdisk.csi.acstor.io/accept-ephemeral-storage: "true"
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: local

--- a/examples/nvme/storageclass.yaml
+++ b/examples/nvme/storageclass.yaml
@@ -3,8 +3,8 @@ kind: StorageClass
 metadata:
   name: local
 parameters:
-  local.csi.azure.com/vg: containerstorage
-provisioner: local.csi.azure.com
+  localdisk.csi.acstor.io/vg: containerstorage
+provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/internal/csi/controller/controller.go
+++ b/internal/csi/controller/controller.go
@@ -58,7 +58,7 @@ func New(volume core.ControllerInterface, caps []*csi.ControllerServiceCapabilit
 		selectedInitialNodeParam: selectedInitialNodeParam,
 		removePvNodeAffinity:     removePvNodeAffinity,
 		recorder:                 recorder,
-		tracer:                   tp.Tracer("local.csi.azure.com/internal/csi/controller"),
+		tracer:                   tp.Tracer("localdisk.csi.acstor.io/internal/csi/controller"),
 	}
 }
 

--- a/internal/csi/controller/controller_test.go
+++ b/internal/csi/controller/controller_test.go
@@ -25,8 +25,8 @@ import (
 	"local-csi-driver/internal/pkg/tracing"
 )
 
-var selectedNodeAnnotation = "testlocal.csi.azure.com/selected-node"
-var selectedInitialNodeAnnotation = "testlocal.csi.azure.com/selected-initial-node"
+var selectedNodeAnnotation = "testlocaldisk.csi.acstor.io/selected-node"
+var selectedInitialNodeAnnotation = "testlocaldisk.csi.acstor.io/selected-initial-node"
 
 func initTestControllerServer(ctrl *gomock.Controller) *Server {
 	vc := core.NewFake()

--- a/internal/csi/core/lvm/controller_test.go
+++ b/internal/csi/core/lvm/controller_test.go
@@ -53,14 +53,14 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
 				VolumeContext: map[string]string{
-					"local.csi.azure.com/vg":       "containerstorage",
-					"local.csi.azure.com/capacity": "1073741824",
-					"local.csi.azure.com/limit":    "0",
+					"localdisk.csi.acstor.io/vg":       "containerstorage",
+					"localdisk.csi.acstor.io/capacity": "1073741824",
+					"localdisk.csi.acstor.io/limit":    "0",
 				},
 				AccessibleTopology: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							"topology.local.csi.azure.com/node": "nodename",
+							"topology.localdisk.csi.acstor.io/node": "nodename",
 						},
 					},
 				},
@@ -82,21 +82,21 @@ func TestLVM_Create(t *testing.T) {
 					},
 				},
 				Parameters: map[string]string{
-					"local.csi.azure.com/vg": testVolumeGroup,
+					"localdisk.csi.acstor.io/vg": testVolumeGroup,
 				},
 			},
 			want: &csi.Volume{
 				VolumeId:      testVolumeGroup + "#test-volume",
 				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
 				VolumeContext: map[string]string{
-					"local.csi.azure.com/vg":       testVolumeGroup,
-					"local.csi.azure.com/capacity": "1073741824",
-					"local.csi.azure.com/limit":    "0",
+					"localdisk.csi.acstor.io/vg":       testVolumeGroup,
+					"localdisk.csi.acstor.io/capacity": "1073741824",
+					"localdisk.csi.acstor.io/limit":    "0",
 				},
 				AccessibleTopology: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							"topology.local.csi.azure.com/node": "nodename",
+							"topology.localdisk.csi.acstor.io/node": "nodename",
 						},
 					},
 				},
@@ -123,14 +123,14 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
 				VolumeContext: map[string]string{
-					"local.csi.azure.com/vg":       "containerstorage",
-					"local.csi.azure.com/capacity": "1073741824",
-					"local.csi.azure.com/limit":    "0",
+					"localdisk.csi.acstor.io/vg":       "containerstorage",
+					"localdisk.csi.acstor.io/capacity": "1073741824",
+					"localdisk.csi.acstor.io/limit":    "0",
 				},
 				AccessibleTopology: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							"topology.local.csi.azure.com/node": "nodename",
+							"topology.localdisk.csi.acstor.io/node": "nodename",
 						},
 					},
 				},
@@ -157,14 +157,14 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1919999279104, // 1831054Mi
 				VolumeContext: map[string]string{
-					"local.csi.azure.com/vg":       "containerstorage",
-					"local.csi.azure.com/capacity": "1919999279104",
-					"local.csi.azure.com/limit":    "0",
+					"localdisk.csi.acstor.io/vg":       "containerstorage",
+					"localdisk.csi.acstor.io/capacity": "1919999279104",
+					"localdisk.csi.acstor.io/limit":    "0",
 				},
 				AccessibleTopology: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							"topology.local.csi.azure.com/node": "nodename",
+							"topology.localdisk.csi.acstor.io/node": "nodename",
 						},
 					},
 				},
@@ -192,14 +192,14 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1073741824, // 1 GiB
 				VolumeContext: map[string]string{
-					"local.csi.azure.com/vg":       "containerstorage",
-					"local.csi.azure.com/capacity": "1073741824",
-					"local.csi.azure.com/limit":    "2147483648",
+					"localdisk.csi.acstor.io/vg":       "containerstorage",
+					"localdisk.csi.acstor.io/capacity": "1073741824",
+					"localdisk.csi.acstor.io/limit":    "2147483648",
 				},
 				AccessibleTopology: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							"topology.local.csi.azure.com/node": "nodename",
+							"topology.localdisk.csi.acstor.io/node": "nodename",
 						},
 					},
 				},

--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// DriverName as registered with Kubernetes.
-	DriverName = "local.csi.azure.com"
+	DriverName = "localdisk.csi.acstor.io"
 
 	// DefaultVolumeGroup is the default volume group name used if no
 	// VolumeGroupNameParam is specified in the volume create request.
@@ -42,7 +42,7 @@ const (
 
 	// TopologyKey is the expected key used in the volume request to specify the
 	// node where the volume should be placed.
-	TopologyKey = "topology.local.csi.azure.com/node"
+	TopologyKey = "topology.localdisk.csi.acstor.io/node"
 
 	// Raid0LvType is the logical volume type for raid0.
 	raid0LvType = "raid0"
@@ -183,7 +183,7 @@ func New(k8sclient client.Client, podName, nodeName, releaseNamespace string, pr
 		releaseNamespace: releaseNamespace,
 		probe:            probe,
 		lvm:              lvmMgr,
-		tracer:           tp.Tracer("local.csi.azure.com/internal/csi/api/volume/lvm"),
+		tracer:           tp.Tracer("localdisk.csi.acstor.io/internal/csi/api/volume/lvm"),
 	}, nil
 }
 

--- a/internal/csi/driver.go
+++ b/internal/csi/driver.go
@@ -27,13 +27,13 @@ const (
 
 	// SelectedInitialNodeParam is used by the CSI driver to indicate the node
 	// that received the CreateVolume call and created the volume.
-	SelectedInitialNodeParam = "local.csi.azure.com/selected-initial-node"
+	SelectedInitialNodeParam = "localdisk.csi.acstor.io/selected-initial-node"
 
 	// SelctedNodeAnnotation is used by the CSI driver to indicate the node that
 	// received the NodeStage call in cases where the node is different from the
 	// SelectedInitialNodeParam. In such cases the volume is recreated on
 	// the node that received the NodeStage call to unblock workloads.
-	SelectedNodeAnnotation = "local.csi.azure.com/selected-node"
+	SelectedNodeAnnotation = "localdisk.csi.acstor.io/selected-node"
 )
 
 type Driver struct {

--- a/internal/csi/mounter/mounter.go
+++ b/internal/csi/mounter/mounter.go
@@ -86,7 +86,7 @@ func New(tp trace.TracerProvider) *Mounter {
 			Exec:      utilexec.New(),
 		},
 		hostutil.NewHostUtil(),
-		tp.Tracer("local.csi.azure.com/internal/csi/mounter"),
+		tp.Tracer("localdisk.csi.acstor.io/internal/csi/mounter"),
 	}
 }
 

--- a/internal/csi/node/node.go
+++ b/internal/csi/node/node.go
@@ -66,7 +66,7 @@ func New(volume core.NodeInterface, nodeID, selectedNodeAnnotation, selectedInit
 		selectedInitialNodeParam: selectedInitialNodeParam,
 		removePvNodeAffinity:     removeNodeAffinity,
 		recorder:                 recorder,
-		tracer:                   tp.Tracer("local.csi.azure.com/internal/csi/node"),
+		tracer:                   tp.Tracer("localdisk.csi.acstor.io/internal/csi/node"),
 	}
 }
 

--- a/internal/csi/node/node_test.go
+++ b/internal/csi/node/node_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	testNodeName             = "node-name"
-	driverName               = "testlocal.csi.azure.com"
+	driverName               = "testlocaldisk.csi.acstor.io"
 	testInvalidId            = "invalidId"
 	testVolumeID             = "vg#pv"
 	recoveryOKVolumeID       = "vg#testrecoveryok"
@@ -49,8 +49,8 @@ const (
 	invalidTargetPath        = "invalidTargetPath"
 	permissionError          = "permissionError"
 	testTopologyKey          = "topology." + driverName + "/node"
-	selectedNodeAnnotation   = "testlocal.csi.azure.com/selected-node"
-	selectedInitialNodeParam = "testlocal.csi.azure.com/selected-initial-node"
+	selectedNodeAnnotation   = "testlocaldisk.csi.acstor.io/selected-node"
+	selectedInitialNodeParam = "testlocaldisk.csi.acstor.io/selected-initial-node"
 )
 
 func initTestNodeServer(_ *testing.T, ctrl *gomock.Controller) *Server {
@@ -145,8 +145,8 @@ func initTestNodeServer(_ *testing.T, ctrl *gomock.Controller) *Server {
 							Driver:       driverName,
 							VolumeHandle: recoveryOKVolumeID,
 							VolumeAttributes: map[string]string{
-								selectedInitialNodeParam:       "test-node",
-								"local.csi.azure.com/capacity": "1Gi",
+								selectedInitialNodeParam:           "test-node",
+								"localdisk.csi.acstor.io/capacity": "1Gi",
 							},
 						},
 					},
@@ -751,7 +751,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeContext:     map[string]string{},
 			},
 			resp:      nil,
-			expectErr: status.Error(codes.Internal, fmt.Errorf("volume request size is missing in pv attribute local.csi.azure.com/capacity - recovery impossible").Error()),
+			expectErr: status.Error(codes.Internal, fmt.Errorf("volume request size is missing in pv attribute localdisk.csi.acstor.io/capacity - recovery impossible").Error()),
 		},
 	}
 	for _, test := range tests {

--- a/internal/pkg/lvm/lvm.go
+++ b/internal/pkg/lvm/lvm.go
@@ -87,7 +87,7 @@ type Client struct {
 func NewClient(opts ...ClientOption) *Client {
 	c := &Client{
 		lvmPath: "/sbin/lvm",
-		tracer:  tracing.NewNoopTracerProvider().Tracer("local.csi.azure.com/internal/pkg/lvm"),
+		tracer:  tracing.NewNoopTracerProvider().Tracer("localdisk.csi.acstor.io/internal/pkg/lvm"),
 	}
 
 	for _, opt := range opts {

--- a/internal/pkg/lvm/options.go
+++ b/internal/pkg/lvm/options.go
@@ -35,6 +35,6 @@ func WithLVM(path string) ClientOption {
 // Set the tracer.
 func WithTracerProvider(tp trace.TracerProvider) ClientOption {
 	return func(c *Client) {
-		c.tracer = tp.Tracer("local.csi.azure.com/internal/pkg/lvm")
+		c.tracer = tp.Tracer("localdisk.csi.acstor.io/internal/pkg/lvm")
 	}
 }

--- a/internal/webhook/hyperconverged/suite_test.go
+++ b/internal/webhook/hyperconverged/suite_test.go
@@ -59,7 +59,7 @@ webhooks:
       namespace: kube-system
       path: /mutate-pod
   failurePolicy: Fail # Set to fail for tests.
-  name: hyperconverged.local.csi.azure.com
+  name: hyperconverged.localdisk.csi.acstor.io
   rules:
   - apiGroups:
     - ""

--- a/internal/webhook/pvc/README.md
+++ b/internal/webhook/pvc/README.md
@@ -3,7 +3,8 @@
 The PVC controller ensures that volumes created in an ephemeral pool (local SSD
 or NVme) where replication has not been enabled, are only created using [generic
 ephemeral volumes]. Standard PVCs create requests will be denied, unless
-`local.csi.azure.com/accept-ephemeral-storage=true` annotation is added to the PVCs.
+`localdisk.csi.acstor.io/accept-ephemeral-storage=true` annotation is added to
+the PVCs.
 
 ## Controller Behaviour
 
@@ -13,12 +14,12 @@ allow them immediately. For PVCs from ephemeral pools, it allows those with
 multiple replicas.
 
 For unreplicated PVCs from ephemeral pools, it only allows them if they have an
-ownerReference set to a Pod or an annotation indicating ephemeral storage is acceptable.
-The former should only happen when a Pod is created with one or more
-[generic ephemeral volumes].
-The Pod is set as the PVC owner, so that when the Pod is deleted, its PVCs are too.
-Otherwise, the annotation `local.csi.azure.com/accept-ephemeral-storage=true`
-should be added to PVCs to be allowed.
+ownerReference set to a Pod or an annotation indicating ephemeral storage is
+acceptable. The former should only happen when a Pod is created with one or more
+[generic ephemeral volumes]. The Pod is set as the PVC owner, so that when the
+Pod is deleted, its PVCs are too. Otherwise, the annotation
+`localdisk.csi.acstor.io/accept-ephemeral-storage=true` should be added to PVCs
+to be allowed.
 
 Manual PVC creation without a required annotation for unreplicated volumes from
 ephemeral pools will be denied and and error sent back immediately.

--- a/internal/webhook/pvc/handler.go
+++ b/internal/webhook/pvc/handler.go
@@ -36,7 +36,7 @@ type opType string
 const (
 	unknown                             opType = "unknown"
 	create                              opType = "create"
-	acceptEphemeralStorageAnnotationKey        = "local.csi.azure.com/accept-ephemeral-storage"
+	acceptEphemeralStorageAnnotationKey        = "localdisk.csi.acstor.io/accept-ephemeral-storage"
 )
 
 // Handler implements admission.Handler.
@@ -132,8 +132,8 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		}
 	}
 
-	log.Info("denying pv create", "reason", "only generic ephemeral volumes are allowed for local.csi.azure.com provisioner")
-	return observeResponse(create, admission.Denied("only generic ephemeral volumes are allowed for local.csi.azure.com provisioner"))
+	log.Info("denying pv create", "reason", "only generic ephemeral volumes are allowed for localdisk.csi.acstor.io provisioner")
+	return observeResponse(create, admission.Denied("only generic ephemeral volumes are allowed for localdisk.csi.acstor.io provisioner"))
 }
 
 // isRetriableError returns false if the error is not retriable.

--- a/internal/webhook/pvc/handler_test.go
+++ b/internal/webhook/pvc/handler_test.go
@@ -93,7 +93,7 @@ var _ = Describe("When PVC controller is running", Serial, func() {
 			pvc = GenPVC(testStorageClassName, Namespace, "1Gi")
 			err := k8sClient.Create(ctx, pvc)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("only generic ephemeral volumes are allowed for local.csi.azure.com provisioner"))
+			Expect(err.Error()).Should(ContainSubstring("only generic ephemeral volumes are allowed for localdisk.csi.acstor.io provisioner"))
 
 		})
 	})
@@ -108,7 +108,7 @@ var _ = Describe("When PVC controller is running", Serial, func() {
 			pvc = GenPVC(testStorageClassName, Namespace, "1Gi")
 			err := k8sClient.Create(ctx, pvc)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("only generic ephemeral volumes are allowed for local.csi.azure.com provisioner"))
+			Expect(err.Error()).Should(ContainSubstring("only generic ephemeral volumes are allowed for localdisk.csi.acstor.io provisioner"))
 		})
 	})
 

--- a/internal/webhook/pvc/suite_test.go
+++ b/internal/webhook/pvc/suite_test.go
@@ -62,7 +62,7 @@ webhooks:
       namespace: kube-system
       path: /validate-pvc
   failurePolicy: Fail # Set to fail for tests.
-  name: ephemeral.local.csi.azure.com
+  name: ephemeral.localdisk.csi.acstor.io
   rules:
   - apiGroups:
     - ""

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,8 @@ make test
 
 This will run all the unit tests in the project. Unit tests are throughout the
 code base. All libraries (e.g. `internal/pkg/*`) should be covered completely.
-Elsewhere, functions should be covered as appropriate, depending on their complexity.
+Elsewhere, functions should be covered as appropriate, depending on their
+complexity.
 
 It is expected that all logic outside the controller reconcilers will be covered
 by unit tests. Within the controller reconcilers, complex logic should be
@@ -125,11 +126,12 @@ kinds of tests, the `lvm` and `lvm-annotation` tests.
 The `lvm` tests only run the generic ephemeral volume tests, which is the only
 kind of volume permitted by default by the driver.
 
-The `lvm-annotation` tests run all the tests specified
-by the external tests. It uses [`kyverno`](https://github.com/kyverno/kyverno)
-to add the `local.csi.azure.com/accept-ephemeral-storage: "true"` annotation to
-the persistent volume claim. This allows the tests to test the "accept-ephemeral-storage"
-mode of the driver. The tests are located in the `test/e2e/external` directory.
+The `lvm-annotation` tests run all the tests specified by the external tests. It
+uses [`kyverno`](https://github.com/kyverno/kyverno) to add the
+`localdisk.csi.acstor.io/accept-ephemeral-storage: "true"` annotation to the
+persistent volume claim. This allows the tests to test the
+"accept-ephemeral-storage" mode of the driver. The tests are located in the
+`test/e2e/external` directory.
 
 ### Sanity Tests
 
@@ -139,12 +141,14 @@ To run the sanity tests, run:
 REGISTRY=<registry>.azurecr.io make docker-build helm-build docker-push helm-push test-sanity
 ```
 
-The sanity tests are conformance tests that check if the driver adheres to the CSI
-spec. The tests are written in Go and use the Ginkgo testing framework. The implementation
-can be found in the  [`kubernetes-csi/csi-test`](https://github.com/kubernetes-csi/csi-test)
-repo. The tests are located in the `test/sanity` directory. The tests are run on
-an AKS cluster. If you find a change that you made that breaks the tests, please
-refer to the [`container-storage-interface/spec`](https://github.com/container-storage-interface/spec)
+The sanity tests are conformance tests that check if the driver adheres to the
+CSI spec. The tests are written in Go and use the Ginkgo testing framework. The
+implementation can be found in the
+[`kubernetes-csi/csi-test`](https://github.com/kubernetes-csi/csi-test) repo.
+The tests are located in the `test/sanity` directory. The tests are run on an
+AKS cluster. If you find a change that you made that breaks the tests, please
+refer to the
+[`container-storage-interface/spec`](https://github.com/container-storage-interface/spec)
 repo to review the spec to make any necessary changes to the driver.
 
 ### Scale and AKS Integration Tests
@@ -162,7 +166,8 @@ of volumes can be adjusted by changing the `SCALE` variable.
 
 #### Upgrade Tests
 
-To test the driver's functionality after [upgrading the Kubernetes cluster](https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli):
+To test the driver's functionality after [upgrading the Kubernetes
+cluster](https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli):
 
 ```sh
 LABEL_FILTER=lvm make test-upgrade
@@ -176,7 +181,8 @@ These tests ensure that the driver remains functional after a cluster upgrade.
 
 #### Restart Tests
 
-To test the driver's behavior after [restarting the cluster](https://learn.microsoft.com/en-us/azure/aks/start-stop-cluster?tabs=azure-cli):
+To test the driver's behavior after [restarting the
+cluster](https://learn.microsoft.com/en-us/azure/aks/start-stop-cluster?tabs=azure-cli):
 
 ```sh
 make test-restart
@@ -184,7 +190,8 @@ make test-restart
 
 #### Scaledown Tests
 
-To test the driver's behavior when [scaling down the cluster](https://learn.microsoft.com/en-us/azure/aks/scale-cluster?tabs=azure-cli):
+To test the driver's behavior when [scaling down the
+cluster](https://learn.microsoft.com/en-us/azure/aks/scale-cluster?tabs=azure-cli):
 
 ```sh
 make test-scaledown

--- a/test/aks/aks.go
+++ b/test/aks/aks.go
@@ -178,7 +178,7 @@ func (ts *testsuite) beforeEach(ctx context.Context) {
 					continue
 				}
 				provisionedBy := pv.Annotations[volume.AnnDynamicallyProvisioned]
-				g.Expect(provisionedBy).NotTo(ContainSubstring("local.csi.azure.com"), "provisionedBy annotation should not contain local.csi.azure.com")
+				g.Expect(provisionedBy).NotTo(ContainSubstring("localdisk.csi.acstor.io"), "provisionedBy annotation should not contain localdisk.csi.acstor.io")
 			}
 		}).WithContext(ctx).Should(Succeed(), "failed to wait for persistent volumes to be empty")
 		Eventually(func(g Gomega, ctx context.Context) {
@@ -359,7 +359,7 @@ func pvAffinityForExistingNode(nodeAffinity *corev1.VolumeNodeAffinity, nodes ma
 
 	for _, term := range nodeAffinity.Required.NodeSelectorTerms {
 		for _, expr := range term.MatchExpressions {
-			if expr.Key == "topology.local.csi.azure.com/node" && expr.Operator == corev1.NodeSelectorOpIn {
+			if expr.Key == "topology.localdisk.csi.acstor.io/node" && expr.Operator == corev1.NodeSelectorOpIn {
 				for _, value := range expr.Values {
 					if _, exists := nodes[value]; exists {
 						return true

--- a/test/external/drivers/lvm.yaml
+++ b/test/external/drivers/lvm.yaml
@@ -1,7 +1,7 @@
 StorageClass:
   FromFile: test/external/drivers/lvm_storageclass.yaml
 DriverInfo:
-  Name: local.csi.azure.com
+  Name: localdisk.csi.acstor.io
   SupportedFsType: {"ext2", "ext3", "ext4", "xfs"}
   Capabilities:
     # data is persisted across pod restarts

--- a/test/external/drivers/lvm_storageclass.yaml
+++ b/test/external/drivers/lvm_storageclass.yaml
@@ -3,8 +3,8 @@ kind: StorageClass
 metadata:
   name: local
 parameters:
-  local.csi.azure.com/vg: containerstorage
-provisioner: local.csi.azure.com
+  localdisk.csi.acstor.io/vg: containerstorage
+provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/test/external/fixtures/pvc_annotator.yaml
+++ b/test/external/fixtures/pvc_annotator.yaml
@@ -13,4 +13,4 @@ spec:
       patchStrategicMerge:
         metadata:
           annotations:
-            +(local.csi.azure.com/accept-ephemeral-storage): "true"
+            +(localdisk.csi.acstor.io/accept-ephemeral-storage): "true"

--- a/test/pkg/common/fixtures/lvm_annotation_statefulset.yaml
+++ b/test/pkg/common/fixtures/lvm_annotation_statefulset.yaml
@@ -37,7 +37,7 @@ spec:
         labels:
           part-of: e2e-test
         annotations:
-          local.csi.azure.com/accept-ephemeral-storage: "true"
+          localdisk.csi.acstor.io/accept-ephemeral-storage: "true"
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: local

--- a/test/pkg/common/fixtures/lvm_pvc_annotation.yaml
+++ b/test/pkg/common/fixtures/lvm_pvc_annotation.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     part-of: e2e-test
   annotations:
-    local.csi.azure.com/accept-ephemeral-storage: "true"
+    localdisk.csi.acstor.io/accept-ephemeral-storage: "true"
   name: lvm-pvc-annotation
 spec:
   accessModes:

--- a/test/pkg/common/fixtures/lvm_storageclass.yaml
+++ b/test/pkg/common/fixtures/lvm_storageclass.yaml
@@ -3,8 +3,8 @@ kind: StorageClass
 metadata:
   name: local
 # parameters:
-#   local.csi.azure.com/vg: containerstorage
-provisioner: local.csi.azure.com
+#   localdisk.csi.acstor.io/vg: containerstorage
+provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -56,7 +56,7 @@ var TestConfigs = []testConfig{
 		labels:        Label("aks", "lvm", "sanity"),
 		testVolumeParameters: func() (map[string]string, error) {
 			return map[string]string{
-				"local.csi.azure.com/vg": volumeGroupName,
+				"localdisk.csi.acstor.io/vg": volumeGroupName,
 			}, nil
 		},
 		controllerAddressPort: "10001",


### PR DESCRIPTION
This is a breaking change - ensure all existing PVs are removed before upgrading.

Removes "azure" from the provisioner name.