### PR TITLE
fix: prometheus exporter should not publish target_info metric

### DIFF
--- a/internal/pkg/telemetry/otel.go
+++ b/internal/pkg/telemetry/otel.go
@@ -114,7 +114,7 @@ func InitMetrics(ctx context.Context, cfg config) (*metric.MeterProvider, error)
 		}
 		opts = append(opts, metric.WithReader(metric.NewPeriodicReader(exp, metric.WithProducer(bridge))))
 	case cfg.exporters[Prometheus]:
-		exp, err := prometheus.New(prometheus.WithRegisterer(cfg.prometheus))
+		exp, err := prometheus.New(prometheus.WithRegisterer(cfg.prometheus), prometheus.WithoutTargetInfo())
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize Prometheus exporter: %w", err)
 		}


### PR DESCRIPTION
When exposing open telemetry metrics, there is a target_info metric that has resource attributes that can be exposed. The best way to do it would be not expose target_info but rather add all resource attributes to the actual exported metrics as labels so anything downstream doesn't have to do much.

This PR disables target_info.

Ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1