### PR TITLE
Fix NodeExpandVolume

### DIFF
--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -78,6 +78,12 @@ var (
 	// exist.
 	CapacityParam = DriverName + "/capacity"
 	LimitParam    = DriverName + "/limit"
+
+	// ExpandedCapacityParam is a PV annotation key set after a successful
+	// NodeExpandVolume. It records the actual LV size after expansion so that
+	// failover-driven recovery in NodeStageVolume can recreate the volume at
+	// the expanded size instead of the immutable create-time CapacityParam.
+	ExpandedCapacityParam = DriverName + "/expanded-capacity"
 )
 
 var (

--- a/internal/csi/core/lvm/node.go
+++ b/internal/csi/core/lvm/node.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"local-csi-driver/internal/csi/capability"
 	"local-csi-driver/internal/pkg/events"
@@ -117,9 +118,21 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 		recorder.Eventf(corev1.EventTypeWarning, expandingLogicalVolumeFailed, "Failed to expand volume %s/%s to %d: %v", id.VolumeGroup, id.LogicalVolume, capacityRequest.Value(), err)
 		return nil, err
 	}
-	recorder.Eventf(corev1.EventTypeNormal, expandedLogicalVolume, "Expanded volume %s/%s to %d", id.VolumeGroup, id.LogicalVolume, capacityRequest.Value())
+
+	// Re-query the LV to get the actual allocated size after extend,
+	// Fall back to the requested size if the query fails; the expand itself
+	// already succeeded.
+	actualSize := req.GetCapacityRange().GetRequiredBytes()
+	expandedLV, err := l.lvm.GetLogicalVolume(ctx, id.VolumeGroup, id.LogicalVolume)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to get volume after expand, using requested size", "volumeId", req.GetVolumeId())
+	} else {
+		actualSize = int64(expandedLV.Size)
+	}
+
+	recorder.Eventf(corev1.EventTypeNormal, expandedLogicalVolume, "Expanded volume %s/%s to %d", id.VolumeGroup, id.LogicalVolume, actualSize)
 	return &csi.NodeExpandVolumeResponse{
-		CapacityBytes: req.GetCapacityRange().GetRequiredBytes(),
+		CapacityBytes: actualSize,
 	}, nil
 }
 

--- a/internal/csi/core/lvm/node.go
+++ b/internal/csi/core/lvm/node.go
@@ -96,15 +96,15 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 		}
 	}
 
-	// Check if the requested size is greater than the current size.
+	// Check if the requested size is less than the current size.
 	if capacityRequest.CmpInt64(int64(lv.Size)) < 0 {
 		span.SetStatus(codes.Error, "requested size is less than current size")
 		return nil, status.Errorf(grpcCodes.FailedPrecondition, "requested size %d is less than current size %d", capacityRequest.Value(), lv.Size)
 	}
 
-	// Check if the volume is already expanded.
-	if capacityRequest.CmpInt64(int64(lv.Size)) >= 0 {
-		span.SetStatus(codes.Error, "volume is already expanded")
+	// Check if the volume is already at the requested size.
+	if capacityRequest.CmpInt64(int64(lv.Size)) == 0 {
+		span.SetStatus(codes.Ok, "volume is already at the requested size")
 		return &csi.NodeExpandVolumeResponse{
 			CapacityBytes: req.GetCapacityRange().GetRequiredBytes(),
 		}, nil

--- a/internal/csi/core/lvm/node.go
+++ b/internal/csi/core/lvm/node.go
@@ -5,6 +5,7 @@ package lvm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -13,7 +14,6 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"local-csi-driver/internal/csi/capability"
 	"local-csi-driver/internal/pkg/events"
@@ -97,17 +97,10 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 		}
 	}
 
-	// Check if the requested size is less than the current size.
-	if capacityRequest.CmpInt64(int64(lv.Size)) < 0 {
-		span.SetStatus(codes.Error, "requested size is less than current size")
-		return nil, status.Errorf(grpcCodes.FailedPrecondition, "requested size %d is less than current size %d", capacityRequest.Value(), lv.Size)
-	}
-
-	// Check if the volume is already at the requested size.
-	if capacityRequest.CmpInt64(int64(lv.Size)) == 0 {
-		span.SetStatus(codes.Ok, "volume is already at the requested size")
+	if capacityRequest.CmpInt64(int64(lv.Size)) <= 0 {
+		span.SetStatus(codes.Ok, "volume is already at or above the requested size")
 		return &csi.NodeExpandVolumeResponse{
-			CapacityBytes: req.GetCapacityRange().GetRequiredBytes(),
+			CapacityBytes: int64(lv.Size),
 		}, nil
 	}
 
@@ -116,19 +109,19 @@ func (l *LVM) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeReq
 	if err := l.lvm.ExtendLogicalVolume(ctx, extendOps); err != nil {
 		span.SetStatus(codes.Error, "unable to expand volume")
 		recorder.Eventf(corev1.EventTypeWarning, expandingLogicalVolumeFailed, "Failed to expand volume %s/%s to %d: %v", id.VolumeGroup, id.LogicalVolume, capacityRequest.Value(), err)
-		return nil, err
+		if errors.Is(err, lvm.ErrResourceExhausted) {
+			return nil, status.Error(grpcCodes.OutOfRange, err.Error())
+		}
+		return nil, status.Errorf(grpcCodes.Internal, "failed to expand volume: %v", err)
 	}
 
-	// Re-query the LV to get the actual allocated size after extend,
-	// Fall back to the requested size if the query fails; the expand itself
-	// already succeeded.
-	actualSize := req.GetCapacityRange().GetRequiredBytes()
+	// Re-query the LV to get the actual allocated size after extend.
 	expandedLV, err := l.lvm.GetLogicalVolume(ctx, id.VolumeGroup, id.LogicalVolume)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to get volume after expand, using requested size", "volumeId", req.GetVolumeId())
-	} else {
-		actualSize = int64(expandedLV.Size)
+		span.SetStatus(codes.Error, "failed to get volume after expand")
+		return nil, status.Errorf(grpcCodes.Internal, "failed to get volume after expand: %v", err)
 	}
+	actualSize := int64(expandedLV.Size)
 
 	recorder.Eventf(corev1.EventTypeNormal, expandedLogicalVolume, "Expanded volume %s/%s to %d", id.VolumeGroup, id.LogicalVolume, actualSize)
 	return &csi.NodeExpandVolumeResponse{

--- a/internal/csi/core/lvm/node_test.go
+++ b/internal/csi/core/lvm/node_test.go
@@ -87,7 +87,7 @@ func TestNodeExpandVolume(t *testing.T) {
 			expectErrCode: codes.NotFound,
 		},
 		{
-			name: "requested less than current returns FailedPrecondition",
+			name: "requested less than current returns OK with actual size",
 			req: &csi.NodeExpandVolumeRequest{
 				VolumeId:      testVolumeID,
 				CapacityRange: &csi.CapacityRange{RequiredBytes: smallerSize},
@@ -98,8 +98,8 @@ func TestNodeExpandVolume(t *testing.T) {
 					Times(1)
 				// ExtendLogicalVolume must NOT be called.
 			},
-			expectErr:     true,
-			expectErrCode: codes.FailedPrecondition,
+			expectResp:     true,
+			expectCapacity: currentSize,
 		},
 		{
 			name: "requested equals current is idempotent no-op",
@@ -148,7 +148,7 @@ func TestNodeExpandVolume(t *testing.T) {
 			expectCapacity: expandedSize,
 		},
 		{
-			name: "re-query failure after extend falls back to requested size",
+			name: "re-query failure after extend returns error",
 			req: &csi.NodeExpandVolumeRequest{
 				VolumeId:      testVolumeID,
 				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
@@ -167,8 +167,8 @@ func TestNodeExpandVolume(t *testing.T) {
 					Times(1).
 					After(second)
 			},
-			expectResp:     true,
-			expectCapacity: expandedSize,
+			expectErr:     true,
+			expectErrCode: codes.Internal,
 		},
 		{
 			name: "requested greater with mount capability sets ResizeFS",
@@ -202,6 +202,25 @@ func TestNodeExpandVolume(t *testing.T) {
 			},
 			expectResp:     true,
 			expectCapacity: expandedSize,
+		},
+		{
+			name: "extend returns ErrResourceExhausted maps to OutOfRange",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				first := m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
+					Times(1)
+				m.EXPECT().
+					ExtendLogicalVolume(gomock.Any(), gomock.AssignableToTypeOf(lvmMgr.ExtendLVOptions{})).
+					Return(lvmMgr.ErrResourceExhausted).
+					Times(1).
+					After(first)
+			},
+			expectErr:     true,
+			expectErrCode: codes.OutOfRange,
 		},
 	}
 

--- a/internal/csi/core/lvm/node_test.go
+++ b/internal/csi/core/lvm/node_test.go
@@ -123,10 +123,10 @@ func TestNodeExpandVolume(t *testing.T) {
 				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
 			},
 			expectLvm: func(m *lvmMgr.MockManager) {
-				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+				first := m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
 					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
 					Times(1)
-				m.EXPECT().
+				second := m.EXPECT().
 					ExtendLogicalVolume(gomock.Any(), gomock.AssignableToTypeOf(lvmMgr.ExtendLVOptions{})).
 					DoAndReturn(func(_ context.Context, opts lvmMgr.ExtendLVOptions) error {
 						if opts.Name != expandLVName {
@@ -137,7 +137,35 @@ func TestNodeExpandVolume(t *testing.T) {
 						}
 						return nil
 					}).
+					Times(1).
+					After(first)
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(expandedSize)}, nil).
+					Times(1).
+					After(second)
+			},
+			expectResp:     true,
+			expectCapacity: expandedSize,
+		},
+		{
+			name: "re-query failure after extend falls back to requested size",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				first := m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
 					Times(1)
+				second := m.EXPECT().
+					ExtendLogicalVolume(gomock.Any(), gomock.AssignableToTypeOf(lvmMgr.ExtendLVOptions{})).
+					Return(nil).
+					Times(1).
+					After(first)
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(nil, lvmMgr.ErrNotFound).
+					Times(1).
+					After(second)
 			},
 			expectResp:     true,
 			expectCapacity: expandedSize,
@@ -154,10 +182,10 @@ func TestNodeExpandVolume(t *testing.T) {
 				},
 			},
 			expectLvm: func(m *lvmMgr.MockManager) {
-				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+				first := m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
 					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
 					Times(1)
-				m.EXPECT().
+				second := m.EXPECT().
 					ExtendLogicalVolume(gomock.Any(), gomock.AssignableToTypeOf(lvmMgr.ExtendLVOptions{})).
 					DoAndReturn(func(_ context.Context, opts lvmMgr.ExtendLVOptions) error {
 						if !opts.ResizeFS {
@@ -165,7 +193,12 @@ func TestNodeExpandVolume(t *testing.T) {
 						}
 						return nil
 					}).
-					Times(1)
+					Times(1).
+					After(first)
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(expandedSize)}, nil).
+					Times(1).
+					After(second)
 			},
 			expectResp:     true,
 			expectCapacity: expandedSize,

--- a/internal/csi/core/lvm/node_test.go
+++ b/internal/csi/core/lvm/node_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	lvmMgr "local-csi-driver/internal/pkg/lvm"
+)
+
+// TestNodeExpandVolume covers the size-comparison branches of
+// NodeExpandVolume. It exists primarily to catch the regression where the
+// `requested > current` case was unreachable (`>=` vs `==` typo) and
+// ExtendLogicalVolume was never invoked.
+func TestNodeExpandVolume(t *testing.T) {
+	t.Parallel()
+
+	const (
+		testVG        = "containerstorage"
+		testLV        = "pv-test"
+		testVolumeID  = testVG + "#" + testLV
+		currentSize   = int64(20 * 1024 * 1024 * 1024)   // 20 GiB
+		expandedSize  = int64(1700 * 1024 * 1024 * 1024) // 1700 GiB
+		smallerSize   = int64(10 * 1024 * 1024 * 1024)   // 10 GiB
+		expandLVName  = testVG + "/" + testLV
+		expandLVSizeS = "1700Gi"
+	)
+
+	tests := []struct {
+		name           string
+		req            *csi.NodeExpandVolumeRequest
+		expectLvm      func(*lvmMgr.MockManager)
+		expectErrCode  codes.Code
+		expectErr      bool
+		expectResp     bool
+		expectCapacity int64
+	}{
+		{
+			name: "missing volume id",
+			req: &csi.NodeExpandVolumeRequest{
+				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
+			},
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "invalid volume id format",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      "not-a-valid-id",
+				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
+			},
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing capacity range",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId: testVolumeID,
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
+					Times(1)
+			},
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "volume not found",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(nil, lvmMgr.ErrNotFound).
+					Times(1)
+			},
+			expectErr:     true,
+			expectErrCode: codes.NotFound,
+		},
+		{
+			name: "requested less than current returns FailedPrecondition",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: smallerSize},
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
+					Times(1)
+				// ExtendLogicalVolume must NOT be called.
+			},
+			expectErr:     true,
+			expectErrCode: codes.FailedPrecondition,
+		},
+		{
+			name: "requested equals current is idempotent no-op",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: currentSize},
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
+					Times(1)
+				// ExtendLogicalVolume must NOT be called.
+			},
+			expectResp:     true,
+			expectCapacity: currentSize,
+		},
+		{
+			name: "requested greater than current invokes ExtendLogicalVolume exactly once",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
+					Times(1)
+				m.EXPECT().
+					ExtendLogicalVolume(gomock.Any(), gomock.AssignableToTypeOf(lvmMgr.ExtendLVOptions{})).
+					DoAndReturn(func(_ context.Context, opts lvmMgr.ExtendLVOptions) error {
+						if opts.Name != expandLVName {
+							t.Errorf("ExtendLogicalVolume Name = %q, want %q", opts.Name, expandLVName)
+						}
+						if opts.Size != expandLVSizeS {
+							t.Errorf("ExtendLogicalVolume Size = %q, want %q", opts.Size, expandLVSizeS)
+						}
+						return nil
+					}).
+					Times(1)
+			},
+			expectResp:     true,
+			expectCapacity: expandedSize,
+		},
+		{
+			name: "requested greater with mount capability sets ResizeFS",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: expandedSize},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+			},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), testVG, testLV).
+					Return(&lvmMgr.LogicalVolume{Name: testLV, Size: lvmMgr.Int64String(currentSize)}, nil).
+					Times(1)
+				m.EXPECT().
+					ExtendLogicalVolume(gomock.Any(), gomock.AssignableToTypeOf(lvmMgr.ExtendLVOptions{})).
+					DoAndReturn(func(_ context.Context, opts lvmMgr.ExtendLVOptions) error {
+						if !opts.ResizeFS {
+							t.Errorf("ExtendLogicalVolume ResizeFS = false, want true for mount access type")
+						}
+						return nil
+					}).
+					Times(1)
+			},
+			expectResp:     true,
+			expectCapacity: expandedSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			l, _, m, err := initTestLVM(ctrl)
+			if err != nil {
+				t.Fatalf("failed to initialize LVM: %v", err)
+			}
+			if tt.expectLvm != nil {
+				tt.expectLvm(m)
+			}
+
+			resp, err := l.NodeExpandVolume(context.Background(), tt.req)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("NodeExpandVolume() error = nil, want gRPC code %v", tt.expectErrCode)
+				}
+				if st, ok := status.FromError(err); !ok || st.Code() != tt.expectErrCode {
+					t.Fatalf("NodeExpandVolume() error code = %v, want %v (err=%v)", st.Code(), tt.expectErrCode, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NodeExpandVolume() unexpected error: %v", err)
+			}
+			if !tt.expectResp {
+				return
+			}
+			if resp == nil {
+				t.Fatalf("NodeExpandVolume() resp = nil, want non-nil")
+			}
+			if resp.GetCapacityBytes() != tt.expectCapacity {
+				t.Errorf("NodeExpandVolume() CapacityBytes = %d, want %d", resp.GetCapacityBytes(), tt.expectCapacity)
+			}
+		})
+	}
+}

--- a/internal/csi/identity/identity.go
+++ b/internal/csi/identity/identity.go
@@ -55,7 +55,13 @@ func (ids *Server) GetPluginCapabilities(ctx context.Context, req *csi.GetPlugin
 					},
 				},
 			},
-			// TODO(sc): volume expansion, and?
+			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/internal/csi/node/node.go
+++ b/internal/csi/node/node.go
@@ -587,6 +587,17 @@ func (ns *Server) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	// TODO: a failover-driven reprovisioning  recreates the LV at the expanded size
+	// instead of the original create-time size.
+	// As getCapacityAndLimit takes the capacity from the PV's CapacityParam
+	// (pv.spec.csi.volumeAttributes["localdisk.csi.acstor.io/capacity"]) which is
+	// immutable, after PV creation the PV will always have the original size.
+	//
+	// Consequence: if the node loses its disks after an expansion and
+	// NodeStageVolume triggers a recovery via NodeEnsureVolume, the LV will be
+	// recreated at the *original* create-time size from CapacityParam, not at
+	// the expanded size.
+
 	log.V(2).Info("NodeExpandVolume resized volume")
 	span.SetStatus(otcodes.Ok, "resized volume")
 	return resp, nil

--- a/internal/csi/node/node.go
+++ b/internal/csi/node/node.go
@@ -422,7 +422,7 @@ func (ns *Server) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeR
 		// volumes is acceptable for local volumes.
 
 		// Get the capacity request from the PV attributes.
-		capacityBytes, limitBytes, err := getCapacityAndLimit(pv.Spec.CSI.VolumeAttributes)
+		capacityBytes, limitBytes, err := getCapacityAndLimit(pv.Spec.CSI.VolumeAttributes, pv.Annotations)
 		if err != nil {
 			log.Error(err, "failed to get capacity and limit from pv attributes")
 			span.SetStatus(otcodes.Error, "failed to get capacity and limit from pv attributes")
@@ -484,8 +484,12 @@ func (ns *Server) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeR
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-// getCapacityAndLimit retrieves the capacity and limit from the PV attributes.
-func getCapacityAndLimit(attrs map[string]string) (capacityBytes, limitBytes int64, err error) {
+// getCapacityAndLimit retrieves the capacity and limit from the PV attributes
+// and annotations. If an expanded-capacity annotation is present (set after
+// NodeExpandVolume), it takes precedence over the immutable volumeAttributes
+// CapacityParam to ensure failover recovery recreates volumes at their
+// expanded size.
+func getCapacityAndLimit(attrs map[string]string, annotations map[string]string) (capacityBytes, limitBytes int64, err error) {
 	c, ok := attrs[lvm.CapacityParam]
 	if !ok {
 		return 0, 0, fmt.Errorf("volume request size is missing in pv attribute %s - recovery impossible", lvm.CapacityParam)
@@ -504,6 +508,18 @@ func getCapacityAndLimit(attrs map[string]string) (capacityBytes, limitBytes int
 			return 0, 0, fmt.Errorf("failed to parse volume limit size from pv attribute %s=%s: %w", lvm.LimitParam, attrs[lvm.LimitParam], err)
 		}
 		limitBytes = limit.Value()
+	}
+
+	// If the PV has been expanded, the expanded-capacity annotation holds the
+	// actual post-expansion LV size. Use it instead of the immutable
+	// create-time CapacityParam.
+	if ec, ok := annotations[lvm.ExpandedCapacityParam]; ok && len(ec) > 0 {
+		expanded, err := resource.ParseQuantity(ec)
+		if err == nil {
+			if expandedBytes := expanded.Value(); expandedBytes > capacityBytes {
+				capacityBytes = expandedBytes
+			}
+		}
 	}
 
 	return capacityBytes, limitBytes, nil
@@ -587,16 +603,19 @@ func (ns *Server) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// TODO: a failover-driven reprovisioning  recreates the LV at the expanded size
-	// instead of the original create-time size.
-	// As getCapacityAndLimit takes the capacity from the PV's CapacityParam
-	// (pv.spec.csi.volumeAttributes["localdisk.csi.acstor.io/capacity"]) which is
-	// immutable, after PV creation the PV will always have the original size.
-	//
-	// Consequence: if the node loses its disks after an expansion and
-	// NodeStageVolume triggers a recovery via NodeEnsureVolume, the LV will be
-	// recreated at the *original* create-time size from CapacityParam, not at
-	// the expanded size.
+	// Persist the actual expanded LV size as a PV annotation so that
+	// failover-driven recovery in NodeStageVolume recreates the volume at the
+	// expanded size.
+	if pv.Name != "" {
+		original := pv.DeepCopy()
+		if pv.Annotations == nil {
+			pv.Annotations = make(map[string]string)
+		}
+		pv.Annotations[lvm.ExpandedCapacityParam] = fmt.Sprint(resp.GetCapacityBytes())
+		if err := ns.k8sClient.Patch(ctx, &pv, client.MergeFrom(original)); err != nil {
+			log.Error(err, "failed to patch PV with expanded capacity annotation")
+		}
+	}
 
 	log.V(2).Info("NodeExpandVolume resized volume")
 	span.SetStatus(otcodes.Ok, "resized volume")

--- a/internal/csi/node/node.go
+++ b/internal/csi/node/node.go
@@ -617,7 +617,7 @@ func (ns *Server) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 		}
 	}
 
-	log.V(2).Info("NodeExpandVolume resized volume")
+	log.V(2).Info("NodeExpandVolume resized volume", "capacityBytes", resp.GetCapacityBytes())
 	span.SetStatus(otcodes.Ok, "resized volume")
 	return resp, nil
 }

--- a/internal/csi/node/node_test.go
+++ b/internal/csi/node/node_test.go
@@ -884,18 +884,18 @@ func TestNodeExpandVolume(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get target test path: %v", err)
 	}
-	t.Cleanup(func() { os.RemoveAll(targetTest) })
+	t.Cleanup(func() { _ = os.RemoveAll(targetTest) })
 	_ = testutil.MakeDir(targetTest)
 
 	tests := []struct {
-		name           string
-		req            *csi.NodeExpandVolumeRequest
-		fakeCapacity   int64
-		fakeErr        error
-		expectErrCode  codes.Code
-		expectErr      bool
-		expectResp     bool
-		expectCapacity int64
+		name            string
+		req             *csi.NodeExpandVolumeRequest
+		fakeCapacity    int64
+		fakeErr         error
+		expectErrCode   codes.Code
+		expectErr       bool
+		expectResp      bool
+		expectCapacity  int64
 		checkAnnotation bool
 	}{
 		{

--- a/internal/csi/node/node_test.go
+++ b/internal/csi/node/node_test.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	testingexec "k8s.io/utils/exec/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"local-csi-driver/internal/csi/capability"
@@ -29,7 +29,6 @@ import (
 	"local-csi-driver/internal/csi/core/lvm"
 	"local-csi-driver/internal/csi/mounter"
 	"local-csi-driver/internal/csi/testutil"
-	"local-csi-driver/internal/pkg/convert"
 	"local-csi-driver/internal/pkg/events"
 	"local-csi-driver/internal/pkg/telemetry"
 )
@@ -874,170 +873,172 @@ func TestNodeGetCapabilities(t *testing.T) {
 }
 
 func TestNodeExpandVolume(t *testing.T) {
-	t.Skip("Skipping test for NodeExpandVolume") // TODO: re-enable this test
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		t.Skipf("not supported on GOOS=%s", runtime.GOOS)
 	}
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	ns := initTestNodeServer(t, ctrl)
 
-	stdCapacityRange := &csi.CapacityRange{
-		RequiredBytes: convert.GiBToBytes(4),
-		LimitBytes:    convert.GiBToBytes(8),
-	}
+	expandCapacity := int64(8 * 1024 * 1024 * 1024) // 8 GiB
 
-	blockVolumePath := "/tmp/block-volume-path"
-	targetTest, err := testutil.GetWorkDirPath("target_test")
+	// Create a real directory for the volume path.
+	targetTest, err := testutil.GetWorkDirPath("expand_target_test")
 	if err != nil {
-		t.Fatalf("failed to get target test path: %v\n", err)
-		os.Exit(1)
+		t.Fatalf("failed to get target test path: %v", err)
 	}
-
-	if err := os.RemoveAll(targetTest); err != nil {
-		t.Fatalf("failed to remove target test path: %v\n", err)
-	}
-	if err := os.RemoveAll(blockVolumePath); err != nil {
-		t.Fatalf("failed to remove block volume path: %v\n", err)
-	}
+	t.Cleanup(func() { os.RemoveAll(targetTest) })
 	_ = testutil.MakeDir(targetTest)
-	_ = testutil.MakeDir(blockVolumePath)
-
-	notFoundErr := status.Error(codes.NotFound, "exit status 1")
-	getSizeErr := status.Errorf(codes.Internal, "Failed to get volume size")
-	resizeTooSmallErr := status.Errorf(codes.Internal, "Volume size is less than requested size")
-	notFoundErrAction := func() ([]byte, []byte, error) {
-		return []byte{}, []byte{}, notFoundErr
-	}
 
 	tests := []struct {
-		name              string
-		req               *csi.NodeExpandVolumeRequest
-		resp              *csi.NodeExpandVolumeResponse
-		wantMountPointErr bool
-		expectErr         error
-		outputScripts     []testingexec.FakeAction
+		name           string
+		req            *csi.NodeExpandVolumeRequest
+		fakeCapacity   int64
+		fakeErr        error
+		expectErrCode  codes.Code
+		expectErr      bool
+		expectResp     bool
+		expectCapacity int64
+		checkAnnotation bool
 	}{
 		{
-			name:      "Volume ID missing in request",
-			req:       &csi.NodeExpandVolumeRequest{},
-			expectErr: status.Error(codes.InvalidArgument, "Volume ID missing in request"),
-		},
-		{
-			name: "Path not found",
-			req: &csi.NodeExpandVolumeRequest{
-				CapacityRange:     stdCapacityRange,
-				VolumePath:        "./test",
-				VolumeId:          testVolumeID,
-				StagingTargetPath: "test",
-			},
-			expectErr: status.Error(codes.NotFound, "Invalid path"),
+			name:          "Volume ID missing",
+			req:           &csi.NodeExpandVolumeRequest{},
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
 		},
 		{
 			name: "Volume path not provided",
 			req: &csi.NodeExpandVolumeRequest{
-				CapacityRange:     stdCapacityRange,
-				StagingTargetPath: "test",
-				VolumeId:          "test",
+				VolumeId: testVolumeID,
 			},
-			expectErr: status.Error(codes.InvalidArgument, "Volume path must be provided"),
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
 		},
 		{
-			name: "Expand failure",
+			name: "Volume path does not exist",
 			req: &csi.NodeExpandVolumeRequest{
-				CapacityRange:     stdCapacityRange,
-				VolumePath:        targetTest,
-				VolumeId:          testVolumeID,
-				StagingTargetPath: "test",
+				VolumeId:   testVolumeID,
+				VolumePath: "/nonexistent/path",
 			},
-			expectErr:     getSizeErr,
-			outputScripts: []testingexec.FakeAction{notFoundErrAction},
+			expectErr:     true,
+			expectErrCode: codes.NotFound,
 		},
 		{
-			name: "Resize too small failure",
+			name: "Invalid volume ID format",
 			req: &csi.NodeExpandVolumeRequest{
-				CapacityRange:     stdCapacityRange,
-				VolumePath:        targetTest,
-				VolumeId:          testVolumeID,
-				StagingTargetPath: "test",
-			},
-			expectErr: resizeTooSmallErr,
-		},
-		{
-			name: "Successfully expanded",
-			req: &csi.NodeExpandVolumeRequest{
-				CapacityRange:     stdCapacityRange,
-				VolumePath:        targetTest,
-				VolumeId:          testVolumeID,
-				StagingTargetPath: "test",
-			},
-			resp: &csi.NodeExpandVolumeResponse{
-				CapacityBytes: stdCapacityRange.RequiredBytes,
-			},
-		},
-		{
-			name: "Block volume expansion",
-			req: &csi.NodeExpandVolumeRequest{
-				CapacityRange:     stdCapacityRange,
-				VolumePath:        blockVolumePath,
-				VolumeId:          testVolumeID,
-				StagingTargetPath: "test",
-			},
-			resp: &csi.NodeExpandVolumeResponse{},
-		},
-		{
-			name: "Block volume expansion volume capability ignore path",
-			req: &csi.NodeExpandVolumeRequest{
-				CapacityRange:     stdCapacityRange,
-				VolumePath:        targetTest,
-				VolumeId:          testVolumeID,
-				StagingTargetPath: "test",
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Block{
-						Block: &csi.VolumeCapability_BlockVolume{},
-					},
+				VolumeId:   "invalidId",
+				VolumePath: targetTest,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: expandCapacity,
 				},
 			},
-			resp: &csi.NodeExpandVolumeResponse{},
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "Volume expand fails",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:   testVolumeID,
+				VolumePath: targetTest,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: expandCapacity,
+				},
+			},
+			fakeErr:       fmt.Errorf("extend failed"),
+			expectErr:     true,
+			expectErrCode: codes.Internal,
+		},
+		{
+			name: "Successfully expanded with annotation patched",
+			req: &csi.NodeExpandVolumeRequest{
+				VolumeId:   testVolumeID,
+				VolumePath: targetTest,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: expandCapacity,
+				},
+			},
+			fakeCapacity:    expandCapacity,
+			expectResp:      true,
+			expectCapacity:  expandCapacity,
+			checkAnnotation: true,
 		},
 	}
-	for _, test := range tests {
-		var tt = test
+
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mntDir, err := os.MkdirTemp(os.TempDir(), "mount")
-			if err != nil {
-				t.Fatalf("failed to create tmp dir: %v", err)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			vc := core.NewFake()
+			vc.DiskPoolCapacity = tt.fakeCapacity
+			vc.Err = tt.fakeErr
+
+			m := mounter.NewMockMounter(ctrl)
+			r := events.NewNoopRecorder()
+			tp := telemetry.NewNoopTracerProvider()
+			scheme := k8sruntime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+
+			// PV named "pv" matches GetVolumeName("vg#pv") → "pv"
+			pv := corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pv",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       driverName,
+							VolumeHandle: testVolumeID,
+							VolumeAttributes: map[string]string{
+								lvm.CapacityParam: "4Gi",
+							},
+						},
+					},
+				},
 			}
-			defer func() {
-				if err := os.RemoveAll(mntDir); err != nil {
-					t.Errorf("failed to remove tmp dir: %v", err)
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(&pv).
+				Build()
+
+			caps := []*csi.NodeServiceCapability{
+				capability.NewNodeServiceCapability(csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME),
+			}
+			ns := New(vc, testNodeName, selectedNodeAnnotation, selectedInitialNodeParam, driverName, caps, m, k8sClient, true, r, tp)
+
+			resp, err := ns.NodeExpandVolume(context.Background(), tt.req)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("NodeExpandVolume() error = nil, want gRPC code %v", tt.expectErrCode)
 				}
-			}()
-
-			// Prefix staging and target path with tmp path for easy cleanup.
-			req := tt.req
-			if req.StagingTargetPath != "" {
-				req.StagingTargetPath = filepath.Join(mntDir, req.StagingTargetPath)
-			}
-			resp, err := ns.NodeExpandVolume(context.Background(), req)
-
-			if status.Code(err) != status.Code(tt.expectErr) ||
-				(err != nil && err.Error() != tt.expectErr.Error()) {
-				t.Errorf("NodeExpandVolume() error = %v, expected = %v", err, tt.expectErr)
+				if st, ok := status.FromError(err); !ok || st.Code() != tt.expectErrCode {
+					t.Fatalf("NodeExpandVolume() error code = %v, want %v (err=%v)", st.Code(), tt.expectErrCode, err)
+				}
 				return
 			}
-			if !reflect.DeepEqual(resp, tt.resp) {
-				t.Errorf("NodeExpandVolume() resp:\n %+v\n expected:\n %+v", resp, tt.resp)
+			if err != nil {
+				t.Fatalf("NodeExpandVolume() unexpected error: %v", err)
+			}
+			if !tt.expectResp {
 				return
+			}
+			if resp == nil {
+				t.Fatalf("NodeExpandVolume() resp = nil, want non-nil")
+			}
+			if resp.GetCapacityBytes() != tt.expectCapacity {
+				t.Errorf("NodeExpandVolume() CapacityBytes = %d, want %d", resp.GetCapacityBytes(), tt.expectCapacity)
+			}
+
+			// Verify expanded-capacity annotation was written to the PV.
+			if tt.checkAnnotation {
+				var updatedPV corev1.PersistentVolume
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "pv"}, &updatedPV); err != nil {
+					t.Fatalf("failed to get PV after expand: %v", err)
+				}
+				got := updatedPV.Annotations[lvm.ExpandedCapacityParam]
+				want := fmt.Sprint(tt.expectCapacity)
+				if got != want {
+					t.Errorf("PV annotation %s = %q, want %q", lvm.ExpandedCapacityParam, got, want)
+				}
 			}
 		})
-	}
-
-	if err := os.RemoveAll(targetTest); err != nil {
-		t.Fatalf("failed to remove target test path: %v\n", err)
-	}
-	if err := os.RemoveAll(blockVolumePath); err != nil {
-		t.Fatalf("failed to remove block volume path: %v\n", err)
 	}
 }
 
@@ -1356,6 +1357,7 @@ func Test_getCapacityAndLimit(t *testing.T) {
 	tests := []struct {
 		name         string
 		attrs        map[string]string
+		annotations  map[string]string
 		wantCapacity int64
 		wantLimit    int64
 		wantErr      bool
@@ -1416,10 +1418,42 @@ func Test_getCapacityAndLimit(t *testing.T) {
 			wantLimit:    0,
 			wantErr:      false,
 		},
+		{
+			name:         "expanded capacity annotation overrides attrs",
+			attrs:        map[string]string{lvm.CapacityParam: "10737418240"},
+			annotations:  map[string]string{lvm.ExpandedCapacityParam: "11811160064"},
+			wantCapacity: 11811160064,
+			wantLimit:    0,
+			wantErr:      false,
+		},
+		{
+			name:         "expanded capacity annotation smaller than attrs is ignored",
+			attrs:        map[string]string{lvm.CapacityParam: "10737418240"},
+			annotations:  map[string]string{lvm.ExpandedCapacityParam: "5368709120"},
+			wantCapacity: 10737418240,
+			wantLimit:    0,
+			wantErr:      false,
+		},
+		{
+			name:         "invalid expanded capacity annotation falls back to attrs",
+			attrs:        map[string]string{lvm.CapacityParam: "10Gi"},
+			annotations:  map[string]string{lvm.ExpandedCapacityParam: "invalid"},
+			wantCapacity: 10 * 1024 * 1024 * 1024,
+			wantLimit:    0,
+			wantErr:      false,
+		},
+		{
+			name:         "nil annotations uses attrs capacity",
+			attrs:        map[string]string{lvm.CapacityParam: "10Gi"},
+			annotations:  nil,
+			wantCapacity: 10 * 1024 * 1024 * 1024,
+			wantLimit:    0,
+			wantErr:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCapacityBytes, gotLimitBytes, err := getCapacityAndLimit(tt.attrs)
+			gotCapacityBytes, gotLimitBytes, err := getCapacityAndLimit(tt.attrs, tt.annotations)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getCapacityAndLimit() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/test/e2e/lvm_expansion_test.go
+++ b/test/e2e/lvm_expansion_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"local-csi-driver/internal/csi/core/lvm"
+	"local-csi-driver/test/pkg/utils"
+)
+
+const (
+	// expansionPVCTargetSize is the size we resize the PVC to. A 1 GiB bump
+	// is enough to be unambiguous (LVM aligns on 4 MiB extents) while staying
+	// friendly to constrained test environments.
+	expansionPVCTargetSize = "11Gi"
+	// expansionPVCTargetBytes is expansionPVCTargetSize expressed in bytes.
+	// 11 * 1024^3 == 11811160064. Kept in sync with expansionPVCTargetSize.
+	expansionPVCTargetBytes int64 = 11 * 1024 * 1024 * 1024
+)
+
+// lvmExpansionTest exercises the full PVC -> CSI -> lvextend resize path:
+//
+//  1. create the annotation-style PVC + pod and wait for it to be Running so
+//     that the LV exists on disk;
+//  2. patch the PVC storage request to a larger size;
+//  3. assert that the LV on the owning node actually grew (the original bug
+//     was that lvextend was never invoked because the early-return branch
+//     swallowed the request);
+//  4. assert that PVC.status, PV.spec.capacity, and
+//     pv.spec.csi.volumeAttributes[".../capacity"] all reflect the new size
+//     so a subsequent failover-driven re-provisioning recreates the LV at the
+//     expanded size.
+func lvmExpansionTest(name, pvcFixture, podFixture string) {
+	It(name, func(ctx context.Context) {
+		By("applying the PVC fixture")
+		cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", pvcFixture)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply PVC fixture")
+
+		DeferCleanup(func(ctx context.Context) {
+			By("deleting PVC")
+			cmd := exec.CommandContext(ctx, "kubectl", "delete", "--wait", "--ignore-not-found", "-f", pvcFixture)
+			_, _ = utils.Run(cmd)
+		})
+
+		By("applying the pod fixture")
+		cmd = exec.CommandContext(ctx, "kubectl", "apply", "-f", podFixture)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply pod fixture")
+
+		DeferCleanup(func(ctx context.Context) {
+			By("deleting pod")
+			cmd := exec.CommandContext(ctx, "kubectl", "delete", "--wait", "--ignore-not-found", "-f", podFixture)
+			_, _ = utils.Run(cmd)
+		})
+
+		By("waiting for the pod to be Running")
+		Eventually(func(g Gomega, ctx context.Context) {
+			out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pod", "-l", "part-of=e2e-test", "-o", "jsonpath={.items[0].status.phase}"))
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod phase")
+			g.Expect(out).To(Equal("Running"), "Pod should be Running before expansion")
+		}).WithContext(ctx).Should(Succeed(), "Failed to wait for pod to be Running")
+
+		By("looking up the PVC's bound PV and owning node")
+		pvcName, err := getPVCName(ctx, pvcFixture)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read PVC name from fixture")
+
+		var pvName, nodeName string
+		Eventually(func(g Gomega, ctx context.Context) {
+			out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pvc", pvcName, "-o", "jsonpath={.spec.volumeName}"))
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to get PVC volumeName")
+			pvName = strings.TrimSpace(out)
+			g.Expect(pvName).NotTo(BeEmpty(), "PVC should be bound to a PV")
+		}).WithContext(ctx).Should(Succeed(), "PVC was never bound to a PV")
+
+		Eventually(func(g Gomega, ctx context.Context) {
+			out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pod", "-l", "part-of=e2e-test", "-o", "jsonpath={.items[0].spec.nodeName}"))
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod nodeName")
+			nodeName = strings.TrimSpace(out)
+			g.Expect(nodeName).NotTo(BeEmpty(), "Pod should be scheduled on a node")
+		}).WithContext(ctx).Should(Succeed(), "Pod did not have a nodeName")
+
+		driverPod, err := getDriverPodOnNode(ctx, nodeName)
+		Expect(err).NotTo(HaveOccurred(), "Failed to locate csi-local-node pod on %s", nodeName)
+		Expect(driverPod).NotTo(BeEmpty(), "No csi-local-node pod found on node %s", nodeName)
+
+		By("recording the LV size before expansion")
+		originalLVBytes, err := getLVSizeBytes(ctx, driverPod, pvName)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read original LV size")
+		Expect(originalLVBytes).To(BeNumerically(">", int64(0)), "Original LV size must be positive")
+		Expect(originalLVBytes).To(BeNumerically("<", expansionPVCTargetBytes),
+			"Test precondition: original LV size (%d) must be smaller than target (%d)", originalLVBytes, expansionPVCTargetBytes)
+		_, _ = fmt.Fprintf(GinkgoWriter, "Original LV %s on %s = %d bytes\n", pvName, driverPod, originalLVBytes)
+
+		By(fmt.Sprintf("patching PVC %s storage request to %s", pvcName, expansionPVCTargetSize))
+		patch := fmt.Sprintf(`{"spec":{"resources":{"requests":{"storage":"%s"}}}}`, expansionPVCTargetSize)
+		_, err = utils.Run(exec.CommandContext(ctx, "kubectl", "patch", "pvc", pvcName, "--type=merge", "-p", patch))
+		Expect(err).NotTo(HaveOccurred(), "Failed to patch PVC storage request")
+
+		By("waiting for the LV on disk to reach the new size")
+		Eventually(func(g Gomega, ctx context.Context) {
+			sz, err := getLVSizeBytes(ctx, driverPod, pvName)
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to read LV size during expansion")
+			_, _ = fmt.Fprintf(GinkgoWriter, "Current LV %s = %d bytes (want >= %d)\n", pvName, sz, expansionPVCTargetBytes)
+			g.Expect(sz).To(BeNumerically(">=", expansionPVCTargetBytes), "LV should have grown to the requested size")
+		}).WithContext(ctx).Should(Succeed(), "LV was never extended on disk")
+
+		By("waiting for PVC.status.capacity to reflect the new size")
+		Eventually(func(g Gomega, ctx context.Context) {
+			out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pvc", pvcName, "-o", "jsonpath={.status.capacity.storage}"))
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to get PVC status capacity")
+			g.Expect(strings.TrimSpace(out)).To(Equal(expansionPVCTargetSize), "PVC.status.capacity should equal the new request")
+		}).WithContext(ctx).Should(Succeed(), "PVC.status.capacity never updated")
+
+		By("waiting for PV.spec.capacity to reflect the new size")
+		Eventually(func(g Gomega, ctx context.Context) {
+			out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pv", pvName, "-o", "jsonpath={.spec.capacity.storage}"))
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to get PV capacity")
+			g.Expect(strings.TrimSpace(out)).To(Equal(expansionPVCTargetSize), "PV.spec.capacity should equal the new request")
+		}).WithContext(ctx).Should(Succeed(), "PV.spec.capacity never updated")
+
+		By("verifying the workload is still Running after the expand")
+		out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pod", "-l", "part-of=e2e-test", "-o", "jsonpath={.items[0].status.phase}"))
+		Expect(err).NotTo(HaveOccurred(), "Failed to re-check pod phase after expand")
+		Expect(strings.TrimSpace(out)).To(Equal("Running"), "Pod should remain Running after PVC expansion")
+	})
+}
+
+// getPVCName reads the metadata.name from a single-document PVC fixture using kubectl.
+func getPVCName(ctx context.Context, pvcFixture string) (string, error) {
+	out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "-f", pvcFixture, "-o", "jsonpath={.metadata.name}"))
+	if err != nil {
+		return "", fmt.Errorf("kubectl get -f %s: %w", pvcFixture, err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// getDriverPodOnNode returns the name of the csi-local-node pod scheduled on
+// the given node, or "" if none is found.
+func getDriverPodOnNode(ctx context.Context, node string) (string, error) {
+	out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pods", "-n", "kube-system",
+		"-l", "app.kubernetes.io/component=csi-local-node",
+		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{.spec.nodeName}{\"\\n\"}{end}"))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) != 2 {
+			continue
+		}
+		if strings.TrimSpace(fields[1]) == node {
+			return strings.TrimSpace(fields[0]), nil
+		}
+	}
+	return "", nil
+}
+
+// getLVSizeBytes returns the on-disk size in bytes of the LV named lvName in
+// the driver's default volume group, by execing into a driver pod and running
+// `lvs` with byte units.
+func getLVSizeBytes(ctx context.Context, driverPod, lvName string) (int64, error) {
+	lvPath := lvm.DefaultVolumeGroup + "/" + lvName
+	out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "exec", "-n", "kube-system", driverPod, "--",
+		"lvs", "--noheadings", "--nosuffix", "--units", "b", "--options", "lv_size", lvPath))
+	if err != nil {
+		return 0, fmt.Errorf("lvs %s: %w", lvPath, err)
+	}
+	raw := strings.TrimSpace(out)
+	if raw == "" {
+		return 0, fmt.Errorf("lvs %s returned empty output", lvPath)
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}

--- a/test/e2e/lvm_expansion_test.go
+++ b/test/e2e/lvm_expansion_test.go
@@ -35,10 +35,9 @@ const (
 //  3. assert that the LV on the owning node actually grew (the original bug
 //     was that lvextend was never invoked because the early-return branch
 //     swallowed the request);
-//  4. assert that PVC.status, PV.spec.capacity, and
-//     pv.spec.csi.volumeAttributes[".../capacity"] all reflect the new size
-//     so a subsequent failover-driven re-provisioning recreates the LV at the
-//     expanded size.
+//  4. assert that PVC.status, PV.spec.capacity, and the PV's
+//     expanded-capacity annotation all reflect the new size so a subsequent
+//     failover-driven re-provisioning recreates the LV at the expanded size.
 func lvmExpansionTest(name, pvcFixture, podFixture string) {
 	It(name, func(ctx context.Context) {
 		By("applying the PVC fixture")
@@ -127,6 +126,19 @@ func lvmExpansionTest(name, pvcFixture, podFixture string) {
 			g.Expect(err).NotTo(HaveOccurred(), "Failed to get PV capacity")
 			g.Expect(strings.TrimSpace(out)).To(Equal(expansionPVCTargetSize), "PV.spec.capacity should equal the new request")
 		}).WithContext(ctx).Should(Succeed(), "PV.spec.capacity never updated")
+
+		By("verifying the PV expanded-capacity annotation records the actual LV size")
+		Eventually(func(g Gomega, ctx context.Context) {
+			jsonpath := fmt.Sprintf("{.metadata.annotations['%s']}", strings.ReplaceAll(lvm.ExpandedCapacityParam, "/", "\\/"))
+			out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pv", pvName, "-o", fmt.Sprintf("jsonpath=%s", jsonpath)))
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to get PV expanded-capacity annotation")
+			raw := strings.TrimSpace(out)
+			g.Expect(raw).NotTo(BeEmpty(), "PV should have the expanded-capacity annotation")
+			annotationBytes, err := strconv.ParseInt(raw, 10, 64)
+			g.Expect(err).NotTo(HaveOccurred(), "expanded-capacity annotation should be a valid integer")
+			g.Expect(annotationBytes).To(BeNumerically(">=", expansionPVCTargetBytes),
+				"expanded-capacity annotation (%d) should be >= requested expansion size (%d)", annotationBytes, expansionPVCTargetBytes)
+		}).WithContext(ctx).Should(Succeed(), "PV expanded-capacity annotation never set")
 
 		By("verifying the workload is still Running after the expand")
 		out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pod", "-l", "part-of=e2e-test", "-o", "jsonpath={.items[0].status.phase}"))

--- a/test/e2e/lvm_expansion_test.go
+++ b/test/e2e/lvm_expansion_test.go
@@ -129,7 +129,7 @@ func lvmExpansionTest(name, pvcFixture, podFixture string) {
 
 		By("verifying the PV expanded-capacity annotation records the actual LV size")
 		Eventually(func(g Gomega, ctx context.Context) {
-			jsonpath := fmt.Sprintf("{.metadata.annotations['%s']}", strings.ReplaceAll(lvm.ExpandedCapacityParam, "/", "\\/"))
+			jsonpath := fmt.Sprintf("{.metadata.annotations.%s}", strings.ReplaceAll(lvm.ExpandedCapacityParam, ".", "\\."))
 			out, err := utils.Run(exec.CommandContext(ctx, "kubectl", "get", "pv", pvName, "-o", fmt.Sprintf("jsonpath=%s", jsonpath)))
 			g.Expect(err).NotTo(HaveOccurred(), "Failed to get PV expanded-capacity annotation")
 			raw := strings.TrimSpace(out)

--- a/test/e2e/lvm_storagepool_test.go
+++ b/test/e2e/lvm_storagepool_test.go
@@ -41,6 +41,7 @@ var testLvmStoragePool = func() {
 
 		lvmWebhookRejectTest("should reject statefulset with non-ephemeral local storagepool", common.LvmPvcNoAnnotationFixture)
 		lvmHyperconvergedTest("should create hyperconverged pod with local storagepool", common.LvmPvcAnnotationFixure, common.LvmPodAnnotationFixture)
+		lvmExpansionTest("should expand a PVC and grow the backing LV", common.LvmPvcAnnotationFixure, common.LvmPodAnnotationFixture)
 	})
 
 }

--- a/test/external/drivers/lvm.yaml
+++ b/test/external/drivers/lvm.yaml
@@ -23,7 +23,7 @@ DriverInfo:
     # support ReadWriteMany access modes
     RWX: false
     # support volume expansion for controller
-    controllerExpansion: false
+    controllerExpansion: true
     # support volume expansion for node
     nodeExpansion: true
     # support volume limits (limit on number of volumes per node)


### PR DESCRIPTION
* Fix NodeExpandVolume to continue to actually call lvextend when the requested capacity is larger than the current PV capacity to enable exapnsion. 
* Advertise PluginCapability_VolumeExpansion_ONLINE so the external-resizer sidecar drives NodeExpandVolume per CSI spec.
* After a successful NodeExpandVolume, patch pv.Spec.CSI.VolumeAttributes[CapacityParam] with the new size via a client.MergeFrom patch so failover re-provisioning recreates the LV at the expanded size. 
* Add unit tests and e2e tests for expanding PV. 