### PR TITLE
fix(e2e): wait for webhook before testing PVC rejection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -236,3 +236,18 @@ mgr.GetWebhookServer().Register(
 OpenTelemetry tracing is opt-in via `--trace-address` and
 `--trace-sample-rate` flags. Prometheus metrics are served
 on configurable ports with auth filters.
+
+### Code style
+
+Use only ASCII characters in source code (strings, comments). Do not use unicode dashes, quotes, or other non-ASCII punctuation.
+
+### Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Format: `<type>(<scope>): <description>`, e.g.:
+
+- `fix(e2e): wait for webhook before testing rejection`
+- `feat(csi): add volume expansion support`
+- `test(lvm): add hyperconverged node affinity test`
+- `docs: update copilot instructions`
+
+Common types: `feat`, `fix`, `test`, `docs`, `refactor`, `chore`, `ci`.

--- a/test/e2e/lvm_storagepool_test.go
+++ b/test/e2e/lvm_storagepool_test.go
@@ -34,6 +34,11 @@ var testLvmStoragePool = func() {
 
 		lvmStatefulsetTest("should create statefulset with local storagepool", common.LvmStatefulSetFixture)
 		lvmStatefulsetTest("should create annotation statefulset with local storagepool", common.LvmAnnotationStatefulSetFixture)
+
+		It("should have webhook serving", func(ctx context.Context) {
+			common.VerifyWebhookServing(ctx, common.LvmPvcNoAnnotationFixture)
+		})
+
 		lvmWebhookRejectTest("should reject statefulset with non-ephemeral local storagepool", common.LvmPvcNoAnnotationFixture)
 		lvmHyperconvergedTest("should create hyperconverged pod with local storagepool", common.LvmPvcAnnotationFixure, common.LvmPodAnnotationFixture)
 	})

--- a/test/pkg/common/common.go
+++ b/test/pkg/common/common.go
@@ -426,3 +426,18 @@ func VerifyDriverUp(ctx context.Context, namespace string) {
 	}
 	Eventually(verifyNodeUp).WithTimeout(5 * time.Minute).WithContext(ctx).Should(Succeed())
 }
+
+// VerifyWebhookServing confirms the validating webhook is actually serving
+// by using --dry-run=server to submit a PVC that should be rejected. The VWC
+// has failurePolicy: Ignore, so if the webhook isn't reachable the API server
+// silently accepts the request. This check must run after the storageclass
+// is created (the webhook allows PVCs whose storageclass doesn't exist).
+func VerifyWebhookServing(ctx context.Context, pvcFixture string) {
+	By("verifying that the validating webhook is serving")
+	Eventually(func(g Gomega) {
+		cmd := exec.CommandContext(ctx, "kubectl", "apply", "--dry-run=server", "-f", pvcFixture)
+		output, err := utils.Run(cmd)
+		g.Expect(err).To(HaveOccurred(), "Webhook is not yet serving - dry-run was accepted instead of rejected")
+		g.Expect(output).To(ContainSubstring("denied the request"), "Error is not a webhook rejection - webhook may not be serving")
+	}).WithContext(ctx).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "Validating webhook did not start serving within timeout")
+}


### PR DESCRIPTION
The lvmWebhookRejectTest flakes because the ValidatingWebhookConfiguration (csi-local-enforce-ephemeral) has failurePolicy: Ignore. When the webhook endpoint isn't reachable yet, the API server silently allows the PVC through instead of rejecting it.

Add VerifyWebhookServing() that uses kubectl apply --dry-run=server to confirm the webhook is actually serving before running the rejection test. The dry-run goes through the full admission pipeline without persisting to etcd. This check runs as its own test step after the storageclass is created (the webhook allows PVCs whose storageclass doesn't exist).