### PR TITLE
ci: add markdown link check automation

### DIFF
--- a/.markdown-links-config.json
+++ b/.markdown-links-config.json
@@ -1,0 +1,17 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^.*@microsoft\\.com"
+    },
+    {
+      "pattern": ".*127\\.0\\.0\\.1.*"
+    },
+    {
+    }
+  ],
+  "aliveStatusCodes": [200, 206],
+  "retryOn429": true,
+  "timeout": "20s",
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s"
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
   rev: v1.7.7
   hooks:
   - id: actionlint-docker
+- repo: https://github.com/tcort/markdown-link-check
+  rev: v3.12.2 # Use older version as current version has 0 exit code for broken links
+  hooks:
+    - id: markdown-link-check
+      args: [--verbose, --config, .markdown-links-config.json]
 - repo: local
   hooks:
   - id: bicep-lint

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The local-csi-driver provides access to local NVMe disks on Kubernetes clusters.
 ## Getting Started
 
 For details on how to get started with the local-csi-driver, see the [User
-Guide](./docs/user-guide.md) or [Helm Chart](./chart/latest/README.md).
+Guide](./docs/user-guide.md) or [Helm Chart](./charts/latest/README.md).
 
 ## Development
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,7 +129,7 @@ make aks
 ```
 
 For more details on the bicep template and available parameters, refer to the
-[aks/README.md](./deploy/README.md) file.
+[deploy/README.md](../deploy/README.md) file.
 
 ### To Deploy
 
@@ -171,8 +171,7 @@ Generally, if something can be tested with a unit test, it should be. If
 something is too complex to test with a unit test, it should be tested with an
 E2E test. The sanity and external E2E tests are conformance tests provided by
 the Kubernetes community to test CSI drivers. For more details on the tests,
-refer to the [test/README.md](./test/README.md) file. Unit tests can be found in
-the [test/README.md](./test/README.md) file. Unit tests can be found throughout
+refer to the [test/README.md](../test/README.md) file. Unit tests can be found throughout
 the project, but other tests are located in the `test` directory.
 
 ### Unit tests

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -31,7 +31,7 @@ below:
 Only one instance of local-csi-driver can be installed per cluster.
 
 Helm chart values are documented in: [Helm chart
-README](./charts/latest/README.md).
+README](../charts/latest/README.md).
 
 ## Creating a StorageClass
 

--- a/internal/pkg/lvm/README.md
+++ b/internal/pkg/lvm/README.md
@@ -15,4 +15,4 @@ changes.
 
 ## Usage
 
-For detailed examples see the [lvm_test.go](./lvm2_test.go) file.
+For detailed examples see the [lvm_test.go](./lvm_test.go) file.

--- a/test/README.md
+++ b/test/README.md
@@ -107,7 +107,7 @@ REGISTRY=<registry>.azurecr.io make docker-build helm-build docker-push helm-pus
 ```
 
 For more information on how to set up the AKS cluster, see the deployment
-instructions in the deployment [README](../deployment/README.md).
+instructions in the deployment [README](../deploy/README.md).
 
 ### External E2E Tests
 


### PR DESCRIPTION
This pull request introduces a configuration for checking markdown links and integrates it into the pre-commit hooks. The changes aim to ensure that markdown links are validated effectively during the development workflow.

### Markdown link validation setup:

* [`.markdown-links-config.json`](diffhunk://#diff-46ca0e8d1336f545bf928ef8c5ba5f15c5e9edf0a18c5be750bafbcc3a268180R1-R11): Added a configuration file specifying status codes for "alive" links, a timeout value, retry count, and a fallback retry delay to customize the behavior of the markdown link checker.

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R40-R44): Integrated the `markdown-link-check` tool into the pre-commit hooks, using version `v3.12.2` and referencing the new configuration file for link validation.

### Fixes

I fixed several incorrect markdown lints thanks to automation detection them