### PR TITLE
fix: uncomment git push in update-version script

### DIFF
--- a/.github/workflows/scripts/update-version.sh
+++ b/.github/workflows/scripts/update-version.sh
@@ -70,7 +70,7 @@ if git diff --staged --quiet; then
 fi
 
 git commit -m "docs: update version to ${VERSION} in README.md"
-# git push origin "${BRANCH}"
+git push origin "${BRANCH}"
 
 # # Create pull request
 gh pr create \


### PR DESCRIPTION
The update-version workflow was failing because the branch was never pushed to the remote before gh pr create was called. Uncomment the git push command so the branch exists on the remote.

I did it while testing and forgot to revert