### PR TITLE
chore: remove localdisk.csi.acstor.io/vg as storageclass/CreateVolume…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: check-xml
   - id: check-json
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.1.6
+  rev: v2.2.1
   hooks:
   - id: golangci-lint-full
 - repo: https://github.com/hadolint/hadolint
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: markdownlint-fix-docker
 - repo: https://github.com/pycqa/flake8
-  rev: 7.2.0
+  rev: 7.3.0
   hooks:
   - id: flake8
 - repo: https://github.com/codespell-project/codespell

--- a/charts/latest/templates/NOTES.txt
+++ b/charts/latest/templates/NOTES.txt
@@ -11,8 +11,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local
-parameters:
-  localdisk.csi.acstor.io/vg: containerstorage
 provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/docs/design/disk-selection.md
+++ b/docs/design/disk-selection.md
@@ -24,21 +24,6 @@ want and excludes those they do not want.
 
 ## Design
 
-Currently, we allow customization of the volume group name through the
-StorageClass parameter `localdisk.csi.acstor.io/vg`. For example:
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: local
-provisioner: localdisk.csi.acstor.io
-parameters:
-  localdisk.csi.acstor.io/vg: containerstorage
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
-```
-
 We will add three new parameters to the storage class to allow users to
 customize the disk selection:
 
@@ -61,7 +46,6 @@ path prefix.
 
 | Parameter                                   | Description                 | Default Value                                              |
 |----------------------------------------------|----------------------------|------------------------------------------------------------|
-| `localdisk.csi.acstor.io/vg`                     | Name of the volume group   | `containerstorage`                                         |
 | `localdisk.csi.acstor.io/disk-path-prefixes`     | Prefix of the disk path    | `/dev/nvme`                                                |
 | `localdisk.csi.acstor.io/disk-models`            | Model of the disk          | `Microsoft NVMe Direct Disk,Microsoft NVMe Direct Disk v2` |
 | `localdisk.csi.acstor.io/disk-types`             | Type of the disk           | `disk`                                                     |
@@ -75,7 +59,6 @@ metadata:
   name: local
 provisioner: localdisk.csi.acstor.io
 parameters:
-  localdisk.csi.acstor.io/vg: containerstorage
   localdisk.csi.acstor.io/disk-path-prefixes: /dev/nvme,/dev/sda
   localdisk.csi.acstor.io/disk-models: Microsoft NVMe Direct Disk,Microsoft NVMe Direct Disk v2
   localdisk.csi.acstor.io/disk-types: disk

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,8 +42,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local
-parameters:
-  localdisk.csi.acstor.io/vg: containerstorage
 provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/examples/nvme/storageclass.yaml
+++ b/examples/nvme/storageclass.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local
-parameters:
-  localdisk.csi.acstor.io/vg: containerstorage
 provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/internal/csi/core/lvm/controller_test.go
+++ b/internal/csi/core/lvm/controller_test.go
@@ -53,7 +53,6 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
 				VolumeContext: map[string]string{
-					"localdisk.csi.acstor.io/vg":       "containerstorage",
 					"localdisk.csi.acstor.io/capacity": "1073741824",
 					"localdisk.csi.acstor.io/limit":    "0",
 				},
@@ -81,15 +80,12 @@ func TestLVM_Create(t *testing.T) {
 						},
 					},
 				},
-				Parameters: map[string]string{
-					"localdisk.csi.acstor.io/vg": testVolumeGroup,
-				},
+				Parameters: map[string]string{},
 			},
 			want: &csi.Volume{
-				VolumeId:      testVolumeGroup + "#test-volume",
+				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
 				VolumeContext: map[string]string{
-					"localdisk.csi.acstor.io/vg":       testVolumeGroup,
 					"localdisk.csi.acstor.io/capacity": "1073741824",
 					"localdisk.csi.acstor.io/limit":    "0",
 				},
@@ -123,7 +119,6 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1024 * 1024 * 1024, // 1 GiB
 				VolumeContext: map[string]string{
-					"localdisk.csi.acstor.io/vg":       "containerstorage",
 					"localdisk.csi.acstor.io/capacity": "1073741824",
 					"localdisk.csi.acstor.io/limit":    "0",
 				},
@@ -157,7 +152,6 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1919999279104, // 1831054Mi
 				VolumeContext: map[string]string{
-					"localdisk.csi.acstor.io/vg":       "containerstorage",
 					"localdisk.csi.acstor.io/capacity": "1919999279104",
 					"localdisk.csi.acstor.io/limit":    "0",
 				},
@@ -192,7 +186,6 @@ func TestLVM_Create(t *testing.T) {
 				VolumeId:      "containerstorage#test-volume",
 				CapacityBytes: 1073741824, // 1 GiB
 				VolumeContext: map[string]string{
-					"localdisk.csi.acstor.io/vg":       "containerstorage",
 					"localdisk.csi.acstor.io/capacity": "1073741824",
 					"localdisk.csi.acstor.io/limit":    "2147483648",
 				},

--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -69,11 +69,6 @@ const (
 
 // Volume context parameters.
 var (
-	// VolumeGroupParam is the expected key used in the volume create request to
-	// specify the LVM volume group name where the logical volume should be
-	// created.
-	VolumeGroupParam = DriverName + "/vg"
-
 	// CapacityParam and LimitParam are used in the volume context to specify
 	// the requested and maximum size of the logical volume. It is used for PV
 	// recovery during NodeStageVolume to recreate the volume if it doesn't

--- a/test/external/drivers/lvm_storageclass.yaml
+++ b/test/external/drivers/lvm_storageclass.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local
-parameters:
-  localdisk.csi.acstor.io/vg: containerstorage
 provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/test/pkg/common/fixtures/lvm_storageclass.yaml
+++ b/test/pkg/common/fixtures/lvm_storageclass.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local
-# parameters:
-#   localdisk.csi.acstor.io/vg: containerstorage
 provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/test/sanity/id.go
+++ b/test/sanity/id.go
@@ -10,6 +10,11 @@ import (
 	"github.com/kubernetes-csi/csi-test/v5/pkg/sanity"
 )
 
+const (
+	// volumeGroupName is the name of the volume group used in the sanity tests.
+	volumeGroupName = "containerstorage"
+)
+
 // Verify VGIDGenerator implements IDGenerator interface.
 var _ sanity.IDGenerator = &LvmIDGenerator{}
 
@@ -17,21 +22,15 @@ var _ sanity.IDGenerator = &LvmIDGenerator{}
 // It generates volume IDs in the format "vgName#volumeName".
 type LvmIDGenerator struct {
 	sanity.DefaultIDGenerator
-	// VolumeGroupName is the volume group name to use in generated IDs
-	VolumeGroupName string
 }
 
 // NewLVMGenerator creates a new VGIDGenerator with the specified volume group name.
-func NewLVMGenerator(volumeGroupName string) (*LvmIDGenerator, error) {
-	if len(volumeGroupName) == 0 {
-		return nil, fmt.Errorf("volume group name cannot be empty")
-	}
-	return &LvmIDGenerator{
-		VolumeGroupName: volumeGroupName,
-	}, nil
+func NewLVMGenerator() (*LvmIDGenerator, error) {
+
+	return &LvmIDGenerator{}, nil
 }
 
 // GenerateUniqueValidVolumeID generates a unique volume ID in the format "vgName#volumeName".
 func (g LvmIDGenerator) GenerateUniqueValidVolumeID() string {
-	return fmt.Sprintf("%s#%s", g.VolumeGroupName, uuid.New().String()[:10])
+	return fmt.Sprintf("%s#%s", volumeGroupName, uuid.New().String()[:10])
 }


### PR DESCRIPTION
This pull request removes support for specifying custom volume groups in the LVM storage class and simplifies the related codebase. The changes include removing the `localdisk.csi.acstor.io/vg` parameter, updating documentation to reflect this removal, and refactoring associated logic in the code and tests.

### Removal of custom volume group support:

* [`internal/csi/core/lvm/controller.go`](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L54-R54): Removed logic for handling the `VolumeGroupParam` parameter and replaced it with the default volume group (`DefaultVolumeGroup`) in methods like `Create`, `GetCapacity`, and `ValidateCapabilities`. [[1]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L54-R54) [[2]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L230-R228) [[3]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L365-L369)
* [`internal/csi/core/lvm/lvm.go`](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL72-L76): Removed the `VolumeGroupParam` constant, as it is no longer needed.
* [`internal/csi/core/lvm/controller_test.go`](diffhunk://#diff-5060a8629f8bb63873dee9181ae9568fa1ab4fdcd4bbc7596e9ef1d14089cc19L56): Updated tests to remove references to `localdisk.csi.acstor.io/vg` and ensure they work with the default volume group. [[1]](diffhunk://#diff-5060a8629f8bb63873dee9181ae9568fa1ab4fdcd4bbc7596e9ef1d14089cc19L56) [[2]](diffhunk://#diff-5060a8629f8bb63873dee9181ae9568fa1ab4fdcd4bbc7596e9ef1d14089cc19L84-L92) [[3]](diffhunk://#diff-5060a8629f8bb63873dee9181ae9568fa1ab4fdcd4bbc7596e9ef1d14089cc19L126)

### Documentation updates:

* [`docs/design/disk-selection.md`](diffhunk://#diff-cdc299202b7d3c3e6099588636229778ac0460155ecb3ebddb17022c42ce00e9L27-L41): Removed references to the `localdisk.csi.acstor.io/vg` parameter and updated the design documentation to reflect the removal of volume group customization. [[1]](diffhunk://#diff-cdc299202b7d3c3e6099588636229778ac0460155ecb3ebddb17022c42ce00e9L27-L41) [[2]](diffhunk://#diff-cdc299202b7d3c3e6099588636229778ac0460155ecb3ebddb17022c42ce00e9L64) [[3]](diffhunk://#diff-cdc299202b7d3c3e6099588636229778ac0460155ecb3ebddb17022c42ce00e9L78)
* [`docs/user-guide.md`](diffhunk://#diff-971a69e5ae264bfdae535d0c72902cc6f15a559f6d2dc650b78b473f6783c3caL45-L46): Updated examples to exclude the `localdisk.csi.acstor.io/vg` parameter.

### Configuration and example updates:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L15-R15): Updated versions of `golangci-lint` and `flake8` to their latest versions. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L15-R15) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L27-R27)
* Various YAML files (`examples/nvme/storageclass.yaml`, `test/external/drivers/lvm_storageclass.yaml`, etc.): Removed the `localdisk.csi.acstor.io/vg` parameter from storage class definitions.

### Test suite simplifications:

* [`test/sanity/id.go`](diffhunk://#diff-a755dde6a24370926b85107a6167f356abbddeda5ee65965e54979b16c8952e5R13-R35): Simplified the `LvmIDGenerator` by removing the ability to specify a custom volume group name. It now uses the default volume group directly.
* [`test/sanity/sanity_test.go`](diffhunk://#diff-0426edb781a00c7e1615f8d45f69d0404173f4401334d872a7fde05d6669c3eaL32-L33): Removed test volume parameters related to volume group customization and updated the ID generator initialization. [[1]](diffhunk://#diff-0426edb781a00c7e1615f8d45f69d0404173f4401334d872a7fde05d6669c3eaL32-L33) [[2]](diffhunk://#diff-0426edb781a00c7e1615f8d45f69d0404173f4401334d872a7fde05d6669c3eaL136-L146)… parameter