### PR TITLE
ci: trigger pull_request for branch and pull_request_target for fork

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,6 +7,8 @@ concurrency:
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main, release-**]
   pull_request_target:
     types: [labeled]
     branches: [main, release-**]
@@ -25,8 +27,19 @@ env:
   REPO_BASE: "acstor"
 
 jobs:
+  should-run:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    runs-on: ubuntu-latest
+    steps:
+      - name:
+        run: |
+          echo "Workflow will run!"
+
   vars:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    needs: [should-run]
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.set-tag.outputs.TAG }}
@@ -58,7 +71,6 @@ jobs:
           fi
           echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
   build-docker:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     needs: [vars]
     uses: ./.github/workflows/docker-build-template.yml
     with:
@@ -75,7 +87,6 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   build-helm:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     needs: [vars]
     uses: ./.github/workflows/helm-build-template.yml
     with:
@@ -91,7 +102,6 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   e2e-test:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     needs: [build-docker, build-helm, vars]
     runs-on: ubuntu-latest
     environment: pull-request


### PR DESCRIPTION
This pull request updates the `.github/workflows/test-e2e.yml` workflow to improve security and control over when end-to-end tests run, especially for pull requests from forks. The main change is the introduction of a dedicated `should-run` job that centralizes the logic for determining if the workflow should proceed, replacing repetitive `if` conditions in multiple jobs.

Workflow control and security improvements:

* Added a `should-run` job that checks the event type and pull request source, ensuring that workflows only run for trusted events (pushes, internal pull requests, or external pull requests with a `safe to test` label). This centralizes and simplifies the workflow's execution logic.
* Updated the workflow triggers to run on pull requests targeting `main` or `release-**` branches, in addition to pushes and `pull_request_target` events, improving coverage for different development flows.

Job dependency and condition changes:

* Modified the `vars`, `build-docker`, `build-helm`, and `e2e-test` jobs to depend on the outcome of the `should-run` job, removing their individual `if` conditions and ensuring consistency in when jobs are executed. [[1]](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becR30-R42) [[2]](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becL61) [[3]](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becL78) [[4]](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becL94)