### PR TITLE
build: update go version to 1.24.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module local-csi-driver
 
-go 1.24.4
+go 1.24.5
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
New version of Go was released.

https://devblogs.microsoft.com/go/go-1-24-5-1-and-1-23-11-1-microsoft-builds-now-available/

go1.24.5 (released 2025-07-08) includes security fixes to the go command, as well as bug fixes to the compiler, the linker, the runtime, and the go command. See the [Go 1.24.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.5+label%3ACherryPickApproved) on our issue tracker for details.


This pull request updates the Go module version in the `go.mod` file to ensure compatibility with the latest features and fixes.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.24.4` to `1.24.5` to leverage improvements and bug fixes in the newer version.
