### PR TITLE
refactor: reduce log verbosity on blockdevice scanning code

### DIFF
--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -120,7 +120,7 @@ observability:
       port: 8091
   nodeDriverRegistrar:
     log:
-      level: 2
+      level: 1
     http:
       port: 8092
 

--- a/internal/pkg/probe/probe.go
+++ b/internal/pkg/probe/probe.go
@@ -45,7 +45,7 @@ func (m *deviceScanner) ScanAvailableDevices(ctx context.Context, log logr.Logge
 	var unformatted []block.Device
 	for _, device := range devices.Devices {
 		if !m.filter.Match(device) {
-			log.V(2).Info("device filtered out", "device", device)
+			log.V(3).Info("device filtered out", "device", device)
 			continue
 		}
 		isFormatted, err := m.IsFormatted(device.Path)
@@ -53,11 +53,11 @@ func (m *deviceScanner) ScanAvailableDevices(ctx context.Context, log logr.Logge
 			return nil, fmt.Errorf("failed to check if device is unformatted: %w", err)
 		}
 		if !isFormatted {
-			log.V(2).Info("unformatted device found", "device", device)
+			log.V(3).Info("unformatted device found", "device", device)
 			unformatted = append(unformatted, device)
 			continue
 		}
-		log.V(2).Info("device is formatted, skipping", "device", device)
+		log.V(3).Info("device is formatted, skipping", "device", device)
 	}
 
 	if len(unformatted) == 0 {


### PR DESCRIPTION
GetCapacity calls get called periodically, which prints a lot of logs every time even when driver is not doing anything. I reduce logs for this and set their log level to 3. I also reduce node driver registrar to 1

This pull request includes changes to adjust logging levels across different components of the codebase. The updates primarily focus on reducing verbosity in certain areas.

### Adjustments to logging levels:

* [`charts/latest/values.yaml`](diffhunk://#diff-d29b314008db700bde7facdb68fc5dcd58008824558728002e8d9b436fb0fc04L123-R123): Changed the logging level for `nodeDriverRegistrar` from `2` to `1` to reduce verbosity in logs.
* [`internal/pkg/probe/probe.go`](diffhunk://#diff-ec2634d477ebbff447037ba26b615307de8775ed568ec6539037cd0a0c4867c7L48-R60): Increased the logging level for device scanning operations from `2` to `3` to provide less detailed information about filtered, unformatted, and formatted devices.