### PR TITLE
test: update support-bundle to collect logs and other diagnostic data properly

### DIFF
--- a/test/config/support-bundle.yaml
+++ b/test/config/support-bundle.yaml
@@ -13,9 +13,17 @@ spec:
         includeSecrets: false
         collectValues: true
     - logs:
-        name: logs
+        name: driver-logs
         selector:
-          - control-plane=local-csi-driver
+          - app.kubernetes.io/component=csi-local-node
+        namespace: kube-system
+        limits:
+          maxAge: 720h
+          maxLines: 10000
+    - logs:
+        name: manager-logs
+        selector:
+          - app.kubernetes.io/component=manager
         namespace: kube-system
         limits:
           maxAge: 720h
@@ -23,7 +31,7 @@ spec:
     - exec:
         collectorName: lsblk
         selector:
-          - control-plane=local-csi-driver
+          - app.kubernetes.io/component=csi-local-node
         namespace: kube-system
         command: ["/bin/sh", "-c"]
         args: ["lsblk --json --output-all"]
@@ -31,7 +39,7 @@ spec:
     - exec:
         collectorName: pvs
         selector:
-          - control-plane=local-csi-driver
+          - app.kubernetes.io/component=csi-local-node
         namespace: kube-system
         command: ["/bin/sh", "-c"]
         args: ["pvs --reportformat=json --binary --unit=B --options=pv_all,vg_name"]
@@ -39,7 +47,7 @@ spec:
     - exec:
         collectorName: vgs
         selector:
-          - control-plane=local-csi-driver
+          - app.kubernetes.io/component=csi-local-node
         namespace: kube-system
         command: ["/bin/sh", "-c"]
         args: ["vgs --reportformat=json --binary --unit=B --options=vg_all"]
@@ -47,7 +55,7 @@ spec:
     - exec:
         collectorName: lvs
         selector:
-          - control-plane=local-csi-driver
+          - app.kubernetes.io/component=csi-local-node
         namespace: kube-system
         command: ["/bin/sh", "-c"]
         args: ["lvs --reportformat=json --binary --unit=B --options=lv_all,seg_all,vg_name"]

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 })
 
 var _ = AfterSuite(func(ctx context.Context) {
-	common.Teardown(ctx, namespace)
+	common.Teardown(ctx, namespace, *supportBundleDir)
 })
 
 var _ = AfterEach(func(ctx context.Context) {

--- a/test/external/external_suite_test.go
+++ b/test/external/external_suite_test.go
@@ -66,7 +66,7 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 	By("Installing csi driver and other required components")
 	common.Setup(ctx, namespace)
 	DeferCleanup(func(ctx context.Context) {
-		common.Teardown(ctx, namespace)
+		common.Teardown(ctx, namespace, *supportBundleDir)
 	})
 
 	for _, testConfig := range testConfigs {

--- a/test/sanity/sanity_suite_test.go
+++ b/test/sanity/sanity_suite_test.go
@@ -86,7 +86,7 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 	By("Installing csi driver and other required components")
 	common.Setup(ctx, namespace, helmArgs)
 	DeferCleanup(func(ctx context.Context) {
-		common.Teardown(ctx, namespace)
+		common.Teardown(ctx, namespace, *supportBundleDir)
 	})
 
 	By("Applying socat patch to node and controller")


### PR DESCRIPTION
The selector for collecting logs in support bundle is incorrect - must have changed at some point. Pulled in some other changes for test to grab the suite-level support-bundle prior to test teardown. 


This fixes that issue by using the correct selectors. 