### PR TITLE
chore: bump README to v0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before proceeding, ensure you have the following installed:
 To install the latest release:
 
 ```sh
-helm install local-csi-driver oci://localcsidriver.azurecr.io/acstor/charts/local-csi-driver --version 0.2.8 --namespace kube-system
+helm install local-csi-driver oci://localcsidriver.azurecr.io/acstor/charts/local-csi-driver --version 0.2.9 --namespace kube-system
 ```
 
 Only one instance of local-csi-driver can run per cluster.


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file to use the latest release of the `local-csi-driver` Helm chart.

- Updated the Helm chart version in the installation command from `0.2.8` to `0.2.9` to reflect the latest release.