### PR TITLE
feat: add RAID support for NVMe device consolidation

### DIFF
--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -56,6 +56,8 @@ spec:
         - --trace-service-id=$(POD_NAME)
         - --v={{ .Values.observability.driver.log.level }}
         - --enable-cleanup={{ .Values.cleanup.enabled }}
+        - --enable-raid={{ .Values.raid.enabled }}
+        - --raid-volume-group={{ .Values.raid.volumeGroup }}
         {{- if or .Values.webhook.enforceEphemeral.enabled .Values.webhook.hyperconverged.enabled }}
         - --webhook-service-name={{ .Values.name }}-webhook-service
         {{- end }}

--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -46,6 +46,13 @@ cleanup:
   # Cleanup volume groups and physical volumes on pod termination if logical volume are not in use.
   enabled: true
 
+# RAID configuration for consolidating multiple NVMe devices.
+raid:
+  # Enable RAID consolidation of multiple NVMe devices into a single volume group.
+  enabled: true
+  # Name of the volume group to use when consolidating multiple NVMe devices with RAID.
+  volumeGroup: nvme-raid
+
 # Webhook configuration.
 webhook:
   enforceEphemeral:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,6 +89,8 @@ func main() {
 	var printVersionAndExit bool
 	var eventRecorderEnabled bool
 	var enableCleanup bool
+	var enableRaid bool
+	var raidVolumeGroup string
 	flag.StringVar(&nodeName, "node-name", "",
 		"The name of the node this agent is running on.")
 	flag.StringVar(&podName, "pod-name", "",
@@ -131,6 +133,8 @@ func main() {
 	flag.BoolVar(&eventRecorderEnabled, "event-recorder-enabled", true,
 		"If enabled, the driver will use the event recorder to record events. This is useful for debugging and monitoring purposes.")
 	flag.BoolVar(&enableCleanup, "enable-cleanup", true, "If enabled, the driver will clean up the LVM volume groups and persistent volumes when not in use")
+	flag.BoolVar(&enableRaid, "enable-raid", true, "If enabled, the driver will consolidate multiple NVMe devices into a single RAID0 volume group")
+	flag.StringVar(&raidVolumeGroup, "raid-volume-group", "nvme-raid", "The name of the volume group to use when consolidating multiple NVMe devices with RAID")
 
 	// Initialize logger flagsconfig.
 	logConfig := textlogger.NewConfig(textlogger.VerbosityFlagName("v"))
@@ -308,7 +312,7 @@ func main() {
 	//
 	// Volume client is an abstraction that understands csi requests and
 	// responses and how to implement them for a storage type.
-	volumeClient, err := lvm.New(podName, nodeName, namespace, enableCleanup, deviceProbe, lvmMgr, tp)
+	volumeClient, err := lvm.New(podName, nodeName, namespace, enableCleanup, deviceProbe, lvmMgr, tp, enableRaid, raidVolumeGroup)
 	if err != nil {
 		logAndExit(err, "unable to create lvm volume client")
 	}

--- a/internal/csi/core/lvm/controller_test.go
+++ b/internal/csi/core/lvm/controller_test.go
@@ -295,7 +295,7 @@ func TestLVM_Create(t *testing.T) {
 			p := probe.NewFake([]string{"device1", "device2"}, nil)
 			lvmMgr := lvmMgr.NewFake()
 
-			l, err := lvm.New("podname", "nodename", "default", true, p, lvmMgr, tp)
+			l, err := lvm.New("podname", "nodename", "default", true, p, lvmMgr, tp, false, "nvme-raid")
 			if err != nil {
 				t.Fatalf("failed to create LVM instance: %v", err)
 			}


### PR DESCRIPTION
Fix #207 

This pull request introduces support for consolidating multiple NVMe devices into a single RAID volume group, making it easier to manage high-performance storage pools. The changes add new configuration options for RAID in the Helm chart, propagate these settings through the codebase, and update the LVM logic to use a consolidated volume group when RAID is enabled. Comprehensive tests have also been added to ensure correct behavior in both RAID and non-RAID scenarios.

**RAID configuration support:**

* Added `raid.enabled` and `raid.volumeGroup` options to `charts/latest/values.yaml` and corresponding flags in `charts/latest/templates/daemonset.yaml`, allowing users to enable RAID and specify the volume group name via Helm values. [[1]](diffhunk://#diff-d29b314008db700bde7facdb68fc5dcd58008824558728002e8d9b436fb0fc04R49-R55) [[2]](diffhunk://#diff-fcc631e58f1d911bbb1909e7edef4d9a41a03bae29c7467d6ac83b83a062b6f0R59-R60)
* Extended CLI flags in `cmd/main.go` to accept `--enable-raid` and `--raid-volume-group`, and updated the instantiation of the LVM client to pass these new parameters. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R92-R93) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R136-R137) [[3]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L311-R315)

**LVM logic enhancements:**

* Updated the `LVM` struct and constructor in `internal/csi/core/lvm/lvm.go` to include RAID configuration, defaulting the volume group name if not provided. [[1]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afR40-R42) [[2]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afR161-R169) [[3]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afR179-R188)
* Modified the `EnsureVolume` method to use the RAID volume group for all LVM operations when RAID is enabled, ensuring correct provisioning and cleanup behavior. [[1]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afR438-R454) [[2]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL446-R480) [[3]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL485-R528) [[4]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL533-R551) [[5]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL546-R566)

**Testing improvements:**

* Updated unit tests and test helpers to include RAID configuration parameters and added a comprehensive table-driven test suite for RAID scenarios in `internal/csi/core/lvm/lvm_test.go`. [[1]](diffhunk://#diff-5060a8629f8bb63873dee9181ae9568fa1ab4fdcd4bbc7596e9ef1d14089cc19L298-R298) [[2]](diffhunk://#diff-4c6592132c9ffe4d7605f48529cf585d714459a6a3f6b9a3873f97d7f1922c1cL39-R39) [[3]](diffhunk://#diff-4c6592132c9ffe4d7605f48529cf585d714459a6a3f6b9a3873f97d7f1922c1cL104-R104) [[4]](diffhunk://#diff-4c6592132c9ffe4d7605f48529cf585d714459a6a3f6b9a3873f97d7f1922c1cR829-R961)