### PR TITLE
chore: update statefulsets to properly create date, add annotation ex…

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -65,7 +65,7 @@ To create a StatefulSet using the StorageClass, apply the following YAML:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: statefulset-cns-lvm
+  name: statefulset-lcd-lvm
   labels:
     app: busybox
 spec:
@@ -79,15 +79,15 @@ spec:
       nodeSelector:
         "kubernetes.io/os": linux
       containers:
-        - name: statefulset-cns
+        - name: statefulset-lcd
           image: mcr.microsoft.com/azurelinux/busybox:1.36
           command:
             - "/bin/sh"
             - "-c"
-            - set -euo pipefail; trap exit TERM; while true; do echo $(date -u +"%Y-%m-%dT%H:%M:%SZ") | tee -a /mnt/cns/outfile; sleep 1; done
+            - set -euo pipefail; trap exit TERM; while true; do date -u +"%Y-%m-%dT%H:%M:%SZ" | tee -a /mnt/lcd/outfile; sleep 1; done
           volumeMounts:
             - name: ephemeral-storage
-              mountPath: /mnt/cns
+              mountPath: /mnt/lcd
       volumes:
         - name: ephemeral-storage
           ephemeral:
@@ -127,12 +127,12 @@ will be lost if the node is deleted or the pod is moved to another node.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: statefulset-cns-lvm-annotation
+  name: statefulset-lcd-lvm-annotation
   labels:
     app: busybox
 spec:
   podManagementPolicy: Parallel  # default is OrderedReady
-  serviceName: statefulset-cns
+  serviceName: statefulset-lcd
   replicas: 10
   template:
     metadata:
@@ -142,15 +142,15 @@ spec:
       nodeSelector:
         "kubernetes.io/os": linux
       containers:
-        - name: statefulset-cns
+        - name: statefulset-lcd
           image: mcr.microsoft.com/azurelinux/busybox:1.36
           command:
             - "/bin/sh"
             - "-c"
-            - set -euo pipefail; trap exit TERM; while true; do echo $(date) >> /mnt/cns/outfile; sleep 1; done
+            - set -euo pipefail; trap exit TERM; while true; do date -u +"%Y-%m-%dT%H:%M:%SZ" >> /mnt/lcd/outfile; sleep 1; done
           volumeMounts:
             - name: persistent-storage
-              mountPath: /mnt/cns
+              mountPath: /mnt/lcd
   updateStrategy:
     type: RollingUpdate
   selector:

--- a/examples/nvme/statefulset.yaml
+++ b/examples/nvme/statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: statefulset-cns-lvm
+  name: statefulset-lcd-lvm
   labels:
     app: busybox
 spec:
@@ -16,15 +16,15 @@ spec:
       nodeSelector:
         "kubernetes.io/os": linux
       containers:
-        - name: statefulset-cns
+        - name: statefulset-lcd
           image: mcr.microsoft.com/azurelinux/busybox:1.36
           command:
             - "/bin/sh"
             - "-c"
-            - set -euo pipefail; trap exit TERM; while true; do echo $(date -u +"%Y-%m-%dT%H:%M:%SZ") | tee -a /mnt/cns/outfile; sleep 1; done
+            - set -euo pipefail; trap exit TERM; while true; do date -u +"%Y-%m-%dT%H:%M:%SZ" | tee -a /mnt/lcd/outfile; sleep 1; done
           volumeMounts:
             - name: ephemeral-storage
-              mountPath: /mnt/cns
+              mountPath: /mnt/lcd
       volumes:
         - name: ephemeral-storage
           ephemeral:

--- a/examples/nvme/statefulset_annotation.yaml
+++ b/examples/nvme/statefulset_annotation.yaml
@@ -7,8 +7,7 @@ metadata:
     app: busybox
 spec:
   podManagementPolicy: Parallel  # default is OrderedReady
-  serviceName: statefulset-lcd
-  replicas: 10
+  replicas:  5
   template:
     metadata:
       labels:
@@ -34,8 +33,6 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: persistent-storage
-        labels:
-          part-of: e2e-test
         annotations:
           localdisk.csi.acstor.io/accept-ephemeral-storage: "true"
       spec:

--- a/internal/csi/server/endpoint_test.go
+++ b/internal/csi/server/endpoint_test.go
@@ -16,9 +16,9 @@ func Test_parseEndpoint(t *testing.T) {
 		wantAddr  string
 		wantErr   bool
 	}{
-		{"unix:///var/lib/cns/csi.sock", "unix", "/var/lib/cns/csi.sock", false},
+		{"unix:///var/lib/lcd/csi.sock", "unix", "/var/lib/lcd/csi.sock", false},
 		{"tcp://10.0.0.1:1000", "tcp", "10.0.0.1:1000", false},
-		{"/var/lib/cns/csi.sock", "", "", true},
+		{"/var/lib/lcd/csi.sock", "", "", true},
 		{"10.0.0.1:1000", "", "", true},
 	}
 	for _, tt := range tests {

--- a/internal/webhook/pvc/README.md
+++ b/internal/webhook/pvc/README.md
@@ -9,9 +9,9 @@ the PVCs.
 ## Controller Behaviour
 
 The PVC controller watches for PVC create requests. When a request is received,
-it will try to rule out non-cns PVCs or PVCs from non-ephemeral pools and
-allow them immediately. For PVCs from ephemeral pools, it allows those with
-multiple replicas.
+it will try to rule out non-local-csi-driver PVCs or PVCs from non-ephemeral
+pools and allow them immediately. For PVCs from ephemeral pools, it allows those
+with multiple replicas.
 
 For unreplicated PVCs from ephemeral pools, it only allows them if they have an
 ownerReference set to a Pod or an annotation indicating ephemeral storage is

--- a/test/aks/aks.go
+++ b/test/aks/aks.go
@@ -257,7 +257,7 @@ func (ts *testsuite) beforeEach(ctx context.Context) {
 //  1. If the test failed or was skipped, afterEach is skipped. No need to check.
 //  2. Otherwise, it verifies that:
 //     - All cluster nodes are in Ready condition
-//     - All CNS system pods are running properly
+//     - All local-csi-driver system pods are running properly
 //     - All DiskPools are ready and not degraded
 //     - All application StatefulSets are running with expected replica counts
 //     - All application pods can write to their mounted volumes
@@ -324,7 +324,7 @@ func (ts *testsuite) verifyApplicationRunning(g Gomega, ctx context.Context) {
 		// This can happen when the nexus is paused
 		writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		cmd := exec.CommandContext(writeCtx, "kubectl", "exec", pod.Name, "-n", applicationNamespace, "--", "sh", "-c", fmt.Sprintf("echo '%s' > /mnt/cns/check", time.Now().UTC().Format(time.RFC3339)))
+		cmd := exec.CommandContext(writeCtx, "kubectl", "exec", pod.Name, "-n", applicationNamespace, "--", "sh", "-c", fmt.Sprintf("echo '%s' > /mnt/lcd/check", time.Now().UTC().Format(time.RFC3339)))
 		_, err := utils.Run(cmd)
 		g.Expect(err).NotTo(HaveOccurred(), "Failed to write to pod mount")
 	}

--- a/test/external/external_suite_test.go
+++ b/test/external/external_suite_test.go
@@ -58,7 +58,7 @@ func TestExternalE2E(t *testing.T) {
 	SetDefaultEventuallyPollingInterval(time.Second)
 	EnforceDefaultTimeoutsWhenUsingContexts()
 	RegisterFailHandler(Fail)
-	_, _ = fmt.Fprintf(GinkgoWriter, "Starting cns integration test suite\n")
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting lcd integration test suite\n")
 	RunSpecs(t, "external e2e suite")
 }
 

--- a/test/pkg/common/fixtures/lvm_pod_annotation.yaml
+++ b/test/pkg/common/fixtures/lvm_pod_annotation.yaml
@@ -9,15 +9,15 @@ spec:
   nodeSelector:
     "kubernetes.io/os": linux
   containers:
-    - name: statefulset-cns
+    - name: statefulset-lcd
       image: mcr.microsoft.com/azurelinux/busybox:1.36
       command:
         - "/bin/sh"
         - "-c"
-        - set -euo pipefail; trap exit TERM; while true; do echo $(date) >> /mnt/cns/outfile; sleep 1; done
+        - set -euo pipefail; trap exit TERM; while true; do date -u +"%Y-%m-%dT%H:%M:%SZ" >> /mnt/lcd/outfile; sleep 1; done
       volumeMounts:
         - name: persistent-storage
-          mountPath: /mnt/cns
+          mountPath: /mnt/lcd
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:

--- a/test/pkg/common/fixtures/lvm_statefulset.yaml
+++ b/test/pkg/common/fixtures/lvm_statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: statefulset-cns-lvm
+  name: statefulset-lcd-lvm
   labels:
     app: busybox
 spec:
@@ -16,15 +16,15 @@ spec:
       nodeSelector:
         "kubernetes.io/os": linux
       containers:
-        - name: statefulset-cns
+        - name: statefulset-lcd
           image: mcr.microsoft.com/azurelinux/busybox:1.36
           command:
             - "/bin/sh"
             - "-c"
-            - set -euo pipefail; trap exit TERM; while true; do echo $(date -u +"%Y-%m-%dT%H:%M:%SZ") | tee -a /mnt/cns/outfile; sleep 1; done
+            - set -euo pipefail; trap exit TERM; while true; do date -u +"%Y-%m-%dT%H:%M:%SZ"| tee -a /mnt/lcd/outfile; sleep 1; done
           volumeMounts:
             - name: ephemeral-storage
-              mountPath: /mnt/cns
+              mountPath: /mnt/lcd
       volumes:
         - name: ephemeral-storage
           ephemeral:

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -221,7 +221,7 @@ func (t *testConfig) SkipUnsupportedTest() {
 	}
 }
 
-// mkdirInPod creates a directory in the cns-node-agent pod.
+// mkdirInPod creates a directory in the csi-local-node pod.
 func mkdirInPod(path string) (string, error) {
 	procPath := fmt.Sprintf("%s-%d", path, GinkgoParallelProcess())
 	_, err := execInPod("mkdir", "-p", procPath)
@@ -231,13 +231,13 @@ func mkdirInPod(path string) (string, error) {
 	return procPath, nil
 }
 
-// removePathInPod removes a path in the cns-node-agent pod.
+// removePathInPod removes a path in the csi-local-node pod.
 func removePathInPod(path string) error {
 	_, err := execInPod("rm", "-rf", path)
 	return err
 }
 
-// checkPathInPod checks the type of path in the cns-node-agent pod.
+// checkPathInPod checks the type of path in the csi-local-node pod.
 func checkPathInPod(path string) (sanity.PathKind, error) {
 	output, err := execInPod("sh", "-c", "if [ -f "+path+" ]; then echo file; elif [ -d "+path+" ]; then echo directory; elif [ ! -e "+path+" ]; then echo not_found; else echo other; fi")
 	if err != nil {

--- a/test/scale/fixtures/ephemeral_statefulset.yaml
+++ b/test/scale/fixtures/ephemeral_statefulset.yaml
@@ -16,15 +16,15 @@ spec:
       nodeSelector:
         "kubernetes.io/os": linux
       containers:
-        - name: statefulset-cns
+        - name: statefulset-lcd
           image: mcr.microsoft.com/azurelinux/busybox:1.36
           command:
             - "/bin/sh"
             - "-c"
-            - set -euo pipefail; trap exit TERM; while true; do echo $(date) >> /mnt/cns/outfile; sleep 1; done
+            - set -euo pipefail; trap exit TERM; while true; do date -u +"%Y-%m-%dT%H:%M:%SZ" >> /mnt/lcd/outfile; sleep 1; done
           volumeMounts:
             - name: ephemeral-storage
-              mountPath: /mnt/cns
+              mountPath: /mnt/lcd
       volumes:
         - name: ephemeral-storage
           ephemeral:


### PR DESCRIPTION
This pull request makes extensive changes to rename references from "CNS" (Container Native Storage) to "LCD" (Local CSI Driver) across multiple files, updating metadata, commands, mount paths, and documentation to reflect the new naming convention. The changes are grouped into three main themes: StatefulSet updates, testing framework adjustments, and documentation updates.

### StatefulSet Updates:
* Renamed StatefulSet metadata and container names from `statefulset-cns` to `statefulset-lcd`, updated mount paths from `/mnt/cns` to `/mnt/lcd`, and modified commands to use `date -u` for consistent timestamp formatting in `docs/user-guide.md`, `examples/nvme/statefulset.yaml`, and `test/pkg/common/fixtures/*.yaml`. [[1]](diffhunk://#diff-971a69e5ae264bfdae535d0c72902cc6f15a559f6d2dc650b78b473f6783c3caL64-R64) [[2]](diffhunk://#diff-971a69e5ae264bfdae535d0c72902cc6f15a559f6d2dc650b78b473f6783c3caL78-R86) [[3]](diffhunk://#diff-67e5eac210a5eed95dc861a1cd73aaa742252bae890aa8824d0a349ded23856fL5-R5) [[4]](diffhunk://#diff-67e5eac210a5eed95dc861a1cd73aaa742252bae890aa8824d0a349ded23856fL19-R27) [[5]](diffhunk://#diff-3facf0a60b3e11bd0c27ec9f183e86f3c19d6251e0574a563e2f26b455ac472cL5-R10) [[6]](diffhunk://#diff-3facf0a60b3e11bd0c27ec9f183e86f3c19d6251e0574a563e2f26b455ac472cL20-R28) [[7]](diffhunk://#diff-45b942e781998bc6e651c4aa5abececeab1402eb851fbccd3be7113d247ea53aL5-R5) [[8]](diffhunk://#diff-45b942e781998bc6e651c4aa5abececeab1402eb851fbccd3be7113d247ea53aL19-R27) [[9]](diffhunk://#diff-f2d82c23a5817283061db06b8400add35558f3f8472b0fa1870aaf94ea66988dL12-R20) [[10]](diffhunk://#diff-4df704da7f91c08949ccc64963a368950adacf1d25358269187d2ff204e3ce28L19-R27)

### Testing Framework Adjustments:
* Updated test configurations to replace references to "CNS" with "LCD" in pod names, paths, and integration test suite messages across multiple test files (`internal/csi/server/endpoint_test.go`, `test/aks/aks.go`, `test/external/external_suite_test.go`, `test/sanity/sanity_test.go`). [[1]](diffhunk://#diff-a826f465d079f5b4dc8a95029388510d940e9956f70d7814ba0ddbe8920d9144L19-R21) [[2]](diffhunk://#diff-cdcfeef8004bb41ca52081c3d282ebf04042ee0c62ed2abda18926b0261e02feL260-R260) [[3]](diffhunk://#diff-cdcfeef8004bb41ca52081c3d282ebf04042ee0c62ed2abda18926b0261e02feL327-R327) [[4]](diffhunk://#diff-c7ce3f9e0f2f2bad1321e0ea8208b7c418c3b22d7066746554cd480fb46feacbL61-R61) [[5]](diffhunk://#diff-0426edb781a00c7e1615f8d45f69d0404173f4401334d872a7fde05d6669c3eaL224-R224) [[6]](diffhunk://#diff-0426edb781a00c7e1615f8d45f69d0404173f4401334d872a7fde05d6669c3eaL234-R240)

### Documentation Updates:
* Revised documentation references from "CNS" to "LCD" in `internal/pkg/tracing/provider.go` and `internal/webhook/pvc/README.md`, ensuring alignment with the new naming convention. [[1]](diffhunk://#diff-733849c6cd73c30cf3b35bcac74496f4807eb99add859d0fae26f8cf2e7f10a5L30-R30) [[2]](diffhunk://#diff-c4fad5ff8dcc470f4b473fd3311933600c5290720e0f33c6eda6d8c01ae0d590L12-R14)

These changes collectively ensure consistency across the codebase and documentation, reflecting the transition from CNS to LCD.…ample to top-level examples