### PR TITLE
ci: drop redundant loaded-image check in docker-push-template

### DIFF
--- a/.github/workflows/docker-push-template.yml
+++ b/.github/workflows/docker-push-template.yml
@@ -75,16 +75,6 @@ jobs:
           fi
           docker load -i "$tar"
 
-          expected="local/${IMAGE_NAME}:build"
-          loaded=$(docker image ls --format '{{.Repository}}:{{.Tag}}' | sort -u)
-          if [[ "$loaded" != "$expected" ]]; then
-            echo "::error::Unexpected images loaded from artifact." >&2
-            echo "Expected exactly: $expected" >&2
-            echo "Got:" >&2
-            echo "$loaded" >&2
-            exit 1
-          fi
-
       - name: Azure CLI Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:


### PR DESCRIPTION
The 'Load image into docker' step compared the entire 'docker image ls' output against the expected loaded image. On runners with pre-pulled images (dependabot, gh-aw-firewall, github-mcp-server, etc.) this falsely failed even though the tarball loaded exactly the expected image.

The check was defense-in-depth and added no real safety: the retag step that follows only references 'local/${IMAGE_NAME}:build' explicitly, so any extra images in the artifact are inert and never pushed to ACR. If the expected image is missing, 'docker tag' fails loudly on its own.

Drop the check rather than patching it.