### PR TITLE
fix: make pod owner of csistoragecapacity objects so they get cleaned…

### DIFF
--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -150,7 +150,7 @@ spec:
         - --feature-gates=Topology=true
         - --strict-topology=true
         - --enable-capacity
-        - --capacity-ownerref-level=1
+        - --capacity-ownerref-level=0
         - --capacity-poll-interval=15s
         - --v={{ .Values.observability.csiProvisioner.log.level }}
         env:


### PR DESCRIPTION
This pull request updates the `charts/latest/templates/daemonset.yaml` file to adjust the configuration of the CSI provisioner. The most significant change involves modifying the `--capacity-ownerref-level` parameter to align with updated requirements.

This causes csistoragecapacity objects to have the owner as the csi-local pod. When the pod is deleted, these will be cleaned up. Currently, the owner is the daemonset, so stale csistoragecapacity objects remain when node is deleted. 


Configuration updates:

* [`charts/latest/templates/daemonset.yaml`](diffhunk://#diff-fcc631e58f1d911bbb1909e7edef4d9a41a03bae29c7467d6ac83b83a062b6f0L153-R153): Changed the `--capacity-ownerref-level` parameter from `1` to `0` to reflect a new configuration standard or requirement.… up when node is deleted