### PR TITLE
fix(ci): prefix short SHA with "g" to ensure valid SemVer

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -46,8 +46,10 @@ jobs:
           # For push: this is the commit SHA
           SHORT_SHA=$(git rev-parse --short HEAD)
 
-          # Create tag in format MAJOR.MINOR.PATCH-REF
-          TAG="v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}-${SHORT_SHA}"
+          # Create tag in format MAJOR.MINOR.PATCH-gREF
+          # Prefix SHA with 'g' (git convention) to ensure valid SemVer:
+          # numeric-only pre-release identifiers must not have leading zeros.
+          TAG="v${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}-g${SHORT_SHA}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
           # Only set latest tag for push events to main


### PR DESCRIPTION
SemVer 2.0 forbids leading zeros on numeric pre-release identifiers. When `git rev-parse --short HEAD` produces a SHA starting with 0 (e.g. 0078127), the resulting version like 0.0.1-0078127 is invalid and causes `helm package` to fail with "chart.metadata.version is invalid".

Prefix the short SHA with "g" (the standard git convention used by `git describe`) to make the identifier alphanumeric, where leading zeros are permitted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>