### PR TITLE
fix: rotator should not cause restart after refreshing certs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -273,8 +273,9 @@ func main() {
 				fmt.Sprintf("%s.%s.svc.cluster.local", webhookSvcName, namespace),
 				fmt.Sprintf("%s.%s", webhookSvcName, namespace),
 			},
-			Webhooks: webhooks,
-			IsReady:  certSetupFinished,
+			Webhooks:             webhooks,
+			IsReady:              certSetupFinished,
+			EnableReadinessCheck: true,
 		}); err != nil {
 			logAndExit(err, "unable to set up cert rotation")
 		}


### PR DESCRIPTION
Fixes a benign issue during startup where the instance that creates the certs will restart. It doesn't cause any problems, but there is no reason it should restart.

This was caused by a race condition in the cert-controller library. The [fix](https://github.com/open-policy-agent/cert-controller/pull/342) is enabled by setting `EnableReadinessCheck=true`.