### PR TITLE
build(go): update go to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module local-csi-driver
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
https://devblogs.microsoft.com/go/go-1-24-6-1-and-1-23-12-1-microsoft-builds-now-available/

https://github.com/microsoft/go/releases/tag/v1.24.6-1

Release notes: https://go.dev/doc/devel/release#go1.24.6
go1.24.6 (released 2025-08-06) includes security fixes to the database/sql and os/exec packages, as well as bug fixes to the runtime. See the [Go 1.24.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.6+label%3ACherryPickApproved) on our issue tracker for details.