### PR TITLE
chore: add event when provisioning a new empty volume during mount

### DIFF
--- a/internal/csi/core/lvm/controller.go
+++ b/internal/csi/core/lvm/controller.go
@@ -84,7 +84,7 @@ func (l *LVM) Create(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.Vo
 	}
 
 	// Check for existing volume on the node.
-	if err := l.EnsureVolume(ctx, id.String(), capacity, limit); err != nil {
+	if err := l.EnsureVolume(ctx, id.String(), capacity, limit, false); err != nil {
 		log.Error(err, "failed to ensure volume", "name", id.String())
 		span.SetStatus(codes.Error, "failed to ensure volume")
 		span.RecordError(err)

--- a/internal/csi/core/lvm/lvm_test.go
+++ b/internal/csi/core/lvm/lvm_test.go
@@ -604,7 +604,7 @@ func TestEnsureVolume(t *testing.T) {
 			if tt.expectProbe != nil {
 				tt.expectProbe(p)
 			}
-			err = l.EnsureVolume(context.Background(), tt.volumeId, tt.request, tt.limit)
+			err = l.EnsureVolume(context.Background(), tt.volumeId, tt.request, tt.limit, true)
 			if !errors.Is(err, tt.expectedErr) {
 				t.Errorf("EnsureVolume() error = %v, expectErr %v", err, tt.expectedErr)
 			}

--- a/internal/csi/core/lvm/node.go
+++ b/internal/csi/core/lvm/node.go
@@ -126,5 +126,5 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 // NodeEnsureVolume ensures that the volume exists on the node.
 // It will create the volume if it does not exist.
 func (l *LVM) NodeEnsureVolume(ctx context.Context, volumeId string, capacity int64, limit int64) error {
-	return l.EnsureVolume(ctx, volumeId, capacity, limit)
+	return l.EnsureVolume(ctx, volumeId, capacity, limit, true)
 }


### PR DESCRIPTION
This pull request introduces changes to the `EnsureVolume` method in the LVM package to support a new `isMountOperation` parameter, which enables the system to differentiate between regular volume creation and mount-specific operations. Additionally, a new event type `provisionedEmptyVolume` has been added for logging purposes, and corresponding updates have been made to the test suite and related method calls.

### Enhancements to `EnsureVolume` method:

* [`internal/csi/core/lvm/lvm.go`](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL376-R377): Updated the `EnsureVolume` method to include a new `isMountOperation` boolean parameter. This allows the method to log a specific event (`provisionedEmptyVolume`) when a volume is created during a mount operation. [[1]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL376-R377) [[2]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afR485-R487)

### New event type:

* [`internal/csi/core/lvm/lvm.go`](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afR68): Added a new constant `provisionedEmptyVolume` to represent the event when an empty volume is created during a mount operation.

### Method updates for `EnsureVolume` parameter:

* [`internal/csi/core/lvm/controller.go`](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L87-R87): Modified the `Create` method to pass `false` for the new `isMountOperation` parameter when calling `EnsureVolume`.
* [`internal/csi/core/lvm/node.go`](diffhunk://#diff-98650537312e0815eb596ee43ba6b6c9f1dba7ad1ade7d442b9da5f947490e4bL129-R129): Updated the `NodeEnsureVolume` method to pass `true` for the `isMountOperation` parameter when invoking `EnsureVolume`.

### Test updates:

* [`internal/csi/core/lvm/lvm_test.go`](diffhunk://#diff-4c6592132c9ffe4d7605f48529cf585d714459a6a3f6b9a3873f97d7f1922c1cL607-R607): Adjusted the `TestEnsureVolume` test case to account for the new `isMountOperation` parameter, passing `true` where applicable.