### PR TITLE
chore: hotfix tags should trigger build & push

### DIFF
--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-preview.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-hotfix.[0-9]+'
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request makes a small update to the workflow trigger configuration in `.github/workflows/push-tag.yml`. The change adds support for triggering the workflow on tags that match the hotfix pattern.