### PR TITLE
Add startup diagnostic warning when no NVMe disks available

### DIFF
--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -249,6 +249,13 @@ func main() {
 		recorder = mgr.GetEventRecorderFor("local-csi-driver")
 	}
 
+	// Run startup diagnostic to check disk availability and emit a Warning
+	// event on the pod if no disks are available for volume group creation.
+	startupDiag := lvm.NewStartupDiagnostic(deviceProbe, blockDevUtils, probe.EphemeralDiskFilter, recorder, mgr.GetClient(), podName, namespace)
+	if err := mgr.Add(startupDiag); err != nil {
+		logAndExit(err, "unable to add startup diagnostic to manager")
+	}
+
 	// Setup PV garbage collection controller to clean up orphaned LVM volumes
 	// when PV node annotations don't match the current node
 	if enableLVGarbageCollection {

--- a/internal/csi/core/lvm/startup.go
+++ b/internal/csi/core/lvm/startup.go
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"local-csi-driver/internal/pkg/block"
+	"local-csi-driver/internal/pkg/probe"
+)
+
+const (
+	// Startup diagnostic event reasons.
+	noDiskAvailable       = "NoDiskAvailable"
+	diskDiscoveryComplete = "DiskDiscoveryComplete"
+)
+
+// StartupDiagnostic runs a one-time disk availability check when the pod starts
+// and emits a Kubernetes event on the pod with the results. It emits a Warning
+// event if no disks are available, or a Normal event listing available and
+// in-use disks.
+type StartupDiagnostic struct {
+	probe     probe.Interface
+	block     block.Interface
+	filter    *probe.Filter
+	recorder  record.EventRecorder
+	k8sClient client.Client
+	podName   string
+	namespace string
+}
+
+// NewStartupDiagnostic creates a new StartupDiagnostic instance.
+func NewStartupDiagnostic(
+	p probe.Interface,
+	b block.Interface,
+	filter *probe.Filter,
+	recorder record.EventRecorder,
+	k8sClient client.Client,
+	podName string,
+	namespace string,
+) *StartupDiagnostic {
+	return &StartupDiagnostic{
+		probe:     p,
+		block:     b,
+		filter:    filter,
+		recorder:  recorder,
+		k8sClient: k8sClient,
+		podName:   podName,
+		namespace: namespace,
+	}
+}
+
+// Start implements manager.Runnable. It performs the disk availability check
+// once at startup and emits a Kubernetes event on the pod with the results.
+func (s *StartupDiagnostic) Start(ctx context.Context) error {
+	log := log.FromContext(ctx).WithName("startup-diagnostic")
+
+	// Fetch the pod for event emission.
+	var pod corev1.Pod
+	if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: s.namespace, Name: s.podName}, &pod); err != nil {
+		log.Error(err, "failed to get pod for event emission", "pod", s.podName, "namespace", s.namespace)
+		return nil
+	}
+
+	// Check if there are any available disks.
+	devices, err := s.probe.ScanAvailableDevices(ctx)
+	if err != nil && !errors.Is(err, probe.ErrNoDevicesFound) {
+		log.Error(err, "failed to scan for available devices during startup diagnostic")
+		return nil
+	}
+
+	// Scan all NVMe devices on the node to build a full picture.
+	summary := s.scanNVMeDevices(ctx)
+
+	if devices == nil || len(devices.Devices) == 0 {
+		log.Info("no available disks found", "totalNVMeDisks", summary.total, "nonLVM2FormattedDisks", summary.nonLVM2Formatted)
+		msg := buildNoDiskMessage(summary)
+		s.recorder.Event(&pod, corev1.EventTypeWarning, noDiskAvailable, msg)
+		return nil
+	}
+
+	log.Info("startup disk discovery complete", "availableDisks", len(devices.Devices))
+	msg := buildDiskDiscoveryMessage(devices.Devices, summary)
+	s.recorder.Event(&pod, corev1.EventTypeNormal, diskDiscoveryComplete, msg)
+	return nil
+}
+
+// NeedLeaderElection returns false since the diagnostic should run on every node.
+func (s *StartupDiagnostic) NeedLeaderElection() bool {
+	return false
+}
+
+// deviceSummary holds the results of scanning all NVMe devices on the node.
+type deviceSummary struct {
+	total            int
+	nonLVM2Formatted int
+	available        []block.Device
+	inUse            []block.Device
+}
+
+// scanNVMeDevices scans all block devices and categorizes NVMe devices
+// matching the filter. Returns a summary with device lists.
+func (s *StartupDiagnostic) scanNVMeDevices(ctx context.Context) deviceSummary {
+	log := log.FromContext(ctx).WithName("startup-diagnostic")
+
+	allDevices, err := s.block.GetDevices(ctx)
+	if err != nil {
+		log.Error(err, "failed to list all block devices for diagnostic context")
+		return deviceSummary{}
+	}
+
+	var summary deviceSummary
+	for _, d := range allDevices.Devices {
+		if !s.filter.Match(d) {
+			continue
+		}
+		summary.total++
+
+		isFormatted, err := s.block.IsFormatted(d.Path)
+		if err != nil {
+			log.Error(err, "failed to check device format status", "device", d.Path)
+			continue
+		}
+		if !isFormatted {
+			log.V(1).Info("NVMe device found (unformatted)", "path", d.Path, "model", d.Model, "size", d.Size)
+			summary.available = append(summary.available, d)
+			continue
+		}
+
+		isLVM2, err := s.block.IsLVM2(d.Path)
+		if err != nil {
+			log.Error(err, "failed to check device LVM2 status", "device", d.Path)
+			continue
+		}
+		if isLVM2 {
+			log.V(1).Info("NVMe device found (LVM2, part of a volume group)", "path", d.Path, "model", d.Model, "size", d.Size)
+			summary.available = append(summary.available, d)
+			continue
+		}
+
+		summary.nonLVM2Formatted++
+		log.V(1).Info("NVMe device found (formatted, non-LVM2)", "path", d.Path, "model", d.Model, "size", d.Size)
+		summary.inUse = append(summary.inUse, d)
+	}
+
+	return summary
+}
+
+// formatDeviceList formats a list of devices into a human-readable string.
+func formatDeviceList(devices []block.Device) string {
+	names := make([]string, len(devices))
+	for i, d := range devices {
+		names[i] = fmt.Sprintf("%s (%s)", d.Path, formatBytes(d.Size))
+	}
+	return strings.Join(names, ", ")
+}
+
+// formatBytes formats bytes into a human-readable string.
+func formatBytes(b int64) string {
+	const gi = 1024 * 1024 * 1024
+	if b >= gi {
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(gi))
+	}
+	const mi = 1024 * 1024
+	return fmt.Sprintf("%.1f MiB", float64(b)/float64(mi))
+}
+
+// buildDiskDiscoveryMessage constructs a Normal event message listing
+// available and in-use devices.
+func buildDiskDiscoveryMessage(available []block.Device, summary deviceSummary) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Disk discovery complete: found %d available disk(s) for volume group creation", len(available))
+
+	sb.WriteString(". Available: ")
+	sb.WriteString(formatDeviceList(available))
+
+	if len(summary.inUse) > 0 {
+		sb.WriteString(". In use (non-LVM formatted): ")
+		sb.WriteString(formatDeviceList(summary.inUse))
+	}
+
+	return sb.String()
+}
+
+// buildNoDiskMessage constructs a Warning event message when no disks are
+// available, with diagnostic context and remediation advice.
+func buildNoDiskMessage(summary deviceSummary) string {
+	if summary.total == 0 {
+		return "No NVMe disks matching the expected model (Microsoft NVMe Direct Disk) " +
+			"were found on this node. This can happen when the node pool uses a VM SKU " +
+			"with ephemeral OS disk enabled, which consumes the NVMe disk for the OS. " +
+			"Consider using a VM SKU with additional NVMe disks, or disable " +
+			"ephemeral OS disk on the node pool."
+	}
+
+	if summary.nonLVM2Formatted == summary.total {
+		return fmt.Sprintf(
+			"No available disks for volume group creation. Found %d NVMe disk(s) "+
+				"on this node, but all are already formatted with a non-LVM filesystem: %s. "+
+				"Consider using a VM SKU with additional NVMe disks.",
+			summary.total, formatDeviceList(summary.inUse),
+		)
+	}
+
+	return fmt.Sprintf(
+		"No available disks for volume group creation. Found %d NVMe disk(s) "+
+			"on this node (%d formatted with a non-LVM filesystem, %d unformatted or already "+
+			"in a volume group), but none are newly available for volume group creation.",
+		summary.total, summary.nonLVM2Formatted, summary.total-summary.nonLVM2Formatted,
+	)
+}

--- a/internal/csi/core/lvm/startup_test.go
+++ b/internal/csi/core/lvm/startup_test.go
@@ -1,0 +1,427 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"local-csi-driver/internal/csi/core/lvm"
+	"local-csi-driver/internal/pkg/block"
+	"local-csi-driver/internal/pkg/probe"
+)
+
+const (
+	expectedWarningPrefix = "Warning NoDiskAvailable"
+	expectedNormalPrefix  = "Normal DiskDiscoveryComplete"
+)
+
+func newTestPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+	}
+}
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	return scheme
+}
+
+func TestStartupDiagnostic_DisksAvailable(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme1n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+
+	mockBlock := block.NewMock(ctrl)
+	// scanNVMeDevices is always called to build the full picture.
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme0n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+			{Path: "/dev/nvme1n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+			{Path: "/dev/sda", Model: "Some SCSI Disk", Size: 100 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(true, nil)
+	mockBlock.EXPECT().IsLVM2("/dev/nvme0n1").Return(false, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme1n1").Return(false, nil)
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedNormalPrefix) {
+			t.Fatalf("expected Normal DiskDiscoveryComplete event, got: %s", event)
+		}
+		if !strings.Contains(event, "/dev/nvme1n1") {
+			t.Fatalf("expected event to list available disk /dev/nvme1n1, got: %s", event)
+		}
+		if !strings.Contains(event, "/dev/nvme0n1") {
+			t.Fatalf("expected event to list in-use disk /dev/nvme0n1, got: %s", event)
+		}
+		if !strings.Contains(event, "In use") {
+			t.Fatalf("expected event to mention 'In use', got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Normal event, got none")
+	}
+}
+
+func TestStartupDiagnostic_DisksAvailable_NoInUse(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme0n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+
+	mockBlock := block.NewMock(ctrl)
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme0n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(false, nil)
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedNormalPrefix) {
+			t.Fatalf("expected Normal event, got: %s", event)
+		}
+		if strings.Contains(event, "In use") {
+			t.Fatalf("expected no 'In use' section when all disks are available, got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Normal event, got none")
+	}
+}
+
+func TestStartupDiagnostic_NoDisks_AllFormattedNVMe(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(nil, probe.ErrNoDevicesFound)
+
+	mockBlock := block.NewMock(ctrl)
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme0n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+			{Path: "/dev/sda", Model: "Some SCSI Disk", Size: 100 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(true, nil)
+	mockBlock.EXPECT().IsLVM2("/dev/nvme0n1").Return(false, nil)
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedWarningPrefix) {
+			t.Fatalf("expected Warning event, got: %s", event)
+		}
+		if !strings.Contains(event, "1 NVMe disk(s)") {
+			t.Fatalf("expected event to mention '1 NVMe disk(s)', got: %s", event)
+		}
+		if !strings.Contains(event, "non-LVM filesystem") {
+			t.Fatalf("expected event to mention 'non-LVM filesystem', got: %s", event)
+		}
+		if !strings.Contains(event, "/dev/nvme0n1") {
+			t.Fatalf("expected event to list the in-use disk, got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Warning event, got none")
+	}
+}
+
+func TestStartupDiagnostic_NoDisks_NoNVMe(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(nil, probe.ErrNoDevicesFound)
+
+	mockBlock := block.NewMock(ctrl)
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/sda", Model: "Some SCSI Disk", Size: 100 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedWarningPrefix) {
+			t.Fatalf("expected Warning event, got: %s", event)
+		}
+		if !strings.Contains(event, "No NVMe disks matching the expected model") {
+			t.Fatalf("expected ephemeral OS disk message, got: %s", event)
+		}
+		if !strings.Contains(event, "ephemeral OS disk") {
+			t.Fatalf("expected event to mention 'ephemeral OS disk', got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Warning event, got none")
+	}
+}
+
+func TestStartupDiagnostic_ScanError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(nil, fmt.Errorf("scan failed"))
+
+	mockBlock := block.NewMock(ctrl)
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// On scan error, the diagnostic should log and return without emitting events.
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("expected no event on scan error, got: %s", event)
+	default:
+	}
+}
+
+func TestStartupDiagnostic_PodNotFound(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockBlock := block.NewMock(ctrl)
+	recorder := record.NewFakeRecorder(10)
+	// No pod object — simulates pod not found.
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("expected no event when pod not found, got: %s", event)
+	default:
+	}
+}
+
+func TestStartupDiagnostic_MultipleNVMe_SomeFormatted(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(nil, probe.ErrNoDevicesFound)
+
+	mockBlock := block.NewMock(ctrl)
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme0n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+			{Path: "/dev/nvme1n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(true, nil)
+	mockBlock.EXPECT().IsLVM2("/dev/nvme0n1").Return(false, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme1n1").Return(false, nil)
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedWarningPrefix) {
+			t.Fatalf("expected Warning event, got: %s", event)
+		}
+		if !strings.Contains(event, "2 NVMe disk(s)") {
+			t.Fatalf("expected event to mention '2 NVMe disk(s)', got: %s", event)
+		}
+		if !strings.Contains(event, "1 formatted with a non-LVM filesystem") {
+			t.Fatalf("expected event to mention '1 formatted with a non-LVM filesystem', got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Warning event, got none")
+	}
+}
+
+func TestStartupDiagnostic_NeedLeaderElection(t *testing.T) {
+	t.Parallel()
+	diag := lvm.NewStartupDiagnostic(nil, nil, nil, nil, nil, "", "")
+	if diag.NeedLeaderElection() {
+		t.Fatal("expected NeedLeaderElection to return false")
+	}
+}
+
+func TestStartupDiagnostic_GetDevicesError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(nil, probe.ErrNoDevicesFound)
+
+	mockBlock := block.NewMock(ctrl)
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(nil, fmt.Errorf("lsblk failed"))
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should still emit a warning (with totalNVMe=0 fallback).
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedWarningPrefix) {
+			t.Fatalf("expected Warning event, got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Warning event, got none")
+	}
+}
+
+func TestStartupDiagnostic_IsFormattedError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(nil, probe.ErrNoDevicesFound)
+
+	mockBlock := block.NewMock(ctrl)
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme0n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(false, fmt.Errorf("blkid failed"))
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedWarningPrefix) {
+			t.Fatalf("expected Warning event, got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Warning event, got none")
+	}
+}
+
+func TestStartupDiagnostic_IsLVM2Error(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProbe := probe.NewMock(ctrl)
+	mockProbe.EXPECT().ScanAvailableDevices(gomock.Any()).Return(nil, probe.ErrNoDevicesFound)
+
+	mockBlock := block.NewMock(ctrl)
+	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(&block.DeviceList{
+		Devices: []block.Device{
+			{Path: "/dev/nvme0n1", Model: "Microsoft NVMe Direct Disk", Size: 500 * 1024 * 1024 * 1024, Type: "disk"},
+		},
+	}, nil)
+	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(true, nil)
+	mockBlock.EXPECT().IsLVM2("/dev/nvme0n1").Return(false, fmt.Errorf("check failed"))
+
+	recorder := record.NewFakeRecorder(10)
+	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
+
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+
+	if err := diag.Start(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.HasPrefix(event, expectedWarningPrefix) {
+			t.Fatalf("expected Warning event, got: %s", event)
+		}
+	default:
+		t.Fatal("expected a Warning event, got none")
+	}
+}


### PR DESCRIPTION
When the CSI driver pod starts, a new StartupDiagnostic runnable scans for available NVMe disks. If none are found (e.g., all consumed by ephemeral OS disk on single-NVMe VM SKUs like Standard_L2as_v4), it emits a Warning/NoDiskAvailable Kubernetes event on the driver pod with contextual details and remediation advice.

This helps customers and CSS quickly identify why no volume group can be created, rather than discovering the issue only when a volume creation request fails.

real examples from test

kube-system         2m7s        Normal    DiskDiscoveryComplete       pod/csi-local-node-pc9dw                                                    Disk discovery complete: found 3 available disk(s) for volume group creation. Available: /dev/nvme3n1 (447.0 GiB), /dev/nvme2n1 (447.0 GiB), /dev/nvme1n1 (447.0 GiB)

kube-system               2m56s       Normal    DiskDiscoveryComplete       pod/csi-local-node-9k94v                                                    Disk discovery complete: found 1 available disk(s) for volume group creation. Available: /dev/nvme0n1 (1788.5 GiB)


kube-system          22s         Warning   NoDiskAvailable           pod/csi-local-node-l6l2x                       No NVMe disks matching the expected model (Microsoft NVMe Direct Disk) were found on this node. This can happen when the node pool uses a VM SKU with ephemeral OS disk enabled, which consumes the NVMe disk for the OS. Consider using a VM SKU with additional NVMe disks, or disable ephemeral OS disk on the node pool.
