### PR TITLE
ci: run external e2e and sanity tests on pr on kind

### DIFF
--- a/.github/workflows/scripts/run_tests.py
+++ b/.github/workflows/scripts/run_tests.py
@@ -10,6 +10,7 @@ import time
 import argparse
 import logging
 import asyncio
+import sys
 import uuid
 import json
 import functools
@@ -227,14 +228,34 @@ class KindCluster(Cluster):
     Class for managing a kind cluster.
     """
 
+    def __init__(self, nodes: str = "single", setup_vg: bool = False):
+        if nodes not in ("single", "multi"):
+            raise ValueError(f"Unsupported kind node config: {nodes}")
+        self.nodes = nodes
+        self.setup_vg = setup_vg
+
     async def setup(self) -> None:
         """
         Set up the kind cluster.
         """
-        logging.info("Creating kind cluster")
-        if await run_command("make single", os.environ.copy()) != 0:
+        logging.info(f"Creating kind cluster (target=make {self.nodes})")
+        if await run_command(f"make {self.nodes}", os.environ.copy()) != 0:
             logging.error("Failed to create kind cluster")
             raise RuntimeError("Failed to create kind cluster")
+        if self.setup_vg:
+            # Pre-create the LVM volume group the driver expects on each kind
+            # node so tests can run without real NVMe hardware. The driver's
+            # CreateVolume path short-circuits NVMe discovery when the VG
+            # already exists.
+            logging.info("Setting up LVM volume group on kind nodes")
+            cmd = "make kind-setup-vg"
+            if await run_command(cmd, os.environ.copy()) != 0:
+                logging.error(
+                    "Failed to set up LVM volume group on kind nodes"
+                )
+                raise RuntimeError(
+                    "Failed to set up LVM volume group on kind nodes"
+                )
 
     async def cleanup(self) -> None:
         """
@@ -425,7 +446,7 @@ def create_cluster(args: argparse.Namespace, config: EnvConfig) -> Cluster:
         Cluster: An instance of the appropriate cluster class.
     """
     if args.cluster_type == "kind":
-        return KindCluster()
+        return KindCluster(nodes=args.kind_nodes, setup_vg=args.kind_setup_vg)
     elif args.cluster_type == "aks":
         return AksCluster(
             args.aks_template,
@@ -483,7 +504,7 @@ async def retry_async(func, retries, delay, validator, error_msg):
             await asyncio.sleep(delay)
 
 
-async def main() -> None:
+async def main() -> int:
     """
     Main function to run the script.
     """
@@ -504,6 +525,28 @@ async def main() -> None:
         default="none",
         required=False,
         help="Specify the cluster type: kind, aks, or none",
+    )
+
+    parser.add_argument(
+        "--kind-nodes",
+        type=str,
+        choices=["single", "multi"],
+        default="single",
+        required=False,
+        help=(
+            "Kind cluster configuration: single (1 node) or multi (3 nodes). "
+            "Only used when --cluster-type=kind."
+        ),
+    )
+
+    parser.add_argument(
+        "--kind-setup-vg",
+        action="store_true",
+        help=(
+            "After creating the kind cluster, pre-create the LVM volume "
+            "group the driver expects on each node. "
+            "Only used when --cluster-type=kind."
+        ),
     )
 
     parser.add_argument(
@@ -568,6 +611,8 @@ async def main() -> None:
     logging.info("Script execution completed")
 
     await cluster.cleanup()
+
+    return exit_code
 
 
 @dataclass
@@ -913,4 +958,4 @@ async def _install_elastic_san_extension() -> None:
             raise RuntimeError(f"Failed to install extension: {str(e)}")
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    sys.exit(asyncio.run(main()))

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -51,17 +51,14 @@ jobs:
             id: e2e
             make-target: test-e2e
             kind-args: --kind-nodes single --kind-setup-vg
-            extra-helm: ""
           - name: Kind External E2E
             id: external-e2e
             make-target: test-external-e2e
             kind-args: --kind-nodes single --kind-setup-vg
-            extra-helm: ""
           - name: Kind Sanity
             id: sanity
             make-target: test-sanity
             kind-args: --kind-nodes single --kind-setup-vg
-            extra-helm: --set cleanup.lvGarbageCollection.enabled=false --set cleanup.lvmOrphanCleanup.enabled=false
         exclude:
           # external-e2e and sanity work on arm64 too, but to save CI minutes
           # we only run them on amd64. Plain e2e still runs on both arches.
@@ -151,14 +148,13 @@ jobs:
         env:
           MAKE_TARGET: ${{ matrix.test.make-target }}
           KIND_ARGS: ${{ matrix.test.kind-args }}
-          EXTRA_HELM: ${{ matrix.test.extra-helm }}
         run: |
           # PR builds never push to ACR. The suite consumes the pre-built chart
           # with pullPolicy=IfNotPresent so kubelet uses the locally-loaded
           # image instead of trying to pull from the registry.
           # shellcheck disable=SC2086  # KIND_ARGS intentionally word-splits.
           python .github/workflows/scripts/run_tests.py \
-            --command "make ${MAKE_TARGET} REGISTRY=${REGISTRY} REPO_BASE=${REPO_BASE} TAG=${TAG} INSTALLATION_METHOD=localHelm CHART_SOURCE=/tmp/helm/local-csi-driver-${TAG#v}.tgz SKIP_BUILD=true HELM_ARGS='--set image.driver.pullPolicy=IfNotPresent --set image.manager.pullPolicy=IfNotPresent ${EXTRA_HELM}'" \
+            --command "make ${MAKE_TARGET} REGISTRY=${REGISTRY} REPO_BASE=${REPO_BASE} TAG=${TAG} INSTALLATION_METHOD=localHelm CHART_SOURCE=/tmp/helm/local-csi-driver-${TAG#v}.tgz SKIP_BUILD=true HELM_ARGS='--set image.driver.pullPolicy=IfNotPresent --set image.manager.pullPolicy=IfNotPresent'" \
             --cluster-type kind ${KIND_ARGS}
 
       - name: Upload test results

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -33,9 +33,9 @@ jobs:
       repo_base: "acstor"
       tags: "v0.0.1-pr"
 
-  kind-e2e:
+  kind-test:
     needs: [build-docker, build-helm]
-    name: Kind Integration Test (${{ matrix.arch.tag-suffix }})
+    name: ${{ matrix.test.name }} (${{ matrix.arch.tag-suffix }})
     permissions:
       contents: read
     strategy:
@@ -46,6 +46,29 @@ jobs:
             tag-suffix: amd64
           - runs-on: ubuntu-24.04-arm
             tag-suffix: arm64
+        test:
+          - name: Kind E2E
+            id: e2e
+            make-target: test-e2e
+            kind-args: --kind-nodes single --kind-setup-vg
+            extra-helm: ""
+          - name: Kind External E2E
+            id: external-e2e
+            make-target: test-external-e2e
+            kind-args: --kind-nodes single --kind-setup-vg
+            extra-helm: ""
+          - name: Kind Sanity
+            id: sanity
+            make-target: test-sanity
+            kind-args: --kind-nodes single --kind-setup-vg
+            extra-helm: --set cleanup.lvGarbageCollection.enabled=false --set cleanup.lvmOrphanCleanup.enabled=false
+        exclude:
+          # external-e2e and sanity work on arm64 too, but to save CI minutes
+          # we only run them on amd64. Plain e2e still runs on both arches.
+          - arch: { tag-suffix: arm64 }
+            test: { id: external-e2e }
+          - arch: { tag-suffix: arm64 }
+            test: { id: sanity }
     runs-on: ${{ matrix.arch.runs-on }}
     steps:
       - name: Harden Runner
@@ -88,7 +111,6 @@ jobs:
           name: helm-charts
           path: /tmp/helm
 
-
       - name: Load images into docker and retag for kind
         env:
           TAG_SUFFIX: ${{ matrix.arch.tag-suffix }}
@@ -110,21 +132,34 @@ jobs:
               "${REGISTRY}/${REPO_BASE}/${img}:${TAG}"
           done
 
+      - name: Create kind cluster
+        run: |
+          # Ensure kind binary is on PATH for any in-suite invocations
+          # (e.g. external-e2e's `kind load docker-image` in BeforeSuite).
+          make kind
+          echo "${PWD}/bin" >> "$GITHUB_PATH"
+
       - name: Setup TestRunId
         env:
           TAG_SUFFIX: ${{ matrix.arch.tag-suffix }}
+          TEST_ID: ${{ matrix.test.id }}
         run: |
-          TEST_RUN_ID="${{ github.run_id }}-kind-${TAG_SUFFIX}-${{ github.run_attempt }}"
+          TEST_RUN_ID="${{ github.run_id }}-kind-${TEST_ID}-${TAG_SUFFIX}-${{ github.run_attempt }}"
           echo "TestRunId=${TEST_RUN_ID}" >> "$GITHUB_ENV"
 
-      - name: Run Kind E2E
+      - name: Run ${{ matrix.test.name }}
+        env:
+          MAKE_TARGET: ${{ matrix.test.make-target }}
+          KIND_ARGS: ${{ matrix.test.kind-args }}
+          EXTRA_HELM: ${{ matrix.test.extra-helm }}
         run: |
-          # PR builds never push to ACR. Override pullPolicy so kubelet uses
-          # the locally-loaded image instead of trying to pull from the
-          # registry (which would 404).
+          # PR builds never push to ACR. The suite consumes the pre-built chart
+          # with pullPolicy=IfNotPresent so kubelet uses the locally-loaded
+          # image instead of trying to pull from the registry.
+          # shellcheck disable=SC2086  # KIND_ARGS intentionally word-splits.
           python .github/workflows/scripts/run_tests.py \
-            --command "make test-e2e REGISTRY=${REGISTRY} REPO_BASE=${REPO_BASE} TAG=${TAG} CHART_SOURCE=/tmp/helm/local-csi-driver-${TAG#v}.tgz HELM_ARGS='--set image.driver.pullPolicy=IfNotPresent --set image.manager.pullPolicy=IfNotPresent'" \
-            --cluster-type kind
+            --command "make ${MAKE_TARGET} REGISTRY=${REGISTRY} REPO_BASE=${REPO_BASE} TAG=${TAG} INSTALLATION_METHOD=localHelm CHART_SOURCE=/tmp/helm/local-csi-driver-${TAG#v}.tgz SKIP_BUILD=true HELM_ARGS='--set image.driver.pullPolicy=IfNotPresent --set image.manager.pullPolicy=IfNotPresent ${EXTRA_HELM}'" \
+            --cluster-type kind ${KIND_ARGS}
 
       - name: Upload test results
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ config/controller/generated_config.yaml
 
 # Generated NOTICE file (regenerated during docker build)
 NOTICE.txt
+.github/workflows/scripts/__pycache__/run_tests.cpython-312.pyc

--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,17 @@ multi: kind ## Create a multi node kind cluster.
 		$(KIND) create cluster --config=./test/config/kind-3-node.yaml; \
 	fi
 
+.PHONY: kind-setup-vg
+kind-setup-vg: kind ## Create a 100GiB loop-backed LVM VG (containerstorage) on each kind node.
+	KIND=$(KIND) ./hack/kind-setup-vg.sh
+
+.PHONY: kind-teardown-vg
+kind-teardown-vg: kind ## Remove the loop-backed LVM VG from each kind node.
+	KIND=$(KIND) ./hack/kind-setup-vg.sh --teardown
+
+.PHONY: kind-e2e-bootstrap
+kind-e2e-bootstrap: multi kind-setup-vg ## Create a 3-node kind cluster + VG on each node, ready for e2e / external-e2e.
+
 .PHONY: clean
 clean: kind ## Deletes the kind cluster.
 	$(KIND) delete cluster --name kind

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ test-e2e-aks: ginkgo ## Run the e2e tests on AKS.
 
 .PHONY: test-sanity
 test-sanity: ginkgo ## Run the sanity tests.
-	$(eval ARGS := $(ADDITIONAL_GINKGO_FLAGS))
+	$(eval ARGS := $(ADDITIONAL_GINKGO_FLAGS) --fail-fast)
 	$(if $(findstring --dry-run,$(ADDITIONAL_GINKGO_FLAGS)), , $(eval ARGS := $(ARGS) --procs=16))
 	$(call run_tests,sanity,./test/sanity,$(ARGS),)
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ test-sanity: ginkgo ## Run the sanity tests.
 
 .PHONY: test-external-e2e
 test-external-e2e: ginkgo ## Run the external e2e tests.
-	$(eval ARGS := $(ADDITIONAL_GINKGO_FLAGS))
+	$(eval ARGS := $(ADDITIONAL_GINKGO_FLAGS) --fail-fast)
 	$(if $(findstring --dry-run,$(ADDITIONAL_GINKGO_FLAGS)), , $(eval ARGS := $(ARGS) --procs=16))
 	$(call run_tests,external-e2e && !Disruptive,./test/external,$(ARGS),)
 

--- a/hack/kind-setup-vg.sh
+++ b/hack/kind-setup-vg.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Pre-creates an LVM volume group on each Kind node so the local-csi-driver
+# can use it without real NVMe devices.
+#
+# The driver's CreateVolume path calls GetVolumeGroup() first and short-circuits
+# device discovery if the VG already exists, so this is enough to make the
+# e2e / external-e2e suites runnable on Kind.
+#
+# Each node gets a sparse file (default 100G) attached to a loop device, with a
+# physical volume on top and the expected VG (default "containerstorage")
+# created with the "local-csi" tag. Because the backing file is sparse, only
+# data actually written to logical volumes consumes real host disk space.
+#
+# Usage:
+#   ./hack/kind-setup-vg.sh                       # cluster "kind", VG "containerstorage", 100G
+#   KIND_CLUSTER=mycluster VG_SIZE=8G ./hack/kind-setup-vg.sh
+#   ./hack/kind-setup-vg.sh --teardown            # remove VG + loop + backing file
+#
+# Requires: docker, kind (or $KIND set to a kind binary path).
+
+set -euo pipefail
+
+CLUSTER="${KIND_CLUSTER:-kind}"
+VG_NAME="${VG_NAME:-containerstorage}"
+VG_TAG="${VG_TAG:-local-csi}"
+VG_SIZE="${VG_SIZE:-100G}"
+IMG_PATH_TEMPLATE="${IMG_PATH:-/csi-local-vg/__HOSTNAME__.img}"
+TMPFS_DIR="${TMPFS_DIR:-/csi-local-vg}"
+KIND_BIN="${KIND:-kind}"
+
+ACTION="setup"
+if [[ "${1:-}" == "--teardown" || "${1:-}" == "-d" ]]; then
+    ACTION="teardown"
+fi
+
+nodes=$("${KIND_BIN}" get nodes --name "${CLUSTER}")
+if [[ -z "${nodes}" ]]; then
+    echo "No kind nodes found for cluster '${CLUSTER}'" >&2
+    exit 1
+fi
+
+# Verify every node container is actually running before touching it. A stopped
+# kind cluster (e.g. after a host reboot) returns node names from `kind get
+# nodes` but `docker exec` will fail with "container is not running".
+not_running=()
+for node in ${nodes}; do
+    state=$(docker inspect -f '{{.State.Running}}' "${node}" 2>/dev/null || echo "missing")
+    if [[ "${state}" != "true" ]]; then
+        not_running+=("${node} (${state})")
+    fi
+done
+if (( ${#not_running[@]} > 0 )); then
+    echo "The following kind node containers are not running:" >&2
+    printf '  - %s\n' "${not_running[@]}" >&2
+    echo >&2
+    echo "Start them with:    docker start ${nodes//$'\n'/ }" >&2
+    echo "Or recreate with:   make clean && make kind-e2e-bootstrap" >&2
+    exit 1
+fi
+
+setup_node() {
+    local node="$1"
+    echo ">>> [${node}] ensuring VG ${VG_NAME} (${VG_SIZE})"
+    docker exec -i \
+        -e VG_NAME="${VG_NAME}" \
+        -e VG_TAG="${VG_TAG}" \
+        -e VG_SIZE="${VG_SIZE}" \
+        -e IMG_PATH_TEMPLATE="${IMG_PATH_TEMPLATE}" \
+        -e TMPFS_DIR="${TMPFS_DIR}" \
+        "${node}" bash -euo pipefail <<'INNER'
+if ! command -v vgcreate >/dev/null 2>&1; then
+    echo "installing lvm2..."
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq lvm2 >/dev/null
+fi
+
+# A kind node's /dev is a small tmpfs, populated at boot by systemd via
+# `kmod static-nodes` (see /lib/modules/$(uname -r)/modules.devname). The
+# loop driver statically declares only loop0..loop7 there, so that's all
+# the device nodes the container starts with. The kernel's loop pool is
+# not capped at 8 - `losetup -f` will happily allocate loop8, loop9, ...
+# but it returns ENOENT unless the device node exists. Once our VG backing
+# file and any other loop users have consumed those 8 slots, kubelet's
+# MapBlockVolume (which losetup's the published file for each block-mode
+# PVC) fails with "No such file or directory". Pre-create extra device
+# nodes so the kernel can hand them out on demand.
+# See: https://github.com/kubernetes-sigs/kind/issues/1452
+#      man 4 loop (max_loop / dynamic allocation)
+for i in $(seq 8 31); do
+    if [ ! -e "/dev/loop${i}" ]; then
+        mknod "/dev/loop${i}" b 7 "${i}" 2>/dev/null || true
+        chmod 660 "/dev/loop${i}" 2>/dev/null || true
+    fi
+done
+
+# Loop devices are kernel-global across all kind containers on the same host
+# kernel. The backing file path MUST be unique per node so `losetup -j` on one
+# node does not match (and accidentally detach) another node's loop device.
+IMG_PATH="${IMG_PATH_TEMPLATE//__HOSTNAME__/$(hostname)}"
+
+# Loop devices backed by files on overlayfs do NOT round-trip writes through
+# the file. Use a tmpfs mount so the backing file lives on a real fs. A sparse
+# file in tmpfs consumes no RAM until LVs actually write data.
+mkdir -p "${TMPFS_DIR}"
+if ! mountpoint -q "${TMPFS_DIR}"; then
+    mount -t tmpfs -o "size=${VG_SIZE}" tmpfs "${TMPFS_DIR}"
+fi
+
+if [ ! -f "${IMG_PATH}" ]; then
+    if vgs --noheadings -o vg_name 2>/dev/null | tr -d ' ' | grep -qx "${VG_NAME}"; then
+        vgchange -an "${VG_NAME}" 2>/dev/null || true
+        vgremove -ff -y "${VG_NAME}" 2>/dev/null || true
+    fi
+    for L in $(losetup -j "${IMG_PATH}" 2>/dev/null | awk -F: '{print $1}'); do
+        losetup -d "${L}" 2>/dev/null || true
+    done
+    truncate -s "${VG_SIZE}" "${IMG_PATH}"
+fi
+
+if vgs --noheadings -o vg_name 2>/dev/null | tr -d ' ' | grep -qx "${VG_NAME}"; then
+    echo "VG ${VG_NAME} already exists, skipping."
+    vgs "${VG_NAME}"
+    exit 0
+fi
+
+LOOP=$(losetup -j "${IMG_PATH}" | awk -F: 'NR==1{print $1}')
+if [ -z "${LOOP}" ]; then
+    LOOP=$(losetup -f --show "${IMG_PATH}")
+fi
+echo "using loop device ${LOOP}"
+
+if ! pvs --noheadings -o pv_name "${LOOP}" >/dev/null 2>&1; then
+    pvcreate -ff -y "${LOOP}"
+fi
+
+vgcreate --addtag "${VG_TAG}" "${VG_NAME}" "${LOOP}"
+vgs "${VG_NAME}"
+INNER
+}
+
+teardown_node() {
+    local node="$1"
+    echo ">>> [${node}] removing VG ${VG_NAME}"
+    docker exec -i \
+        -e VG_NAME="${VG_NAME}" \
+        -e IMG_PATH_TEMPLATE="${IMG_PATH_TEMPLATE}" \
+        -e TMPFS_DIR="${TMPFS_DIR}" \
+        "${node}" bash -euo pipefail <<'INNER' || true
+IMG_PATH="${IMG_PATH_TEMPLATE//__HOSTNAME__/$(hostname)}"
+if vgs --noheadings -o vg_name 2>/dev/null | tr -d ' ' | grep -qx "${VG_NAME}"; then
+    vgchange -an "${VG_NAME}" || true
+    vgremove -ff -y "${VG_NAME}" || true
+fi
+LOOP=$(losetup -j "${IMG_PATH}" 2>/dev/null | awk -F: 'NR==1{print $1}')
+if [ -n "${LOOP}" ]; then
+    pvremove -ff -y "${LOOP}" 2>/dev/null || true
+    losetup -d "${LOOP}" || true
+fi
+rm -f "${IMG_PATH}"
+if mountpoint -q "${TMPFS_DIR}"; then
+    umount "${TMPFS_DIR}" || true
+fi
+INNER
+}
+
+for node in ${nodes}; do
+    if [[ "${ACTION}" == "teardown" ]]; then
+        teardown_node "${node}"
+    else
+        setup_node "${node}"
+    fi
+done
+
+echo "Done."

--- a/hack/kind-setup-vg.sh
+++ b/hack/kind-setup-vg.sh
@@ -9,13 +9,13 @@
 # device discovery if the VG already exists, so this is enough to make the
 # e2e / external-e2e suites runnable on Kind.
 #
-# Each node gets a sparse file (default 100G) attached to a loop device, with a
+# Each node gets a sparse file (default 500G) attached to a loop device, with a
 # physical volume on top and the expected VG (default "containerstorage")
 # created with the "local-csi" tag. Because the backing file is sparse, only
 # data actually written to logical volumes consumes real host disk space.
 #
 # Usage:
-#   ./hack/kind-setup-vg.sh                       # cluster "kind", VG "containerstorage", 100G
+#   ./hack/kind-setup-vg.sh                       # cluster "kind", VG "containerstorage", 500G
 #   KIND_CLUSTER=mycluster VG_SIZE=8G ./hack/kind-setup-vg.sh
 #   ./hack/kind-setup-vg.sh --teardown            # remove VG + loop + backing file
 #
@@ -26,7 +26,7 @@ set -euo pipefail
 CLUSTER="${KIND_CLUSTER:-kind}"
 VG_NAME="${VG_NAME:-containerstorage}"
 VG_TAG="${VG_TAG:-local-csi}"
-VG_SIZE="${VG_SIZE:-100G}"
+VG_SIZE="${VG_SIZE:-500G}"
 IMG_PATH_TEMPLATE="${IMG_PATH:-/csi-local-vg/__HOSTNAME__.img}"
 TMPFS_DIR="${TMPFS_DIR:-/csi-local-vg}"
 KIND_BIN="${KIND:-kind}"

--- a/hack/kind-setup-vg.sh
+++ b/hack/kind-setup-vg.sh
@@ -2,24 +2,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Pre-creates an LVM volume group on each Kind node so the local-csi-driver
-# can use it without real NVMe devices.
+# Pre-create an LVM volume group on each Kind node so local-csi-driver can
+# run without real NVMe devices.
 #
-# The driver's CreateVolume path calls GetVolumeGroup() first and short-circuits
-# device discovery if the VG already exists, so this is enough to make the
-# e2e / external-e2e suites runnable on Kind.
+# Each node gets a sparse backing file under /var (kind's real-fs Docker
+# volume, NOT overlayfs - loop devices on overlayfs don't round-trip
+# writes), attached to a loop device with a PV/VG on top.
 #
-# Each node gets a sparse file (default 500G) attached to a loop device, with a
-# physical volume on top and the expected VG (default "containerstorage")
-# created with the "local-csi" tag. Because the backing file is sparse, only
-# data actually written to logical volumes consumes real host disk space.
+#   ./hack/kind-setup-vg.sh              # setup
+#   ./hack/kind-setup-vg.sh --teardown   # tear down
 #
-# Usage:
-#   ./hack/kind-setup-vg.sh                       # cluster "kind", VG "containerstorage", 500G
-#   KIND_CLUSTER=mycluster VG_SIZE=8G ./hack/kind-setup-vg.sh
-#   ./hack/kind-setup-vg.sh --teardown            # remove VG + loop + backing file
-#
-# Requires: docker, kind (or $KIND set to a kind binary path).
+# Env: KIND_CLUSTER (kind), VG_NAME (containerstorage), VG_TAG (local-csi),
+#      VG_SIZE (500G), KIND (kind binary).
 
 set -euo pipefail
 
@@ -27,150 +21,75 @@ CLUSTER="${KIND_CLUSTER:-kind}"
 VG_NAME="${VG_NAME:-containerstorage}"
 VG_TAG="${VG_TAG:-local-csi}"
 VG_SIZE="${VG_SIZE:-500G}"
-IMG_PATH_TEMPLATE="${IMG_PATH:-/csi-local-vg/__HOSTNAME__.img}"
-TMPFS_DIR="${TMPFS_DIR:-/csi-local-vg}"
 KIND_BIN="${KIND:-kind}"
 
-ACTION="setup"
-if [[ "${1:-}" == "--teardown" || "${1:-}" == "-d" ]]; then
-    ACTION="teardown"
-fi
+action="setup"
+[[ "${1:-}" == "--teardown" || "${1:-}" == "-d" ]] && action="teardown"
 
 nodes=$("${KIND_BIN}" get nodes --name "${CLUSTER}")
-if [[ -z "${nodes}" ]]; then
-    echo "No kind nodes found for cluster '${CLUSTER}'" >&2
-    exit 1
-fi
+[[ -n "${nodes}" ]] || { echo "no kind nodes for cluster '${CLUSTER}'" >&2; exit 1; }
 
-# Verify every node container is actually running before touching it. A stopped
-# kind cluster (e.g. after a host reboot) returns node names from `kind get
-# nodes` but `docker exec` will fail with "container is not running".
-not_running=()
-for node in ${nodes}; do
-    state=$(docker inspect -f '{{.State.Running}}' "${node}" 2>/dev/null || echo "missing")
-    if [[ "${state}" != "true" ]]; then
-        not_running+=("${node} (${state})")
-    fi
-done
-if (( ${#not_running[@]} > 0 )); then
-    echo "The following kind node containers are not running:" >&2
-    printf '  - %s\n' "${not_running[@]}" >&2
-    echo >&2
-    echo "Start them with:    docker start ${nodes//$'\n'/ }" >&2
-    echo "Or recreate with:   make clean && make kind-e2e-bootstrap" >&2
-    exit 1
-fi
-
-setup_node() {
-    local node="$1"
-    echo ">>> [${node}] ensuring VG ${VG_NAME} (${VG_SIZE})"
+run_on_node() {
     docker exec -i \
         -e VG_NAME="${VG_NAME}" \
         -e VG_TAG="${VG_TAG}" \
         -e VG_SIZE="${VG_SIZE}" \
-        -e IMG_PATH_TEMPLATE="${IMG_PATH_TEMPLATE}" \
-        -e TMPFS_DIR="${TMPFS_DIR}" \
-        "${node}" bash -euo pipefail <<'INNER'
-if ! command -v vgcreate >/dev/null 2>&1; then
-    echo "installing lvm2..."
+        "$1" bash -euo pipefail
+}
+
+# shellcheck disable=SC2016  # vars expand inside container, not here
+setup_script='
+command -v vgcreate >/dev/null || {
     apt-get update -qq
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq lvm2 >/dev/null
-fi
+}
 
-# A kind node's /dev is a small tmpfs, populated at boot by systemd via
-# `kmod static-nodes` (see /lib/modules/$(uname -r)/modules.devname). The
-# loop driver statically declares only loop0..loop7 there, so that's all
-# the device nodes the container starts with. The kernel's loop pool is
-# not capped at 8 - `losetup -f` will happily allocate loop8, loop9, ...
-# but it returns ENOENT unless the device node exists. Once our VG backing
-# file and any other loop users have consumed those 8 slots, kubelet's
-# MapBlockVolume (which losetup's the published file for each block-mode
-# PVC) fails with "No such file or directory". Pre-create extra device
-# nodes so the kernel can hand them out on demand.
-# See: https://github.com/kubernetes-sigs/kind/issues/1452
-#      man 4 loop (max_loop / dynamic allocation)
+# Kind /dev only ships loop0..loop7 device nodes; the kernel can hand out
+# more but only if the nodes exist. Pre-create extras so kubelet block-mode
+# losetup calls do not ENOENT. See kubernetes-sigs/kind#1248.
 for i in $(seq 8 31); do
-    if [ ! -e "/dev/loop${i}" ]; then
-        mknod "/dev/loop${i}" b 7 "${i}" 2>/dev/null || true
-        chmod 660 "/dev/loop${i}" 2>/dev/null || true
-    fi
+    [ -e "/dev/loop${i}" ] || { mknod "/dev/loop${i}" b 7 "${i}" && chmod 660 "/dev/loop${i}"; } 2>/dev/null || true
 done
 
-# Loop devices are kernel-global across all kind containers on the same host
-# kernel. The backing file path MUST be unique per node so `losetup -j` on one
-# node does not match (and accidentally detach) another node's loop device.
-IMG_PATH="${IMG_PATH_TEMPLATE//__HOSTNAME__/$(hostname)}"
+# Loop devices are kernel-global across kind containers; per-node filename
+# keeps losetup -j unambiguous.
+img=/var/lib/csi-local-vg/$(hostname).img
+mkdir -p "$(dirname "$img")"
 
-# Loop devices backed by files on overlayfs do NOT round-trip writes through
-# the file. Use a tmpfs mount so the backing file lives on a real fs. A sparse
-# file in tmpfs consumes no RAM until LVs actually write data.
-mkdir -p "${TMPFS_DIR}"
-if ! mountpoint -q "${TMPFS_DIR}"; then
-    mount -t tmpfs -o "size=${VG_SIZE}" tmpfs "${TMPFS_DIR}"
-fi
-
-if [ ! -f "${IMG_PATH}" ]; then
-    if vgs --noheadings -o vg_name 2>/dev/null | tr -d ' ' | grep -qx "${VG_NAME}"; then
-        vgchange -an "${VG_NAME}" 2>/dev/null || true
-        vgremove -ff -y "${VG_NAME}" 2>/dev/null || true
-    fi
-    for L in $(losetup -j "${IMG_PATH}" 2>/dev/null | awk -F: '{print $1}'); do
-        losetup -d "${L}" 2>/dev/null || true
-    done
-    truncate -s "${VG_SIZE}" "${IMG_PATH}"
-fi
-
-if vgs --noheadings -o vg_name 2>/dev/null | tr -d ' ' | grep -qx "${VG_NAME}"; then
+if vgs --noheadings -o vg_name 2>/dev/null | grep -qw "${VG_NAME}"; then
     echo "VG ${VG_NAME} already exists, skipping."
     vgs "${VG_NAME}"
     exit 0
 fi
 
-LOOP=$(losetup -j "${IMG_PATH}" | awk -F: 'NR==1{print $1}')
-if [ -z "${LOOP}" ]; then
-    LOOP=$(losetup -f --show "${IMG_PATH}")
-fi
-echo "using loop device ${LOOP}"
+[ -f "$img" ] || truncate -s "${VG_SIZE}" "$img"
+loop=$(losetup -j "$img" | awk -F: "NR==1{print \$1}")
+[ -n "$loop" ] || loop=$(losetup -f --show "$img")
+echo "using loop device $loop"
 
-if ! pvs --noheadings -o pv_name "${LOOP}" >/dev/null 2>&1; then
-    pvcreate -ff -y "${LOOP}"
-fi
-
-vgcreate --addtag "${VG_TAG}" "${VG_NAME}" "${LOOP}"
+pvs --noheadings -o pv_name "$loop" >/dev/null 2>&1 || pvcreate -ff -y "$loop"
+vgcreate --addtag "${VG_TAG}" "${VG_NAME}" "$loop"
 vgs "${VG_NAME}"
-INNER
-}
+'
 
-teardown_node() {
-    local node="$1"
-    echo ">>> [${node}] removing VG ${VG_NAME}"
-    docker exec -i \
-        -e VG_NAME="${VG_NAME}" \
-        -e IMG_PATH_TEMPLATE="${IMG_PATH_TEMPLATE}" \
-        -e TMPFS_DIR="${TMPFS_DIR}" \
-        "${node}" bash -euo pipefail <<'INNER' || true
-IMG_PATH="${IMG_PATH_TEMPLATE//__HOSTNAME__/$(hostname)}"
-if vgs --noheadings -o vg_name 2>/dev/null | tr -d ' ' | grep -qx "${VG_NAME}"; then
+# shellcheck disable=SC2016
+teardown_script='
+img=/var/lib/csi-local-vg/$(hostname).img
+if vgs --noheadings -o vg_name 2>/dev/null | grep -qw "${VG_NAME}"; then
     vgchange -an "${VG_NAME}" || true
     vgremove -ff -y "${VG_NAME}" || true
 fi
-LOOP=$(losetup -j "${IMG_PATH}" 2>/dev/null | awk -F: 'NR==1{print $1}')
-if [ -n "${LOOP}" ]; then
-    pvremove -ff -y "${LOOP}" 2>/dev/null || true
-    losetup -d "${LOOP}" || true
-fi
-rm -f "${IMG_PATH}"
-if mountpoint -q "${TMPFS_DIR}"; then
-    umount "${TMPFS_DIR}" || true
-fi
-INNER
-}
+loop=$(losetup -j "$img" 2>/dev/null | awk -F: "NR==1{print \$1}")
+[ -z "$loop" ] || { pvremove -ff -y "$loop" 2>/dev/null || true; losetup -d "$loop" || true; }
+rm -f "$img"
+'
 
 for node in ${nodes}; do
-    if [[ "${ACTION}" == "teardown" ]]; then
-        teardown_node "${node}"
+    echo ">>> [${node}] ${action} VG ${VG_NAME} (${VG_SIZE})"
+    if [[ "${action}" == "teardown" ]]; then
+        run_on_node "${node}" <<<"${teardown_script}" || true
     else
-        setup_node "${node}"
+        run_on_node "${node}" <<<"${setup_script}"
     fi
 done
 

--- a/test/e2e/lvm_storagepool_test.go
+++ b/test/e2e/lvm_storagepool_test.go
@@ -46,6 +46,11 @@ var testLvmStoragePool = func() {
 }
 
 // lvmStatefulsetTest applies a statefulset fixture and waits for it to be ready.
+//
+// Labeled "aks" because the post-provision assertions count Microsoft NVMe
+// Direct Disks via getDiskCount and require pv count and LV stripe count to
+// match the number of NVMe disks. On clusters backed by loopback devices
+// (e.g. kind) those assertions cannot hold.
 func lvmStatefulsetTest(name, statefulsetFixture string) {
 	It(name, Label("aks"), func(ctx context.Context) {
 		cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", statefulsetFixture)
@@ -148,7 +153,7 @@ func lvmWebhookRejectTest(name, fixture string) {
 // lvmHyperconvergedTest make sure that pod scheduled second time for
 // annotation PVC ends up on the same node.
 func lvmHyperconvergedTest(name, pvcFixture, podFixture string) {
-	It(name, Label("aks"), func(ctx context.Context) {
+	It(name, func(ctx context.Context) {
 		cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", pvcFixture)
 		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "pvc should be created")

--- a/test/external/external_suite_test.go
+++ b/test/external/external_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +23,12 @@ import (
 )
 
 const namespace = "kube-system"
+
+// externalE2EHelmArgs disables the driver's pod-termination LVM cleanup
+// and the lvGarbageCollection/lvmOrphanCleanup controllers. Otherwise a
+// daemonset rollout (or graceful pod restart) can wipe the kind VG mid-suite,
+// causing CreateVolume RPCs to fail with "0 capacity" / "no devices found".
+const externalE2EHelmArgs = "--set cleanup.enabled=false --set cleanup.lvGarbageCollection.enabled=false --set cleanup.lvmOrphanCleanup.enabled=false"
 
 var (
 
@@ -64,7 +71,8 @@ func TestExternalE2E(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 	By("Installing csi driver and other required components")
-	common.Setup(ctx, namespace)
+	merged := "HELM_ARGS=" + strings.TrimSpace(os.Getenv("HELM_ARGS")+" "+externalE2EHelmArgs)
+	common.Setup(ctx, namespace, merged)
 	DeferCleanup(func(ctx context.Context) {
 		common.Teardown(ctx, namespace, *supportBundleDir)
 	})

--- a/test/external/external_suite_test.go
+++ b/test/external/external_suite_test.go
@@ -24,11 +24,12 @@ import (
 
 const namespace = "kube-system"
 
-// externalE2EHelmArgs disables the driver's pod-termination LVM cleanup
-// and the lvGarbageCollection/lvmOrphanCleanup controllers. Otherwise a
-// daemonset rollout (or graceful pod restart) can wipe the kind VG mid-suite,
-// causing CreateVolume RPCs to fail with "0 capacity" / "no devices found".
-const externalE2EHelmArgs = "--set cleanup.enabled=false --set cleanup.lvGarbageCollection.enabled=false --set cleanup.lvmOrphanCleanup.enabled=false"
+// externalE2EHelmArgs disables the driver's pod-termination LVM cleanup so
+// that a daemonset rollout (or graceful pod restart) does not wipe the kind
+// VG mid-suite. We deliberately keep lvGarbageCollection and lvmOrphanCleanup
+// enabled - those reclaim leaked LVs and are needed to keep the VG from
+// filling up under parallel ephemeral-volume tests.
+const externalE2EHelmArgs = "--set cleanup.enabled=false"
 
 var (
 

--- a/test/external/external_test.go
+++ b/test/external/external_test.go
@@ -64,13 +64,13 @@ type testConfig struct {
 var testConfigs = []testConfig{
 	{
 		driverPath:         path.Join("test", "external", "drivers", "lvm.yaml"),
-		labels:             Label("aks", "lvm", "external-e2e"),
+		labels:             Label("lvm", "external-e2e"),
 		testSuiteName:      "lvm External E2E Test Suite",
 		supportTestPattern: "Generic Ephemeral-volume",
 	},
 	{
 		driverPath:    path.Join("test", "external", "drivers", "lvm.yaml"),
-		labels:        Label("aks", "lvm-annotation", "external-e2e"),
+		labels:        Label("lvm-annotation", "external-e2e"),
 		testSuiteName: "lvm-annotation External E2E Test Suite",
 		setup: func(ctx context.Context) {
 			By("setting up installing kyverno")

--- a/test/sanity/fixtures/socat-patch.yaml
+++ b/test/sanity/fixtures/socat-patch.yaml
@@ -1,48 +1,23 @@
-# This patch will add a socat container to the pod that listens on TCP port 10000 and forwards the traffic to the CSI
-# socket. This is useful for debugging the CSI driver using the csi-sanity tool.
-# Example: kubectl patch deployments.apps -n kube-system cns-cluster-manager --patch-file ./test/sanity/fixtures/agent-patch.yaml
+# This patch adds a socat sidecar to the csi-local-node daemonset so
+# csi-sanity can talk to the CSI socket over TCP port 10000.
+#
+# We use the prebuilt alpine/socat image so the sidecar starts without
+# installing socat at runtime. The previous approach pulled
+# mcr.microsoft.com/azurelinux/base/core and ran `tdnf install socat`
+# against packages.microsoft.com from inside an init container, which
+# was unreliable in kind clusters on CI (CoreDNS cold-start + double-NAT
+# to the host caused the init container to hang for >10 minutes).
+#
+# Example:
+#   kubectl patch daemonsets.apps -n kube-system csi-local-node \
+#     --patch-file ./test/sanity/fixtures/socat-patch.yaml
 spec:
   template:
     spec:
-      initContainers:
-      - name: init-socat
-        image: mcr.microsoft.com/azurelinux/base/core:3.0
-        command:
-          - /bin/sh
-          - -c
-          - |
-            set -e
-            # Wait for cluster DNS to resolve the package mirror before
-            # invoking tdnf. Without this, on slow/just-started clusters
-            # (e.g. CI) tdnf can hit "Could not resolve hostname" and
-            # crash the init container, which then sits in CrashLoopBackOff
-            # for the rest of the test.
-            host=packages.microsoft.com
-            for i in $(seq 1 60); do
-              if getent hosts "$host" >/dev/null 2>&1; then
-                echo "DNS resolved $host after $i attempt(s)"
-                break
-              fi
-              echo "waiting for DNS to resolve $host ($i/60)"
-              sleep 2
-            done
-            getent hosts "$host" >/dev/null || {
-              echo "ERROR: DNS still cannot resolve $host" >&2
-              cat /etc/resolv.conf >&2 || true
-              exit 1
-            }
-            tdnf install -y --releasever 3.0 --installroot /shared \
-              socat \
-              && tdnf clean all \
-              && rm -rf /staging/run /staging/var/log /staging/var/cache/tdnf
-        volumeMounts:
-        - mountPath: /shared
-          name: shared-dir
       containers:
       - name: socat-csi
-        image: mcr.microsoft.com/azurelinux/base/core:3.0
-        command:
-          - /shared/usr/bin/socat
+        image: alpine/socat:1.8.0.3
+        imagePullPolicy: IfNotPresent
         args:
           - tcp-listen:10000,fork,reuseaddr
           - unix-connect:/csi/csi.sock
@@ -51,8 +26,3 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: csi-socket-dir
-        - mountPath: /shared
-          name: shared-dir
-      volumes:
-      - name: shared-dir
-        emptyDir: {}

--- a/test/sanity/fixtures/socat-patch.yaml
+++ b/test/sanity/fixtures/socat-patch.yaml
@@ -11,6 +11,26 @@ spec:
           - /bin/sh
           - -c
           - |
+            set -e
+            # Wait for cluster DNS to resolve the package mirror before
+            # invoking tdnf. Without this, on slow/just-started clusters
+            # (e.g. CI) tdnf can hit "Could not resolve hostname" and
+            # crash the init container, which then sits in CrashLoopBackOff
+            # for the rest of the test.
+            host=packages.microsoft.com
+            for i in $(seq 1 60); do
+              if getent hosts "$host" >/dev/null 2>&1; then
+                echo "DNS resolved $host after $i attempt(s)"
+                break
+              fi
+              echo "waiting for DNS to resolve $host ($i/60)"
+              sleep 2
+            done
+            getent hosts "$host" >/dev/null || {
+              echo "ERROR: DNS still cannot resolve $host" >&2
+              cat /etc/resolv.conf >&2 || true
+              exit 1
+            }
             tdnf install -y --releasever 3.0 --installroot /shared \
               socat \
               && tdnf clean all \

--- a/test/sanity/sanity_suite_test.go
+++ b/test/sanity/sanity_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,10 +29,16 @@ const (
 	// controllerDs is the resource name used in kubectl commands for the node.
 	controllerDs = "daemonsets/csi-local-node"
 
-	// helmArgs is the environment variable used to pass extra arguments to
-	// helm during installation of the csi driver. We need to disable cleanup,
-	// PV garbage collection, and LVM orphan cleanup for the sanity tests.
-	helmArgs = "HELM_ARGS=--set cleanup.lvGarbageCollection.enabled=false --set cleanup.lvmOrphanCleanup.enabled=false"
+	// helmArgs is the make-style HELM_ARGS argument passed to `make deploy`
+	// to disable cleanup, PV garbage collection, and LVM orphan cleanup for
+	// the sanity tests. Any HELM_ARGS already present in the environment
+	// (e.g. set by CI to pin pullPolicy=IfNotPresent) is preserved by
+	// prepending it - later --set flags win in helm.
+	// cleanup.enabled is also disabled so that pod-termination cleanup
+	// does not destroy the volume group when the daemonset is patched to
+	// add the socat sidecar (which causes a rollout that SIGTERMs the
+	// original pod).
+	sanityHelmArgs = "--set cleanup.enabled=false --set cleanup.lvGarbageCollection.enabled=false --set cleanup.lvmOrphanCleanup.enabled=false"
 )
 
 var (
@@ -84,7 +91,8 @@ func TestCSISanity(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 	By("Installing csi driver and other required components")
-	common.Setup(ctx, namespace, helmArgs)
+	merged := "HELM_ARGS=" + strings.TrimSpace(os.Getenv("HELM_ARGS")+" "+sanityHelmArgs)
+	common.Setup(ctx, namespace, merged)
 	DeferCleanup(func(ctx context.Context) {
 		common.Teardown(ctx, namespace, *supportBundleDir)
 	})
@@ -127,7 +135,7 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 
 }, func() {
 	_, _ = fmt.Fprintf(GinkgoWriter, "Finished installing csi driver and other required components\n")
-})
+}, NodeTimeout(10*time.Minute))
 
 var _ = AfterEach(func(ctx context.Context) {
 	common.CollectSupportBundle(ctx, *supportBundleDir)

--- a/test/sanity/sanity_suite_test.go
+++ b/test/sanity/sanity_suite_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"local-csi-driver/test/pkg/common"
+	"local-csi-driver/test/pkg/kind"
 	"local-csi-driver/test/pkg/utils"
 )
 
@@ -47,6 +48,11 @@ var (
 
 	// socatPatch is the path to the socat patch file.
 	socatPatch = filepath.Join("test", "sanity", "fixtures", "socat-patch.yaml")
+
+	// socatImage must match the image used by socatPatch. We preload it
+	// into kind clusters so the patched daemonset does not have to pull
+	// it from Docker Hub through kind's NAT, which is unreliable on CI.
+	socatImage = "alpine/socat:1.8.0.3"
 
 	// junitReport is the report file generated for consumption by test framework.
 	junitReport = flag.String("junit-report", "junit.xml", "Path to the junit report")
@@ -96,6 +102,12 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 	DeferCleanup(func(ctx context.Context) {
 		common.Teardown(ctx, namespace, *supportBundleDir)
 	})
+
+	if kind.IsCluster() {
+		By("Preloading " + socatImage + " into the kind cluster")
+		Expect(kind.LoadImageWithName(ctx, socatImage)).To(Succeed(),
+			"failed to preload %s into kind", socatImage)
+	}
 
 	By("Applying socat patch to node and controller")
 	for _, component := range []string{controllerDs} {

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -49,7 +49,7 @@ type testConfig struct {
 var TestConfigs = []testConfig{
 	{
 		testSuiteName:         "lvm CSI Sanity Suite",
-		labels:                Label("aks", "lvm", "sanity"),
+		labels:                Label("lvm", "sanity"),
 		controllerAddressPort: "10001",
 		socatPort:             "10000",
 		skips: []string{


### PR DESCRIPTION
This change add sanity and external-e2e tests to every PR run on kind clusters (no azure access). This can be executed on PRs from forks with no permissions needed on the repo.


AI Summary
-----------

This pull request introduces several improvements to the Kind-based integration test workflow and related test infrastructure. The most significant changes are the addition of a robust script to pre-create an LVM volume group on each Kind node, new options to configure Kind clusters for tests, and refactoring of test job definitions to support multiple test suites and configurations. There are also targeted test fixes and simplifications to improve reliability and clarity.

**Kind Cluster Setup & LVM Volume Group Management:**
- Added a new script `hack/kind-setup-vg.sh` to automate the creation and teardown of a loop-backed LVM volume group on each Kind node, enabling tests that require persistent storage to run in CI without real NVMe hardware.
- Updated the `Makefile` with `kind-setup-vg`, `kind-teardown-vg`, and `kind-e2e-bootstrap` targets to leverage the new script for cluster preparation and cleanup.

**Test Runner Enhancements:**
- Extended `.github/workflows/scripts/run_tests.py` to accept `--kind-nodes` and `--kind-setup-vg` arguments, allowing dynamic selection of single/multi-node clusters and optional LVM VG setup. The `KindCluster` class and cluster creation logic were updated accordingly. The script now also returns an exit code for better CI integration. [[1]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1R13) [[2]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1R231-R258) [[3]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1L428-R449) [[4]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1R530-R551) [[5]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1R615-R616) [[6]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1L486-R507) [[7]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1L916-R961)

**CI Workflow Refactoring:**
- Refactored `.github/workflows/test-e2e-pr.yml` to define a matrix of Kind-based tests (E2E, external E2E, and sanity), each with specific arguments and Helm overrides. Jobs are now named dynamically, and Kind cluster creation is explicitly separated. [[1]](diffhunk://#diff-9a93506f97e62db8ec3b1b9d6bfa83f7dd343544a3ca27f29d8d8e8432fbef59L36-R38) [[2]](diffhunk://#diff-9a93506f97e62db8ec3b1b9d6bfa83f7dd343544a3ca27f29d8d8e8432fbef59R49-R71) [[3]](diffhunk://#diff-9a93506f97e62db8ec3b1b9d6bfa83f7dd343544a3ca27f29d8d8e8432fbef59L91) [[4]](diffhunk://#diff-9a93506f97e62db8ec3b1b9d6bfa83f7dd343544a3ca27f29d8d8e8432fbef59R135-R162)

**Test Suite Fixes and Improvements:**
- Marked certain LVM tests as "aks" only, clarifying that they require NVMe hardware and should not run on Kind clusters. [[1]](diffhunk://#diff-a6d50610904c89694d8159f6716f041778e5d8fd51965fb0605bf65486e4cb40R49-R53) [[2]](diffhunk://#diff-a6d50610904c89694d8159f6716f041778e5d8fd51965fb0605bf65486e4cb40L151-R156) [[3]](diffhunk://#diff-f1f0a91cfad6fc878110a36426ffd3f49ed27e3edde79b160ded49d95d700a31L67-R73)
- Improved the sanity test socat patch to use a prebuilt `alpine/socat` image, eliminating the need for unreliable runtime installation in CI. [[1]](diffhunk://#diff-176939f78782176b6638e640c21df51087d45148814f148731d22f8e63edf81eL1-R20) [[2]](diffhunk://#diff-176939f78782176b6638e640c21df51087d45148814f148731d22f8e63edf81eL34-L38)

**Minor Improvements:**
- Added `strings` import in `test/sanity/sanity_suite_test.go` for future or existing string manipulation needs.
- Updated the `test-sanity` Makefile target to add `--fail-fast` for quicker feedback on failures.