### PR TITLE
test: disable garbage collector for sanity test

### DIFF
--- a/test/pkg/common/common.go
+++ b/test/pkg/common/common.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Setup installs the CSI driver prerequisites and components.
-func Setup(ctx context.Context, namespace string) {
+func Setup(ctx context.Context, namespace string, helmArgs ...string) {
 	cmd := exec.CommandContext(ctx, "az", "--version")
 	output, err := utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred(), "Failed to get az cli version")
@@ -170,13 +170,17 @@ func Setup(ctx context.Context, namespace string) {
 
 	if useLocalHelmCharts {
 		By("installing csi driver with local helm charts")
-		cmd = exec.CommandContext(ctx, "make", "deploy", fmt.Sprintf("IMG=%s", image))
+		args := []string{"deploy", fmt.Sprintf("IMG=%s", image)}
+		args = append(args, helmArgs...)
+		cmd = exec.CommandContext(ctx, "make", args...)
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install csi driver with local helm charts")
 	} else {
 		By("installing csi driver with helm")
 		Eventually(func(g Gomega, ctx context.Context) {
-			cmd = exec.CommandContext(ctx, "make", "helm-install")
+			args := []string{"helm-install"}
+			args = append(args, helmArgs...)
+			cmd = exec.CommandContext(ctx, "make", args...)
 			_, err = utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred(), "Failed to install csi driver with helm")
 		}).WithTimeout(5*time.Minute).WithContext(ctx).Should(Succeed(), "Failed to install csi driver with helm")

--- a/test/sanity/sanity_suite_test.go
+++ b/test/sanity/sanity_suite_test.go
@@ -27,6 +27,11 @@ const (
 	namespace = "kube-system"
 	// controllerDs is the resource name used in kubectl commands for the node.
 	controllerDs = "daemonsets/csi-local-node"
+
+	// helmArgs is the environment variable used to pass extra arguments to
+	// helm during installation of the csi driver. We need to disable cleanup,
+	// PV garbage collection, and LVM orphan cleanup for the sanity tests.
+	helmArgs = "HELM_ARGS=--set cleanup.pvGarbageCollection.enabled=false --set cleanup.lvmOrphanCleanup.enabled=false"
 )
 
 var (
@@ -79,7 +84,7 @@ func TestCSISanity(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 	By("Installing csi driver and other required components")
-	common.Setup(ctx, namespace)
+	common.Setup(ctx, namespace, helmArgs)
 	DeferCleanup(func(ctx context.Context) {
 		common.Teardown(ctx, namespace)
 	})


### PR DESCRIPTION


* Updated the `Setup` function in `test/pkg/common/common.go` to accept a variadic `helmArgs` parameter, enabling custom Helm arguments to be passed during installation.
* Disabled orphan/garbarge collector for sanity tests since there is no PV created in these tests
