### PR TITLE
fix: update sanitization pattern to prevent invalid XML

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -206,7 +206,7 @@ jobs:
             if [[ -n "$secret_value" ]]; then
               for file in $FILES; do
                 if [[ -f "$file" ]]; then
-                  sed -i "s/${secret_value}/<REDACTED>/g" "$file" || true
+                  sed -i "s/${secret_value}/[REDACTED]/g" "$file" || true
                 fi
               done
             fi


### PR DESCRIPTION
Update artifact sanitization pattern `"s/${secret_value}/<REDACTED>/g"` to use `[ ]` and prevent invalid XML in JUnit file.