### PR TITLE
feat: add customizeable node-affinity

### DIFF
--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -23,19 +23,7 @@ spec:
         kubectl.kubernetes.io/default-container: driver
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - arm64
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
+        {{- include "chart.nodeAffinity" . | nindent 8 }}
       {{- if .Values.raid.enabled }}
       initContainers:
       - name: raid

--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -30,6 +30,11 @@ daemonset:
   # be used to install the driver on a subset of nodes with local NVMe storage.
   nodeSelector: {}
 
+  # Node affinity for the DaemonSet. If empty, no affinity rules are applied except those
+  # for OS and architecture. This can be used to install the driver on a subset of nodes
+  # with local NVMe storage.
+  nodeAffinity: {}
+
   # Tolerations for the DaemonSet. If empty, no tolerations are applied.
   # This can be used to install the driver on nodes with specific taints.
   tolerations:


### PR DESCRIPTION
This pull request enhances the Helm chart's node scheduling logic for the CSI driver DaemonSet. It introduces a new `nodeAffinity` configuration option, allowing users to specify custom node affinity rules while ensuring that mandatory OS and architecture constraints (Linux, amd64/arm64) are always enforced. The implementation centralizes this logic in a new Helm template helper for maintainability and flexibility.

Key changes:

**Node Affinity Configuration and Enforcement:**

* Added a `nodeAffinity` field to `daemonset` in `values.yaml`, enabling users to specify custom node affinity rules for the DaemonSet. If left empty, only the required OS and architecture constraints are applied.
* Introduced a new Helm helper template `chart.nodeAffinity` in `_helpers.tpl` that generates node affinity configuration. This helper always injects mandatory `kubernetes.io/os=linux` and `kubernetes.io/arch in (amd64, arm64)` constraints, merging them with any user-provided affinity.

**DaemonSet Template Refactoring:**

* Updated the DaemonSet manifest (`daemonset.yaml`) to use the new `chart.nodeAffinity` helper, ensuring consistent and configurable node affinity logic in the rendered Kubernetes resources.


