### PR TITLE
fix: return actual PV size on allocation

### DIFF
--- a/internal/csi/core/lvm/controller_test.go
+++ b/internal/csi/core/lvm/controller_test.go
@@ -150,9 +150,9 @@ func TestLVM_Create(t *testing.T) {
 			},
 			want: &csi.Volume{
 				VolumeId:      "containerstorage#test-volume",
-				CapacityBytes: 1919999279104, // 1831054Mi
+				CapacityBytes: 1920001376256, // Rounded up to 4MiB boundary
 				VolumeContext: map[string]string{
-					"localdisk.csi.acstor.io/capacity": "1919999279104",
+					"localdisk.csi.acstor.io/capacity": "1920001376256",
 					"localdisk.csi.acstor.io/limit":    "0",
 				},
 				AccessibleTopology: []*csi.Topology{
@@ -218,6 +218,39 @@ func TestLVM_Create(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "lvm extent boundary allocation",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 1073741824 + 2097152, // 1 GiB + 2 MiB (not aligned to 4MiB boundary)
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Block{
+							Block: &csi.VolumeCapability_BlockVolume{},
+						},
+					},
+				},
+				Parameters: map[string]string{},
+			},
+			want: &csi.Volume{
+				VolumeId:      "containerstorage#test-volume",
+				CapacityBytes: 1077936128, // 1 GiB + 4 MiB (rounded up to next 4MiB boundary)
+				VolumeContext: map[string]string{
+					"localdisk.csi.acstor.io/capacity": "1077936128", // actual allocated size
+					"localdisk.csi.acstor.io/limit":    "0",
+				},
+				AccessibleTopology: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.localdisk.csi.acstor.io/node": "nodename",
+						},
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -383,10 +383,10 @@ func (l *LVM) EnsurePhysicalVolumes(ctx context.Context) ([]string, error) {
 // EnsureVolume ensures that the volume exists with the given name and size.
 // If the volume already exists, it returns it. Otherwise it creates the
 // volume and returns it.
-func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity *int64, limit int64, isMountOperation bool) error {
+func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity int64, limit int64, isMountOperation bool) (int64, error) {
 	ctx, span := l.tracer.Start(ctx, "volume.lvm.csi/EnsureVolume", trace.WithAttributes(
 		attribute.String("vol.id", volumeId),
-		attribute.Int64("vol.capacity", *capacity),
+		attribute.Int64("vol.capacity", capacity),
 		attribute.Int64("vol.limit", limit),
 	))
 	defer span.End()
@@ -399,7 +399,7 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity *int64
 	if err != nil {
 		log.Error(err, "failed to parse volume id", "volumeId", volumeId)
 		span.SetStatus(codes.Error, "failed to parse volume id")
-		return fmt.Errorf("%w: failed to parse volume id %s: %w", core.ErrInvalidArgument, volumeId, err)
+		return 0, fmt.Errorf("%w: failed to parse volume id %s: %w", core.ErrInvalidArgument, volumeId, err)
 	}
 
 	log = log.WithValues("vg", id.VolumeGroup, "lv", id.LogicalVolume)
@@ -407,32 +407,32 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity *int64
 	if id.VolumeGroup == "" {
 		log.Error(fmt.Errorf("volume group name is required"), "vg", id.VolumeGroup)
 		span.SetStatus(codes.Error, "volume group name is required")
-		return fmt.Errorf("%w: volume group name is required", core.ErrInvalidArgument)
+		return 0, fmt.Errorf("%w: volume group name is required", core.ErrInvalidArgument)
 	}
-	if *capacity <= 0 || limit < 0 || (limit > 0 && limit < *capacity) {
-		log.Error(fmt.Errorf("invalid capacity or limit"), "capacity", *capacity, "limit", limit)
+	if capacity <= 0 || limit < 0 || (limit > 0 && limit < capacity) {
+		log.Error(fmt.Errorf("invalid capacity or limit"), "capacity", capacity, "limit", limit)
 		span.SetStatus(codes.Error, "invalid capacity or limit")
-		return fmt.Errorf("%w: invalid capacity %d or limit %d", core.ErrInvalidArgument, capacity, limit)
+		return 0, fmt.Errorf("%w: invalid capacity %d or limit %d", core.ErrInvalidArgument, capacity, limit)
 	}
 
 	// Check for existing volume on the node.
 	lv, err := l.lvm.GetLogicalVolume(ctx, id.VolumeGroup, id.LogicalVolume)
 	if lvm.IgnoreNotFound(err) != nil {
 		log.Error(err, "failed to check if volume exists")
-		return err
+		return 0, err
 	}
 	if err == nil && lv != nil {
 		log.V(2).Info("found existing volume", "bytes", lv.Size)
 		span.AddEvent("found existing volume", trace.WithAttributes(attribute.Int64("bytes", int64(lv.Size))))
 
 		// Check volume size.
-		if int64(lv.Size) < *capacity || (limit > 0 && int64(lv.Size) > limit) {
-			log.Error(err, "volume size mismatch", "request", *capacity, "limit", limit, "actual", lv.Size)
+		if int64(lv.Size) < capacity || (limit > 0 && int64(lv.Size) > limit) {
+			log.Error(err, "volume size mismatch", "request", capacity, "limit", limit, "actual", lv.Size)
 			span.SetStatus(codes.Error, "volume size mismatch")
 			recorder.Eventf(corev1.EventTypeWarning, provisionedLogicalVolumeSizeMismatch, "Volume size mismatch %s/%s: request %d, limit %d, actual %d", id.VolumeGroup, id.LogicalVolume, capacity, limit, lv.Size)
-			return fmt.Errorf("volume size mismatch: request %d, limit %d, actual %d: %w", capacity, limit, lv.Size, core.ErrVolumeSizeMismatch)
+			return 0, fmt.Errorf("volume size mismatch: request %d, limit %d, actual %d: %w", capacity, limit, lv.Size, core.ErrVolumeSizeMismatch)
 		}
-		return nil
+		return 0, nil
 	}
 
 	recorder.Eventf(corev1.EventTypeNormal, provisioningLogicalVolume, "Provisioning logical volume %s/%s", id.VolumeGroup, id.LogicalVolume)
@@ -444,7 +444,7 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity *int64
 		span.SetStatus(codes.Error, "failed to check if volume group exists")
 		span.RecordError(err)
 		recorder.Eventf(corev1.EventTypeWarning, provisioningLogicalVolumeFailed, "Failed to check if volume group exists for %s/%s: %s", id.VolumeGroup, id.LogicalVolume, err.Error())
-		return fmt.Errorf("failed to check if volume group exists: %w", err)
+		return 0, fmt.Errorf("failed to check if volume group exists: %w", err)
 	}
 	if vg == nil {
 		log.V(2).Info("no existing volume group found, creating new one")
@@ -454,21 +454,21 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity *int64
 			span.SetStatus(codes.Error, "failed to ensure physical volumes")
 			span.RecordError(err)
 			recorder.Eventf(corev1.EventTypeWarning, provisioningLogicalVolumeFailed, "Failed to ensure physical volumes created for %s/%s: %s", id.VolumeGroup, id.LogicalVolume, err.Error())
-			return err
+			return 0, err
 		}
 		if vg, err = l.EnsureVolumeGroup(ctx, id.VolumeGroup, devices); err != nil {
 			log.Error(err, "failed to ensure volume group")
 			span.SetStatus(codes.Error, "failed to ensure volume group")
 			span.RecordError(err)
 			recorder.Eventf(corev1.EventTypeWarning, provisioningLogicalVolumeFailed, "Failed to ensure volume group created for %s/%s: %s", id.VolumeGroup, id.LogicalVolume, err.Error())
-			return err
+			return 0, err
 		}
 	}
 	// Provision the logical volume on the node.
 	createOps := lvm.CreateLVOptions{
 		Name:   id.LogicalVolume,
 		VGName: vg.Name,
-		Size:   fmt.Sprintf("%dB", *capacity),
+		Size:   fmt.Sprintf("%dB", capacity),
 	}
 
 	// if we have more than one PV, create a raid0 volume. Otherwise, create a
@@ -478,30 +478,29 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity *int64
 		createOps.Stripes = ptr.Of(int(vg.PVCount))
 	}
 
-	allocated_size, err := l.lvm.CreateLogicalVolume(ctx, createOps)
+	allocatedSize, err := l.lvm.CreateLogicalVolume(ctx, createOps)
 	if err != nil {
-		log.Error(err, "failed to create logical volume", "capacity", *capacity)
+		log.Error(err, "failed to create logical volume", "capacity", capacity)
 		span.SetStatus(codes.Error, "failed to create logical volume")
 		span.RecordError(err)
 		recorder.Eventf(corev1.EventTypeWarning, provisioningLogicalVolumeFailed, "Provisioning logical volume %s/%s failed: %s", id.VolumeGroup, id.LogicalVolume, err)
 		if errors.Is(err, lvm.ErrResourceExhausted) {
-			return fmt.Errorf("failed to create logical volume: %w", core.ErrResourceExhausted)
+			return 0, fmt.Errorf("failed to create logical volume: %w", core.ErrResourceExhausted)
 		}
-		return fmt.Errorf("failed to create logical volume: %w", err)
+		return 0, fmt.Errorf("failed to create logical volume: %w", err)
 	}
 
-	if allocated_size > *capacity {
-		log.V(1).Info("allocated logical volume size is larger than requested", "allocated", allocated_size, "requested", capacity)
+	if allocatedSize > capacity {
+		log.V(1).Info("allocated logical volume size is larger than requested", "allocated", allocatedSize, "requested", capacity)
 	}
-	*capacity = allocated_size
 
-	log.V(1).Info("created logical volume", "capacity", capacity)
-	span.AddEvent("created logical volume", trace.WithAttributes(attribute.Int64("capacity", *capacity)))
+	log.V(1).Info("created logical volume", "capacity", allocatedSize)
+	span.AddEvent("created logical volume", trace.WithAttributes(attribute.Int64("capacity", allocatedSize)))
 	recorder.Eventf(corev1.EventTypeNormal, provisionedLogicalVolume, "Successfully provisioned logical volume %s/%s", id.VolumeGroup, id.LogicalVolume)
 	if isMountOperation {
 		recorder.Eventf(corev1.EventTypeNormal, provisionedEmptyVolume, "A new empty volume was created during mount because the logical volume %s/%s was not found on the node. This may indicate the volume was not previously provisioned on this node.", id.VolumeGroup, id.LogicalVolume)
 	}
-	return nil
+	return allocatedSize, nil
 }
 
 // GetNodeDevicePath returns the device path for the given volume ID.

--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -425,14 +425,15 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity int64,
 		log.V(2).Info("found existing volume", "bytes", lv.Size)
 		span.AddEvent("found existing volume", trace.WithAttributes(attribute.Int64("bytes", int64(lv.Size))))
 
+		lvSize := int64(lv.Size)
 		// Check volume size.
-		if int64(lv.Size) < capacity || (limit > 0 && int64(lv.Size) > limit) {
+		if lvSize < capacity || (limit > 0 && lvSize > limit) {
 			log.Error(err, "volume size mismatch", "request", capacity, "limit", limit, "actual", lv.Size)
 			span.SetStatus(codes.Error, "volume size mismatch")
 			recorder.Eventf(corev1.EventTypeWarning, provisionedLogicalVolumeSizeMismatch, "Volume size mismatch %s/%s: request %d, limit %d, actual %d", id.VolumeGroup, id.LogicalVolume, capacity, limit, lv.Size)
 			return 0, fmt.Errorf("volume size mismatch: request %d, limit %d, actual %d: %w", capacity, limit, lv.Size, core.ErrVolumeSizeMismatch)
 		}
-		return 0, nil
+		return lvSize, nil
 	}
 
 	recorder.Eventf(corev1.EventTypeNormal, provisioningLogicalVolume, "Provisioning logical volume %s/%s", id.VolumeGroup, id.LogicalVolume)

--- a/internal/csi/core/lvm/lvm_test.go
+++ b/internal/csi/core/lvm/lvm_test.go
@@ -566,7 +566,7 @@ func TestEnsureVolume(t *testing.T) {
 			expectLvm: func(m *lvmMgr.MockManager) {
 				m.EXPECT().GetLogicalVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(testVg, nil)
-				m.EXPECT().CreateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().CreateLogicalVolume(gomock.Any(), gomock.Any()).Return(convert.MiBToBytes(1024), nil)
 			},
 			expectedErr: nil,
 		},
@@ -588,7 +588,7 @@ func TestEnsureVolume(t *testing.T) {
 				}
 				m.EXPECT().GetLogicalVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(stripedVg, nil)
-				m.EXPECT().CreateLogicalVolume(gomock.Any(), createArgs).Return(nil)
+				m.EXPECT().CreateLogicalVolume(gomock.Any(), createArgs).Return(convert.MiBToBytes(1024), nil)
 			},
 			expectedErr: nil,
 		},
@@ -647,7 +647,7 @@ func TestEnsureVolume(t *testing.T) {
 			if tt.expectProbe != nil {
 				tt.expectProbe(p)
 			}
-			err = l.EnsureVolume(context.Background(), tt.volumeId, tt.request, tt.limit, true)
+			err = l.EnsureVolume(context.Background(), tt.volumeId, ptr.Of(tt.request), tt.limit, true)
 			if !errors.Is(err, tt.expectedErr) {
 				t.Errorf("EnsureVolume() error = %v, expectErr %v", err, tt.expectedErr)
 			}

--- a/internal/csi/core/lvm/lvm_test.go
+++ b/internal/csi/core/lvm/lvm_test.go
@@ -647,7 +647,7 @@ func TestEnsureVolume(t *testing.T) {
 			if tt.expectProbe != nil {
 				tt.expectProbe(p)
 			}
-			err = l.EnsureVolume(context.Background(), tt.volumeId, ptr.Of(tt.request), tt.limit, true)
+			_, err = l.EnsureVolume(context.Background(), tt.volumeId, tt.request, tt.limit, true)
 			if !errors.Is(err, tt.expectedErr) {
 				t.Errorf("EnsureVolume() error = %v, expectErr %v", err, tt.expectedErr)
 			}

--- a/internal/csi/core/lvm/node.go
+++ b/internal/csi/core/lvm/node.go
@@ -126,5 +126,6 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 // NodeEnsureVolume ensures that the volume exists on the node.
 // It will create the volume if it does not exist.
 func (l *LVM) NodeEnsureVolume(ctx context.Context, volumeId string, capacity int64, limit int64) error {
-	return l.EnsureVolume(ctx, volumeId, &capacity, limit, true)
+	_, err := l.EnsureVolume(ctx, volumeId, capacity, limit, true)
+	return err
 }

--- a/internal/csi/core/lvm/node.go
+++ b/internal/csi/core/lvm/node.go
@@ -126,5 +126,5 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 // NodeEnsureVolume ensures that the volume exists on the node.
 // It will create the volume if it does not exist.
 func (l *LVM) NodeEnsureVolume(ctx context.Context, volumeId string, capacity int64, limit int64) error {
-	return l.EnsureVolume(ctx, volumeId, capacity, limit, true)
+	return l.EnsureVolume(ctx, volumeId, &capacity, limit, true)
 }

--- a/internal/pkg/lvm/lvm_test.go
+++ b/internal/pkg/lvm/lvm_test.go
@@ -280,7 +280,7 @@ func TestClient(t *testing.T) { //nolint:gocyclo
 
 		t.Log("Creating logical volume", lvName)
 
-		err = c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
+		_, err = c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
 			Name:     lvName,
 			VGName:   vgName,
 			Size:     "100M",
@@ -413,7 +413,7 @@ func TestClient(t *testing.T) { //nolint:gocyclo
 
 		// Create logical volume.
 		t.Log("Creating logical volume", lvName)
-		err = c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
+		_, err = c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
 			Name:     lvName,
 			VGName:   vgName,
 			Size:     "100M",

--- a/internal/pkg/lvm/manager.go
+++ b/internal/pkg/lvm/manager.go
@@ -23,7 +23,7 @@ const (
 // we can add it later. context is used to pass the context to the functions. It
 // is used to cancel the operation if required.
 //
-//go:generate mockgen -copyright_file ../../../hack/mockgen_copyright.txt  -source=manager.go -destination=mock.go -package=lvm .
+//go:generate mockgen -copyright_file ../../../hack/mockgen_copyright.txt -source=manager.go -destination=mock.go -package=lvm
 type Manager interface {
 	// IsSupported returns true if LVM is supported on the current node.
 	IsSupported() bool
@@ -44,7 +44,7 @@ type Manager interface {
 	// RemoveVolumeGroup removes a VG.
 	RemoveVolumeGroup(ctx context.Context, opts RemoveVGOptions) error
 	// CreateLogicalVolume creates an LV on a VG.
-	CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) error
+	CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) (int64, error)
 	// RemoveLogicalVolume removes a LV from a VG
 	RemoveLogicalVolume(ctx context.Context, opts RemoveLVOptions) error
 	// ListLogicalVolumes lists the specified LVs.

--- a/internal/pkg/lvm/mock.go
+++ b/internal/pkg/lvm/mock.go
@@ -45,11 +45,12 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // CreateLogicalVolume mocks base method.
-func (m *MockManager) CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) error {
+func (m *MockManager) CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLogicalVolume", ctx, opts)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateLogicalVolume indicates an expected call of CreateLogicalVolume.

--- a/internal/pkg/lvm/unsupported.go
+++ b/internal/pkg/lvm/unsupported.go
@@ -30,8 +30,8 @@ func (l *Noop) IsSupported() bool {
 }
 
 // CreateLogicalVolume implements Manager.
-func (l *Noop) CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) error {
-	return ErrUnsupported
+func (l *Noop) CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) (int64, error) {
+	return 0, ErrUnsupported
 }
 
 // CreatePhysicalVolume implements Manager.


### PR DESCRIPTION
LVM always aligns the size of the LV to default 4MiB size boundary. If the requested size did not match to 4Mi, it's extended to match it. But the PV size returned still showed the user requested size. This PR gets the actual size of the LV post its allocation and this is what is now returned.