### PR TITLE
Adding daemonset to use local NVMe disks for containerd image cache

### DIFF
--- a/docs/samples/containerd_nvme_config.yaml
+++ b/docs/samples/containerd_nvme_config.yaml
@@ -52,6 +52,16 @@ spec:
               echo "Creating new RAID 0 array with NVMe disks..."
               mdadm --create /dev/md0 --level=0 --raid-devices=$(echo "$nvme_disks" | wc -l) $(echo "$nvme_disks" | sed 's/^/\/dev\//')
               
+              # Wait for array to be ready
+              echo "Waiting for RAID array to be ready..."
+              for i in {1..30}; do
+                if mdadm --detail /dev/md0 >/dev/null 2>&1; then
+                  echo "RAID array is ready"
+                  break
+                fi
+                sleep 2
+              done
+              
               # Save RAID configuration for auto-assembly on reboot
               mkdir -p /etc/mdadm
               mdadm --detail --scan >> /etc/mdadm/mdadm.conf


### PR DESCRIPTION
This pull request adds a new sample DaemonSet manifest for Kubernetes to automate the configuration of containerd to use NVMe-backed storage for image caching. The manifest is intended for clusters running on VM sizes with local NVMe disks and ensures optimal container image cache performance by assembling a RAID 0 array when multiple NVMe disks are present, updating containerd's configuration, and making the setup persistent across node restarts.

The most important changes include:

**NVMe-backed storage setup for containerd:**

* Added a DaemonSet (`containerd-nvme-config`) in `docs/samples/containerd_nvme_config.yaml` that runs a privileged Ubuntu container on nodes with NVMe disks to handle storage configuration.
* The DaemonSet script automatically detects available NVMe disks, assembles a RAID 0 array if more than one disk is present, formats and mounts the storage, and ensures the configuration persists via updates to `/etc/fstab`.

**Containerd configuration automation:**

* The setup script locates the containerd config file and updates its `root` directive to point to the NVMe-backed volume, ensuring container images are cached on fast local storage.

**Persistence and system integration:**

* Deploys a custom systemd unit (`setup-raid.service`) to automate RAID assembly and containerd configuration on node restarts