### PR TITLE
fix: only log on orphan cleanup if action is happening, use 2 for driver

### DIFF
--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -200,14 +200,14 @@ observability:
     enabled: true
   manager:
     log:
-      level: 6
+      level: 2
     metrics:
       port: 8080
     health:
       port: 8081
   driver:
     log:
-      level: 6
+      level: 2
     metrics:
       port: 8080
     health:


### PR DESCRIPTION
I found that the orphan cleanup was logging for all of the reconciles. It is nice for it to only log when there is work to do. This will make sure it does not log while the driver is idle and not doing any work.

I also found the driver verbosity was bumped form 2 -> 6 accidentally. I just made it back to 2.