### PR TITLE
ci(deps): split k8s dependencies into separate dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,17 @@ updates:
     schedule:
       interval: "daily"
     groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+        update-types:
+          - "minor"
+          - "patch"
       gomod-minor-patch:
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
Group k8s.io/* and sigs.k8s.io/* packages separately from other gomod minor/patch updates so they get their own PR. These dependencies are typically bumped together (k8s.io/api, apiextensions-apiserver, component-helpers, kubernetes, mount-utils) and bundling them with unrelated updates makes review harder and can block other libraries from being updated if there is an api change.