### PR TITLE
fix: manager deployment should have affinity for system nodepool

### DIFF
--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -155,6 +155,27 @@ manager:
       effect: "NoExecute"
     # Affinity for webhook pods (anti-affinity recommended for HA)
     affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+              - linux
+            - key: kubernetes.io/arch
+              operator: In
+              values:
+              - amd64
+              - arm64
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 90
+          preference:
+            matchExpressions:
+            - key: kubernetes.azure.com/mode
+              operator: In
+              values:
+              - system
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100


### PR DESCRIPTION
This pull request introduces enhanced node affinity settings for the `manager` deployment in the `charts/latest/values.yaml` file. The changes improve scheduling control by specifying required and preferred node characteristics, ensuring pods run on appropriate nodes and optimizing for high availability.

Pod scheduling and affinity improvements:

* Added `nodeAffinity` rules to require pods to be scheduled on nodes with `linux` OS and either `amd64` or `arm64` architecture.
* Added a preferred scheduling rule to favor nodes labeled with `kubernetes.azure.com/mode: system`, assigning a weight of 90 to this preference.