### PR TITLE
build: remove fips images reference and use go1.25

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.24",
+  "image": "golang:1.25",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {},

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -12,7 +12,7 @@ repos:
   - id: check-xml
   - id: check-json
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.3.1
+  rev: v2.4.0
   hooks:
   - id: golangci-lint-full
 - repo: https://github.com/hadolint/hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25-fips-azurelinux3.0@sha256:5b3f5ded6135fd6f0a0a4f4db3be906e5ae816793d9159fe4ca9f5d0c9f0e0bb AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0@sha256:f7845f6cfc283c2a76de39192dfcb1748034aad65458b17ac2152c0726dc51d6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LDFLAGS += -X local-csi-driver/internal/pkg/version.gitCommit=$(COMMIT_HASH)
 LDFLAGS += -X local-csi-driver/internal/pkg/version.buildDate=$(BUILD_DATE)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.33.0
 
 TEST_OUTPUT ?= $(shell pwd)/test.xml
 TEST_COVER ?= $(shell pwd)/coverage.out
@@ -98,14 +98,12 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: envtest go-junit-report gocov gocov-xml ## Run tests and generate coverage report
+test: envtest go-junit-report  ## Run tests and generate coverage report
 	$(eval TMP := $(shell mktemp -d))
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 		go test -race -v -p 8 $$(go list ./... | grep -v -e /test/) -coverprofile $(TMP)/cover.out 2>&1 | \
 		$(GO_JUNIT_REPORT) -set-exit-code -iocopy -out $(TEST_OUTPUT)
-	@cat $(TMP)/cover.out | grep -v -E -f .covignore > $(TMP)/cover.clean
-	@$(GOCOV) convert $(TMP)/cover.clean | $(GOCOV_XML) > $(TEST_COVER)
-	@rm $(TMP)/cover.out $(TMP)/cover.clean && rmdir $(TMP)
+	@cat $(TMP)/cover.out | grep -v -E -f .covignore > $(TEST_COVER)
 
 
 # The default setup assumes Kind is pre-installed and builds/loads the Docker
@@ -416,8 +414,6 @@ KIND ?= $(LOCALBIN)/kind
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GO_JUNIT_REPORT ?= $(LOCALBIN)/go-junit-report
 GINKGO ?= $(LOCALBIN)/ginkgo
-GOCOV ?= $(LOCALBIN)/gocov
-GOCOV_XML ?= $(LOCALBIN)/gocov-xml
 HADOLINT ?= $(LOCALBIN)/hadolint
 CONTAINER_STRUCTURE_TEST ?= $(LOCALBIN)/container-structure-test
 SUPPORT_BUNDLE ?= $(LOCALBIN)/support-bundle
@@ -425,23 +421,21 @@ BICEP ?= $(LOCALBIN)/bicep
 HELM ?= $(LOCALBIN)/helm
 
 ## Tool Versions
-GOMOCK_VERSION ?= v0.5.2
-ENVTEST_VERSION ?= release-0.19
-KIND_VERSION ?= v0.25.0
-GOLANGCI_LINT_VERSION ?= v2.1.6
+GOMOCK_VERSION ?= v0.6.0
+ENVTEST_VERSION ?= release-0.21
+KIND_VERSION ?= v0.29.0
+GOLANGCI_LINT_VERSION ?= v2.4.0
 GO_JUNIT_REPORT_VERSION ?= v2.1.0
 PROMETHEUS_VERSION ?= v0.77.1
 JAEGER_VERSION ?= v1.62.0
 GINKGO_VERSION ?= v2.25.0
-GOCOV_VERSION ?= v1.2.1
-GOCOV_XML_VERSION ?= v1.1.0
 HADOLINT_VERSION ?= v2.12.0
 CONTAINER_STRUCTURE_TEST_VERSION ?= v1.19.3
-GIT_SEMVER_VERSION ?= v6.9.0
-SUPPORT_BUNDLE_VERSION ?= v0.114.0
-BICEP_VERSION ?= v0.32.4
-HELM_VERSION ?= v3.16.4
-MARKDOWNLINT_CLI_VERSION ?= v0.44.0
+GIT_SEMVER_VERSION ?= v6.11.0
+SUPPORT_BUNDLE_VERSION ?= v0.121.2
+BICEP_VERSION ?= v0.37.4
+HELM_VERSION ?= v3.18.6
+MARKDOWNLINT_CLI_VERSION ?= v0.45.0
 
 .PHONY: mockgen
 mockgen: $(MOCK_GEN) ## Installs mockgen locally if necessary.
@@ -469,16 +463,6 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 go-junit-report: $(GO_JUNIT_REPORT) ## Download go-junit-report locally if necessary.
 $(GO_JUNIT_REPORT): $(LOCALBIN)
 	$(call go-install-tool,$(GO_JUNIT_REPORT),github.com/jstemmer/go-junit-report/v2,$(GO_JUNIT_REPORT_VERSION))
-
-.PHONY: gocov
-gocov: $(GOCOV) ## Download gocov locally if necessary.
-$(GOCOV): $(LOCALBIN)
-	$(call go-install-tool,$(GOCOV),github.com/axw/gocov/gocov,$(GOCOV_VERSION))
-
-.PHONY: gocov-xml
-gocov-xml: $(GOCOV_XML) ## Download gocov-xml locally if necessary.
-$(GOCOV_XML): $(LOCALBIN)
-	$(call go-install-tool,$(GOCOV_XML),github.com/AlekSi/gocov-xml,$(GOCOV_XML_VERSION))
 
 ##@ Utilities
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module local-csi-driver
 
-go 1.24.6
+go 1.25.0
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
The -fips variant Docker container images are no longer supported

The change to enable system-provided cryptography by default applies to all Docker container images for the Microsoft build of Go. The -fips image variants only set the GOEXPERIMENT environment to systemcrypto, so there is no longer any reason to use them. These variants are no longer produced.

`gocov` and `gocov-xml` aren't being updated any longer. We don't use those in this repo, anyway. 

AI Summary: 

This pull request primarily updates the development environment and build tooling to use newer versions and simplifies the test coverage reporting process. The most significant changes include upgrading the Go version to 1.25, updating several tool versions, and removing unused coverage tools from the build process.

**Development environment and dependency updates:**

* Updated the Go version to 1.25 in `.devcontainer/devcontainer.json`, `Dockerfile`, and `go.mod` to ensure consistency across development and build environments. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3)
* Upgraded pre-commit hooks and linting tools to newer versions in `.pre-commit-config.yaml` for improved code quality and compatibility. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R3) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L15-R15)

**Build and test process improvements:**

* Updated various tool versions in `Makefile`, including `gomock`, `envtest`, `kind`, `golangci-lint`, and others, to keep the toolchain current.
* Removed `gocov` and `gocov-xml` dependencies and related targets from the `Makefile`, simplifying the test coverage reporting process. Coverage output is now written directly to the coverage file. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L101-R106) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L419-R438) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L473-L482)
* Bumped the `ENVTEST_K8S_VERSION` used for testing from 1.31.0 to 1.33.0 in the `Makefile` for improved test compatibility.