### PR TITLE
test: add kwok test and pprof endpoint for diagnosing memory issues

### DIFF
--- a/.github/workflows/scripts/run_tests.py
+++ b/.github/workflows/scripts/run_tests.py
@@ -265,6 +265,31 @@ class KindCluster(Cluster):
         logging.info("No cleanup needed for kind cluster")
 
 
+class KwokCluster(Cluster):
+    """
+    Class for managing a kwok-tuned kind cluster used by the scale tests.
+
+    The cluster is a single kind node with apiserver/etcd/cm/scheduler tuned
+    for thousands of fake nodes. The kwok controller itself is installed by
+    the test suite (via test/pkg/kwok), not here.
+    """
+
+    async def setup(self) -> None:
+        """
+        Set up the kwok-tuned kind cluster.
+        """
+        logging.info("Creating kwok cluster (target=make kwok-bootstrap)")
+        if await run_command("make kwok-bootstrap", os.environ.copy()) != 0:
+            logging.error("Failed to create kwok-tuned kind cluster")
+            raise RuntimeError("Failed to create kwok-tuned kind cluster")
+
+    async def cleanup(self) -> None:
+        """
+        Clean up the kwok-tuned kind cluster.
+        """
+        logging.info("No cleanup needed for kwok cluster")
+
+
 class AksCluster(Cluster):
     """
     Class for managing an AKS cluster.
@@ -447,6 +472,8 @@ def create_cluster(args: argparse.Namespace, config: EnvConfig) -> Cluster:
     """
     if args.cluster_type == "kind":
         return KindCluster(nodes=args.kind_nodes, setup_vg=args.kind_setup_vg)
+    elif args.cluster_type == "kwok":
+        return KwokCluster()
     elif args.cluster_type == "aks":
         return AksCluster(
             args.aks_template,
@@ -521,7 +548,7 @@ async def main() -> int:
     )
     parser.add_argument(
         "--cluster-type",
-        choices=["kind", "aks", "none"],
+        choices=["kind", "kwok", "aks", "none"],
         default="none",
         required=False,
         help="Specify the cluster type: kind, aks, or none",

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -50,22 +50,42 @@ jobs:
           - name: Kind E2E
             id: e2e
             make-target: test-e2e
+            cluster-type: kind
             kind-args: --kind-nodes single --kind-setup-vg
+            extra-make-vars: ""
           - name: Kind External E2E
             id: external-e2e
             make-target: test-external-e2e
+            cluster-type: kind
             kind-args: --kind-nodes single --kind-setup-vg
+            extra-make-vars: ""
           - name: Kind Sanity
             id: sanity
             make-target: test-sanity
+            cluster-type: kind
             kind-args: --kind-nodes single --kind-setup-vg
+            extra-make-vars: ""
+          - name: Kwok Scale
+            id: kwok
+            make-target: test-kwok
+            cluster-type: kwok
+            kind-args: ""
+            # SKIP_CLEANUP leaves the fake objects in place at end-of-suite
+            # and SKIP_UNINSTALL skips uninstalling kwok and the csi driver,
+            # so the run finishes quickly in CI; the cluster is torn down
+            # with the runner. SKIP_SUPPORT_BUNDLE skips support-bundle
+            # collection - it is not useful for the fake kwok nodes and
+            # only slows down teardown.
+            extra-make-vars: SKIP_CLEANUP=true SKIP_UNINSTALL=true SKIP_SUPPORT_BUNDLE=true
         exclude:
-          # external-e2e and sanity work on arm64 too, but to save CI minutes
-          # we only run them on amd64. Plain e2e still runs on both arches.
+          # external-e2e, sanity, and kwok work on arm64 too, but to save CI
+          # minutes we only run them on amd64. Plain e2e still runs on both.
           - arch: { tag-suffix: arm64 }
             test: { id: external-e2e }
           - arch: { tag-suffix: arm64 }
             test: { id: sanity }
+          - arch: { tag-suffix: arm64 }
+            test: { id: kwok }
     runs-on: ${{ matrix.arch.runs-on }}
     steps:
       - name: Harden Runner
@@ -133,6 +153,7 @@ jobs:
         run: |
           # Ensure kind binary is on PATH for any in-suite invocations
           # (e.g. external-e2e's `kind load docker-image` in BeforeSuite).
+          # run_tests.py creates the cluster itself based on --cluster-type.
           make kind
           echo "${PWD}/bin" >> "$GITHUB_PATH"
 
@@ -147,15 +168,20 @@ jobs:
       - name: Run ${{ matrix.test.name }}
         env:
           MAKE_TARGET: ${{ matrix.test.make-target }}
+          CLUSTER_TYPE: ${{ matrix.test.cluster-type }}
           KIND_ARGS: ${{ matrix.test.kind-args }}
+          EXTRA_MAKE_VARS: ${{ matrix.test.extra-make-vars }}
         run: |
           # PR builds never push to ACR. The suite consumes the pre-built chart
           # with pullPolicy=IfNotPresent so kubelet uses the locally-loaded
           # image instead of trying to pull from the registry.
-          # shellcheck disable=SC2086  # KIND_ARGS intentionally word-splits.
+          # cleanup.enabled=false stops the driver pod from running
+          # `vgremove` on shutdown - if it did, a pod restart mid-test
+          # would permanently delete the VG and every LV inside it.
+          # shellcheck disable=SC2086  # KIND_ARGS/EXTRA_MAKE_VARS intentionally word-split.
           python .github/workflows/scripts/run_tests.py \
-            --command "make ${MAKE_TARGET} REGISTRY=${REGISTRY} REPO_BASE=${REPO_BASE} TAG=${TAG} INSTALLATION_METHOD=localHelm CHART_SOURCE=/tmp/helm/local-csi-driver-${TAG#v}.tgz SKIP_BUILD=true HELM_ARGS='--set image.driver.pullPolicy=IfNotPresent --set image.manager.pullPolicy=IfNotPresent'" \
-            --cluster-type kind ${KIND_ARGS}
+            --command "make ${MAKE_TARGET} REGISTRY=${REGISTRY} REPO_BASE=${REPO_BASE} TAG=${TAG} INSTALLATION_METHOD=localHelm CHART_SOURCE=/tmp/helm/local-csi-driver-${TAG#v}.tgz SKIP_BUILD=true ${EXTRA_MAKE_VARS} HELM_ARGS='--set image.driver.pullPolicy=IfNotPresent --set image.manager.pullPolicy=IfNotPresent --set cleanup.enabled=false'" \
+            --cluster-type ${CLUSTER_TYPE} ${KIND_ARGS}
 
       - name: Upload test results
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -168,13 +168,19 @@ test-upgrade: ginkgo ## Run the upgrade tests.
 test-scaledown: ginkgo ## Run the scale down tests.
 	$(call run_tests,scaledown && aks,./test/e2e,$(ADDITIONAL_GINKGO_FLAGS),--repeat=$(REPEAT))
 
+
+.PHONY: test-kwok
+test-kwok: ginkgo ## Run the kwok tests.
+	$(call run_tests,kwok,./test/kwok,$(ADDITIONAL_GINKGO_FLAGS),--repeat=$(REPEAT) $(if $(filter true,$(SKIP_CLEANUP)),--skip-cleanup))
+
 define run_tests
+PATH="$(LOCALBIN):$$PATH" \
 TAG=$(TAG) \
 REGISTRY=$(REGISTRY) \
 DRIVER_IMG=${DRIVER_IMG} \
 MANAGER_IMG=${MANAGER_IMG} \
 $(GINKGO) -v -r $(3) --label-filter="$(1)$(if $(LABEL_FILTER), && ($(LABEL_FILTER)))" --focus="$(FOCUS)" --no-color="$(NO_COLOR)" --timeout="$(TEST_TIMEOUT)" "$(2)" -- \
-	--junit-report=$(TEST_OUTPUT) --support-bundle-dir=$(SUPPORT_BUNDLE_OUTPUT_DIR) "$(4)"
+	--junit-report=$(TEST_OUTPUT) --support-bundle-dir=$(SUPPORT_BUNDLE_OUTPUT_DIR) $(4)
 endef
 
 .PHONY: test-container-structure
@@ -271,15 +277,15 @@ endef
 docker-load: docker-load-driver docker-load-manager
 
 .PHONY: docker-load-driver
-docker-load-driver: ## Load the docker image into the kind cluster.
+docker-load-driver: kind ## Load the docker image into the kind cluster.
 	$(call docker-load,${DRIVER_IMG})
 
 .PHONY: docker-load-manager
-docker-load-manager: ## Load the manager image into the kind cluster.
+docker-load-manager: kind ## Load the manager image into the kind cluster.
 	$(call docker-load,${MANAGER_IMG})
 
 define docker-load
-	kind load docker-image $(1) --name kind
+	$(KIND) load docker-image $(1) --name kind
 endef
 
 .PHONY: docker-lint
@@ -360,10 +366,10 @@ deploy: helm ## Deploy to the K8s cluster specified in ~/.kube/config.
 		--version $(TAG) \
 		--set image.driver.repository=$(REGISTRY)/$(DRIVER_REPO) \
 		--set image.driver.tag=$(TAG) \
-		--set image.driver.pullPolicy=Always \
+		--set image.driver.pullPolicy=IfNotPresent \
 		--set image.manager.repository=$(REGISTRY)/$(MANAGER_REPO) \
 		--set image.manager.tag=$(TAG) \
-		--set image.manager.pullPolicy=Always \
+		--set image.manager.pullPolicy=IfNotPresent \
 		--set observability.driver.trace.endpoint=$(OTEL_ENDPOINT) \
 		--debug --wait --atomic $(HELM_ARGS)
 
@@ -415,21 +421,34 @@ add-copyright:
 kubeconform-lint: kubeconform-helm ## Lint all Kubernetes manifests using kubeconform.
 	$(HELM) kubeconform --verbose --summary --strict charts/latest
 
-.PHONY: single
-single: kind ## Create a single node kind cluster.
+define create-kind-cluster
 	if $(KIND) get clusters | grep -q kind; then \
 		echo "Cluster 'kind' already exists"; \
 	else \
-		$(KIND) create cluster --config=./test/config/kind-1-node.yaml; \
+		$(KIND) create cluster --config=$(1); \
 	fi
+	kubectl config use-context kind-kind
+endef
+
+.PHONY: single
+single: kind ## Create a single node kind cluster.
+	$(call create-kind-cluster,./test/config/kind-1-node.yaml)
 
 .PHONY: multi
 multi: kind ## Create a multi node kind cluster.
-	if $(KIND) get clusters | grep -q kind; then \
-		echo "Cluster 'kind' already exists"; \
-	else \
-		$(KIND) create cluster --config=./test/config/kind-3-node.yaml; \
-	fi
+	$(call create-kind-cluster,./test/config/kind-3-node.yaml)
+
+.PHONY: kwok-cluster
+kwok-cluster: kind ## Create a single-node kind cluster tuned for the kwok scale test.
+	$(call create-kind-cluster,./test/config/kind-kwok.yaml)
+
+.PHONY: kwok-bootstrap
+kwok-bootstrap: kwok-cluster kind-setup-vg ## Create a kwok-tuned kind cluster + VG, ready for `make test-kwok`.
+	# Real LVM VG is created on the (single) kind node so the driver pod
+	# starts up the same way it does in production. Kwok still fakes the
+	# 10k worker nodes and their volumes - the VG only backs LVs that
+	# could be created on the real driver node.
+	# The kwok test installs the helm chart itself with values-kwok.yaml.
 
 .PHONY: kind-setup-vg
 kind-setup-vg: kind ## Create a 100GiB loop-backed LVM VG (containerstorage) on each kind node.
@@ -443,7 +462,7 @@ kind-teardown-vg: kind ## Remove the loop-backed LVM VG from each kind node.
 kind-e2e-bootstrap: multi kind-setup-vg ## Create a 3-node kind cluster + VG on each node, ready for e2e / external-e2e.
 
 .PHONY: clean
-clean: kind ## Deletes the kind cluster.
+clean: kind kind-teardown-vg ## Deletes the kind cluster.
 	$(KIND) delete cluster --name kind
 
 .PHONY: kubeconfig
@@ -467,6 +486,8 @@ get-support-bundle: support-bundle ## Download support-bundle locally if necessa
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
+
+PATH ?= $(LOCALBIN):$$(PATH)
 
 ## Tool Binaries
 KUBECTL ?= kubectl
@@ -498,6 +519,7 @@ SUPPORT_BUNDLE_VERSION ?= v0.121.2
 BICEP_VERSION ?= v0.37.4
 HELM_VERSION ?= v3.18.6
 MARKDOWNLINT_CLI_VERSION ?= v0.45.0
+KWOK_VERSION ?= v0.7.0
 
 .PHONY: mockgen
 mockgen: $(MOCK_GEN) ## Installs mockgen locally if necessary.
@@ -550,6 +572,20 @@ prometheus-crds: ## Install prometheus crds into the current cluster.
 .PHONY: prometheus-crds-uninstall
 prometheus-crds-uninstall: ## Uninstall prometheus crds from the current cluster.
 	$(KUBECTL) delete -f $(PROMETHEUS_CRD_YAML) --ignore-not-found
+
+KWOK_YAML="https://github.com/kubernetes-sigs/kwok/releases/download/${KWOK_VERSION}/kwok.yaml"
+KWOK_FAST_STAGE_YAML="https://github.com/kubernetes-sigs/kwok/releases/download/${KWOK_VERSION}/stage-fast.yaml"
+
+.PHONY: kwok
+kwok: ## Install Kwok into the current cluster.
+	$(KUBECTL) apply -f $(KWOK_YAML)
+	$(KUBECTL) apply -f $(KWOK_FAST_STAGE_YAML)
+
+.PHONY: kwok-uninstall
+kwok-uninstall: ## Uninstall Kwok from the current cluster.
+	$(KUBECTL) delete -f $(KWOK_FAST_STAGE_YAML) --ignore-not-found || true
+	$(KUBECTL) delete -f $(KWOK_YAML) --ignore-not-found
+
 
 .PHONY: jaeger
 jaeger: jaeger-install jaeger-port-forward ## Install Jaeger into the current cluster and create port-forward.

--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -80,6 +80,9 @@ spec:
         - --metrics-bind-address=:{{ .Values.observability.driver.metrics.port }}
         - --metrics-secure=false
         - --health-probe-bind-address=:{{ .Values.observability.driver.health.port }}
+        {{- if .Values.observability.driver.pprof.enabled }}
+        - --pprof-bind-address=:{{ .Values.observability.driver.pprof.port }}
+        {{- end }}
         - --trace-address={{ .Values.observability.driver.trace.endpoint }}
         - --trace-sample-rate={{ .Values.observability.driver.trace.sampleRate }}
         - --trace-service-id=$(POD_NAME)

--- a/charts/latest/templates/manager-deployment.yaml
+++ b/charts/latest/templates/manager-deployment.yaml
@@ -53,6 +53,9 @@ spec:
         - --namespace=$(POD_NAMESPACE)
         - --health-probe-bind-address=:{{ .Values.observability.manager.health.port }}
         - --metrics-bind-address=:{{ .Values.observability.manager.metrics.port }}
+        {{- if .Values.observability.manager.pprof.enabled }}
+        - --pprof-bind-address=:{{ .Values.observability.manager.pprof.port }}
+        {{- end }}
         {{- if or .Values.webhook.enforceEphemeral.enabled .Values.webhook.hyperconverged.enabled }}
         - --webhook-port={{ .Values.webhook.service.targetPort }}
         - --webhook-service-name={{ .Values.name }}-webhook-service

--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -242,6 +242,9 @@ observability:
       port: 8080
     health:
       port: 8081
+    pprof:
+      enabled: false
+      port: 6060
   driver:
     log:
       level: 2
@@ -249,6 +252,9 @@ observability:
       port: 8080
     health:
       port: 8081
+    pprof:
+      enabled: false
+      port: 6060
     trace:
       # The address to send traces to. Disables tracing if not set.
       endpoint: ""

--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -68,6 +68,7 @@ func main() {
 	var csiAddr string
 	var metricsAddr string
 	var probeAddr string
+	var pprofAddr string
 	var secureMetrics bool
 	var workers int
 	var apiQPS int
@@ -93,6 +94,8 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to (e.g. :6060). "+
+		"Leave empty to disable pprof. Exposes /debug/pprof/* for heap, goroutine, and CPU profiling.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.IntVar(&workers, "worker-threads", 10,
@@ -199,6 +202,7 @@ func main() {
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: probeAddr,
+		PprofBindAddress:       pprofAddr,
 		LeaderElection:         false, // No webhooks, no leader election needed
 		LeaderElectionID:       "local-csi-driver",
 		// Pod is only read once at startup (StartupDiagnostic). Bypass the

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -58,6 +58,7 @@ func main() {
 	var certSecretName string
 	var metricsAddr string
 	var probeAddr string
+	var pprofAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var leaderElectionID string
@@ -86,6 +87,8 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to (e.g. :6060). "+
+		"Leave empty to disable pprof. Exposes /debug/pprof/* for heap, goroutine, and CPU profiling.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
@@ -197,6 +200,7 @@ func main() {
 		Metrics:                    metricsOptions,
 		WebhookServer:              webhookServer,
 		HealthProbeBindAddress:     probeAddr,
+		PprofBindAddress:           pprofAddr,
 		LeaderElection:             enableLeaderElection,
 		LeaderElectionID:           leaderElectionID, // Required for cert rotation.
 		LeaderElectionResourceLock: "leases",

--- a/hack/kind-setup-vg.sh
+++ b/hack/kind-setup-vg.sh
@@ -31,6 +31,7 @@ nodes=$("${KIND_BIN}" get nodes --name "${CLUSTER}")
 
 run_on_node() {
     docker exec -i \
+        -e NODE_NAME="$1" \
         -e VG_NAME="${VG_NAME}" \
         -e VG_TAG="${VG_TAG}" \
         -e VG_SIZE="${VG_SIZE}" \
@@ -51,21 +52,30 @@ for i in $(seq 8 31); do
     [ -e "/dev/loop${i}" ] || { mknod "/dev/loop${i}" b 7 "${i}" && chmod 660 "/dev/loop${i}"; } 2>/dev/null || true
 done
 
-# Loop devices are kernel-global across kind containers; per-node filename
-# keeps losetup -j unambiguous.
-img=/var/lib/csi-local-vg/$(hostname).img
-mkdir -p "$(dirname "$img")"
+# LVM is host-kernel-global across kind nodes (same /dev). Without scoping,
+# every node sees every other node`s PV/VG. Use the lvm devices file so this
+# container`s lvm tools only operate on this node`s loop. Each kind node
+# has its own /etc, so the devices file is per-node.
+mkdir -p /etc/lvm/devices
+: > /etc/lvm/devices/system.devices
 
-if vgs --noheadings -o vg_name 2>/dev/null | grep -qw "${VG_NAME}"; then
-    echo "VG ${VG_NAME} already exists, skipping."
-    vgs "${VG_NAME}"
-    exit 0
-fi
+img=/var/lib/csi-local-vg/${NODE_NAME}.img
+mkdir -p "$(dirname "$img")"
 
 [ -f "$img" ] || truncate -s "${VG_SIZE}" "$img"
 loop=$(losetup -j "$img" | awk -F: "NR==1{print \$1}")
 [ -n "$loop" ] || loop=$(losetup -f --show "$img")
 echo "using loop device $loop"
+
+# Scope lvm to just this loop. lvmdevices --adddev re-creates the file with
+# only this entry; subsequent vgs/pvs/lvs ignore everything else.
+lvmdevices --adddev "$loop" 2>/dev/null || true
+
+if vgs --noheadings -o vg_name 2>/dev/null | grep -qw "${VG_NAME}"; then
+    echo "VG ${VG_NAME} already exists on this node, skipping."
+    vgs "${VG_NAME}"
+    exit 0
+fi
 
 pvs --noheadings -o pv_name "$loop" >/dev/null 2>&1 || pvcreate -ff -y "$loop"
 vgcreate --addtag "${VG_TAG}" "${VG_NAME}" "$loop"
@@ -74,7 +84,7 @@ vgs "${VG_NAME}"
 
 # shellcheck disable=SC2016
 teardown_script='
-img=/var/lib/csi-local-vg/$(hostname).img
+img=/var/lib/csi-local-vg/${NODE_NAME}.img
 if vgs --noheadings -o vg_name 2>/dev/null | grep -qw "${VG_NAME}"; then
     vgchange -an "${VG_NAME}" || true
     vgremove -ff -y "${VG_NAME}" || true
@@ -82,6 +92,7 @@ fi
 loop=$(losetup -j "$img" 2>/dev/null | awk -F: "NR==1{print \$1}")
 [ -z "$loop" ] || { pvremove -ff -y "$loop" 2>/dev/null || true; losetup -d "$loop" || true; }
 rm -f "$img"
+rm -f /etc/lvm/devices/system.devices
 '
 
 for node in ${nodes}; do

--- a/test/config/kind-kwok.yaml
+++ b/test/config/kind-kwok.yaml
@@ -1,0 +1,61 @@
+# Single-node kind config tuned for the kwok scale test (10k+ fake nodes,
+# 50k+ fake objects). Do NOT use for normal e2e - the apiserver, etcd,
+# and CIDR sizing are deliberately oversized.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        # Default 60s causes 504s on DeleteCollection at ~50k objects.
+        request-timeout: "300s"
+        # Defaults: 400 RO / 200 mutating. High-QPS clients queue immediately.
+        max-requests-inflight: "3000"
+        max-mutating-requests-inflight: "1500"
+        # Default 100. With QPS=1000 client over a single TCP conn, HTTP/2
+        # head-of-line blocking caps you at 100 inflight per connection.
+        http2-max-streams-per-connection: "1000"
+        # Keep large object sets warm in apiserver to avoid re-LISTing etcd.
+        # Sized for the 10k-node / 50k-pod kwok scale tests with headroom.
+        watch-cache-sizes: "persistentvolumeclaims#75000,persistentvolumes#75000,pods#75000,nodes#15000"
+        default-watch-cache-size: "1000"
+    etcd:
+      local:
+        extraArgs:
+          # Default 2 GiB. At 50k+ objects with churn you hit
+          # "mvcc: database space exceeded" with no prior warning.
+          quota-backend-bytes: "8589934592"
+          # Aggressive compaction so deleted revisions don't accumulate.
+          auto-compaction-mode: "revision"
+          auto-compaction-retention: "1000"
+          # Smaller WAL = less memory pressure during heavy writes.
+          snapshot-count: "10000"
+    controllerManager:
+      extraArgs:
+        kube-api-qps: "1000"
+        kube-api-burst: "2000"
+        # Default 15s/10s/2s. At >5k kwok nodes the apiserver intermittently
+        # takes >5s to respond, which causes lease renewal Get() to time out
+        # and the controller-manager exits with "leaderelection lost".
+        leader-elect-lease-duration: "60s"
+        leader-elect-renew-deadline: "40s"
+        leader-elect-retry-period: "10s"
+        # Pin pod CIDR allocator to /24. Combined with podSubnet=10.0.0.0/10
+        # (set under networking) this yields 16384 /24 CIDRs, enough for 10k+
+        # kwok nodes without exhausting the cluster CIDR pool.
+        node-cidr-mask-size: "24"
+    scheduler:
+      extraArgs:
+        kube-api-qps: "1000"
+        kube-api-burst: "2000"
+        leader-elect-lease-duration: "60s"
+        leader-elect-renew-deadline: "40s"
+        leader-elect-retry-period: "10s"
+networking:
+  # Default 10.244.0.0/16 with /24 mask = 256 pod CIDRs, far short of 10k
+  # kwok nodes. /10 keeps us clear of the service CIDR (10.96.0.0/16) and
+  # provides 16384 /24 pod CIDRs.
+  podSubnet: "10.0.0.0/10"

--- a/test/kwok/kwok_suite_test.go
+++ b/test/kwok/kwok_suite_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package kwok
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	_ "local-csi-driver/test/aks"
+	"local-csi-driver/test/pkg/common"
+	"local-csi-driver/test/pkg/kwok"
+	_ "local-csi-driver/test/scale"
+)
+
+const (
+	namespace   = "kube-system"
+	clientQPS   = 1000
+	clientBurst = 2000
+)
+
+var (
+	// defaultKubeConfigPath is the default path to the kubeconfig file.
+	defaultKubeConfigPath = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	// junitReport is the report file generated for consumption by test.
+	junitReport = flag.String("junit-report", "junit.xml", "Path to the test report")
+
+	// supportBundleDir is the directory where support bundles are written.
+	supportBundleDir = flag.String("support-bundle-dir", "support-bundles", "Path to write support-bundles")
+
+	// skipCleanup skips the per-resource cleanup of nodes/pods/pvs/pvcs at
+	// the end of the test. Use in CI where the cluster is torn down anyway.
+	// Set SKIP_UNINSTALL=true to also skip uninstalling kwok and the csi
+	// driver.
+	skipCleanup = flag.Bool("skip-cleanup", false, "Skip per-resource cleanup of kwok nodes/pods/pvs/pvcs")
+
+	// scheme is the runtime scheme shared across the suite.
+	scheme = runtime.NewScheme()
+
+	// k8sClient is the controller-runtime client shared across specs.
+	k8sClient client.Client
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv(clientcmd.RecommendedConfigPathEnvVar) == "" {
+		err := os.Setenv(clientcmd.RecommendedConfigPathEnvVar, defaultKubeConfigPath)
+		if err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "Failed to set default kubeconfig path: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
+func TestKwok(t *testing.T) {
+	RegisterFailHandler(Fail)
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting integration test suite\n")
+	RunSpecs(t, "kwok suite")
+}
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	kubeconfig := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
+	Expect(kubeconfig).NotTo(BeEmpty(), "KUBECONFIG env var must be set")
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	Expect(err).NotTo(HaveOccurred(), "building rest config")
+	cfg.QPS = clientQPS
+	cfg.Burst = clientBurst
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred(), "building client")
+
+	By("installing csi driver with kwok-specific helm overrides")
+	merged := "HELM_ARGS=" + strings.TrimSpace(os.Getenv("HELM_ARGS")+" -f test/kwok/values-kwok.yaml")
+	common.Setup(ctx, namespace, merged)
+
+	Eventually(func() error {
+		return kwok.Install(ctx)
+	}, "5m", "10s").Should(Succeed())
+})
+
+var _ = AfterSuite(func(ctx context.Context) {
+	if !*skipCleanup {
+		By("waiting for fake pods to drain")
+		waitEmpty(ctx, &corev1.PodList{}, client.MatchingLabels{"type": "kwok"})
+
+		By("waiting for fake nodes to drain")
+		waitEmpty(ctx, &corev1.NodeList{}, client.MatchingLabels{"type": "kwok"})
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "skip-cleanup: leaving kwok nodes/pods/pvs/pvcs in place\n")
+	}
+
+	if os.Getenv("SKIP_UNINSTALL") != "true" {
+		Eventually(func() error {
+			return kwok.Uninstall(ctx)
+		}, "5m", "10s").Should(Succeed())
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "skip-uninstall: leaving kwok installed\n")
+	}
+
+	common.Teardown(ctx, namespace, *supportBundleDir)
+})
+
+// waitEmpty polls until no objects remain that match the given selector.
+// Uses Limit(1) to keep memory bounded regardless of cluster size.
+func waitEmpty(ctx context.Context, list client.ObjectList, opts ...client.ListOption) {
+	GinkgoHelper()
+	opts = append(opts, client.Limit(1))
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.List(ctx, list, opts...)).To(Succeed(), "listing %T", list)
+		items, err := apimeta.ExtractList(list)
+		g.Expect(err).NotTo(HaveOccurred(), "extracting items from %T", list)
+		g.Expect(items).To(BeEmpty(), "expected 0 items in list %T", list)
+	}).WithTimeout(10*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "objects of type %T still present", list)
+}
+
+var _ = ReportAfterSuite("kwok reporter", func(ctx SpecContext, r Report) {
+	common.PostReport(ctx, r, *junitReport)
+})

--- a/test/kwok/oomkill_test.go
+++ b/test/kwok/oomkill_test.go
@@ -1,0 +1,483 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package kwok
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/sync/errgroup"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"local-csi-driver/internal/csi/core/lvm"
+	"local-csi-driver/test/pkg/kwok"
+	"local-csi-driver/test/pkg/utils"
+)
+
+const (
+	logInterval = 500
+	parallelism = 100
+	nodeCount   = 10000
+	podCount    = 10000
+	pvCount     = 10000
+	pvcCount    = 10000
+)
+
+var _ = Describe("Kwok", Label("kwok"), Ordered, func() {
+
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(time.Second)
+	EnforceDefaultTimeoutsWhenUsingContexts()
+
+	testNamespace := "workload-" + utils.RandomTag()
+
+	Context("local-csi-driver pods", func() {
+		BeforeAll(func(ctx context.Context) {
+
+			By(fmt.Sprintf("creating namespace %q", testNamespace))
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed(), "creating namespace %q", testNamespace)
+			DeferCleanup(func(ctx context.Context) {
+				if *skipCleanup {
+					By("skip-cleanup: leaving namespace")
+					return
+				}
+				By("deleting namespace")
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ns))).To(Succeed(), "deleting namespace %q", testNamespace)
+			})
+
+			By("creating storageclass")
+			sc, err := kwok.NewStorageClass()
+			Expect(err).NotTo(HaveOccurred(), "rendering storageclass")
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, sc))).To(Succeed(), "creating storageclass")
+			DeferCleanup(func(ctx context.Context) {
+				By("deleting storageclass")
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, sc))).To(Succeed(), "deleting storageclass")
+			})
+
+			By("creating kwok no-op storageclass")
+			noopSC, err := kwok.NewNoopStorageClass()
+			Expect(err).NotTo(HaveOccurred(), "rendering kwok no-op storageclass")
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, noopSC))).To(Succeed(), "creating kwok no-op storageclass")
+			DeferCleanup(func(ctx context.Context) {
+				By("deleting kwok no-op storageclass")
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, noopSC))).To(Succeed(), "deleting kwok no-op storageclass")
+			})
+
+			By("warming the csi driver via a real statefulset")
+			warmup, err := kwok.NewWarmupStatefulSet(testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "rendering warmup statefulset")
+			Expect(k8sClient.Create(ctx, warmup)).To(Succeed(), "creating warmup statefulset")
+			Eventually(func(g Gomega) {
+				var got appsv1.StatefulSet
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(warmup), &got)).To(Succeed(), "getting warmup statefulset")
+				g.Expect(got.Status.ReadyReplicas).To(Equal(*warmup.Spec.Replicas), "warmup pods not ready")
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "warmup statefulset never became ready")
+
+			By("deleting the warmup statefulset and waiting for csi-driver volumes to drain")
+			Expect(k8sClient.Delete(ctx, warmup)).To(Succeed(), "deleting warmup statefulset")
+			Eventually(func(g Gomega) int {
+				var pvs corev1.PersistentVolumeList
+				g.Expect(k8sClient.List(ctx, &pvs)).To(Succeed(), "listing pvs")
+				count := 0
+				for _, pv := range pvs.Items {
+					if pv.Spec.StorageClassName == sc.Name {
+						count++
+					}
+				}
+				return count
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(BeZero(), "warmup pvs not drained")
+
+			By("triggering csi-local-manager Node informer via a Released real-driver PV")
+			triggerPV := triggerNodeInformerPV("trigger-node-informer", "node-0")
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, triggerPV))).
+				To(Succeed(), "creating trigger PV")
+			// Phase is set on the status subresource - after Create the PV
+			// is Available, so patch its status to Released to make
+			// pvcleanup-controller reconcile and Get the Node. Re-Get and
+			// retry on conflict: the in-memory object can be stale (e.g.
+			// the PV already existed, or a controller added a finalizer
+			// between Create and this status update).
+			Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(triggerPV), triggerPV); err != nil {
+					return err
+				}
+				triggerPV.Status.Phase = corev1.VolumeReleased
+				return k8sClient.Status().Update(ctx, triggerPV)
+			})).To(Succeed(), "patching trigger PV status to Released")
+			DeferCleanup(func(ctx context.Context) {
+				patch := []byte(`{"metadata":{"finalizers":null}}`)
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, triggerPV,
+					client.RawPatch(types.MergePatchType, patch)))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, triggerPV))
+			})
+
+			Eventually(func(g Gomega) int {
+				var pvcs corev1.PersistentVolumeClaimList
+				g.Expect(k8sClient.List(ctx, &pvcs, client.InNamespace(testNamespace))).To(Succeed(), "listing pvcs")
+				return len(pvcs.Items)
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(BeZero(), "warmup pvcs not drained")
+
+			DeferCleanup(func(ctx context.Context) {
+				if *skipCleanup {
+					By("skip-cleanup: leaving kwok nodes")
+					return
+				}
+				deleteAllInParallel(ctx, "node",
+					func() client.ObjectList { return &corev1.NodeList{} },
+					[]client.ListOption{
+						client.MatchingLabels{"type": "kwok"},
+					},
+					client.GracePeriodSeconds(0),
+					client.PropagationPolicy(metav1.DeletePropagationBackground),
+				)
+			})
+
+			By(fmt.Sprintf("creating %d nodes", nodeCount))
+			createInParallel(ctx, nodeCount, "node", func(i int) client.Object {
+				node, err := kwok.NewNode(fmt.Sprintf("node-%d", i))
+				Expect(err).NotTo(HaveOccurred(), "rendering node %d", i)
+				return node
+			})
+
+			DeferCleanup(func(ctx context.Context) {
+				if *skipCleanup {
+					By("skip-cleanup: leaving kwok pods")
+					return
+				}
+				deleteAllInParallel(ctx, "pod",
+					func() client.ObjectList { return &corev1.PodList{} },
+					[]client.ListOption{
+						client.InNamespace(testNamespace),
+						client.MatchingLabels{"type": "kwok"},
+					},
+					client.GracePeriodSeconds(0),
+					client.PropagationPolicy(metav1.DeletePropagationBackground),
+				)
+			})
+
+			By(fmt.Sprintf("creating %d pods", podCount))
+			createInParallel(ctx, podCount, "pod", func(i int) client.Object {
+				pod, err := kwok.NewPod(fmt.Sprintf("pod-%d", i), testNamespace)
+				Expect(err).NotTo(HaveOccurred(), "rendering pod %d", i)
+				return pod
+			})
+
+			DeferCleanup(func(ctx context.Context) {
+				if *skipCleanup {
+					By("skip-cleanup: leaving kwok pvs")
+					return
+				}
+				deleteAllInParallel(ctx, "pv",
+					func() client.ObjectList { return &corev1.PersistentVolumeList{} },
+					[]client.ListOption{
+						client.MatchingLabels{"type": "kwok"},
+					},
+					client.PropagationPolicy(metav1.DeletePropagationBackground),
+				)
+			})
+
+			By(fmt.Sprintf("creating %d persistent volumes", pvCount))
+			createInParallel(ctx, pvCount, "pv", func(i int) client.Object {
+				pv, err := kwok.NewPV(fmt.Sprintf("pv-%d", i))
+				Expect(err).NotTo(HaveOccurred(), "rendering pv %d", i)
+				return pv
+			})
+
+			DeferCleanup(func(ctx context.Context) {
+				if *skipCleanup {
+					By("skip-cleanup: leaving kwok pvcs")
+					return
+				}
+				deleteAllInParallel(ctx, "pvc",
+					func() client.ObjectList { return &corev1.PersistentVolumeClaimList{} },
+					[]client.ListOption{
+						client.InNamespace(testNamespace),
+						client.MatchingLabels{"type": "kwok"},
+					},
+					client.PropagationPolicy(metav1.DeletePropagationBackground),
+				)
+			})
+
+			By(fmt.Sprintf("creating %d persistent volume claims", pvcCount))
+			createInParallel(ctx, pvcCount, "pvc", func(i int) client.Object {
+				pvc, err := kwok.NewPVC(fmt.Sprintf("pvc-%d", i), testNamespace)
+				Expect(err).NotTo(HaveOccurred(), "rendering pvc %d", i)
+				return pvc
+			})
+
+			By("sleeping for 1 minute to allow resources to stabilize")
+			time.Sleep(1 * time.Minute)
+
+			By("capturing heap dumps from csi-local-node and csi-local-manager pods")
+			captureHeapDumps(ctx, *supportBundleDir)
+		})
+
+		It("should not be oomkilled when many resources exist", func(ctx context.Context) {
+			By("watching csi-local-node and csi-local-manager pods for OOMKilled")
+			Consistently(ctx, func(g Gomega) {
+				for _, sel := range []client.MatchingLabels{
+					{"app.kubernetes.io/component": "csi-local-node"},
+					{"app.kubernetes.io/component": "manager"},
+				} {
+					var pods corev1.PodList
+					g.Expect(k8sClient.List(ctx, &pods, client.InNamespace("kube-system"), sel)).To(Succeed(), "listing pods %v", sel)
+					real := pods.Items[:0]
+					for _, p := range pods.Items {
+						// Skip pods scheduled onto kwok-managed fake nodes.
+						if strings.HasPrefix(p.Spec.NodeName, "node-") {
+							continue
+						}
+						real = append(real, p)
+					}
+					g.Expect(real).NotTo(BeEmpty(), "no real-node pods matched %v", sel)
+					for _, p := range real {
+						for _, cs := range p.Status.ContainerStatuses {
+							if cs.State.Terminated != nil {
+								g.Expect(cs.State.Terminated.Reason).NotTo(Equal("OOMKilled"), "pod %s/%s container %s OOMKilled", p.Namespace, p.Name, cs.Name)
+							}
+							if cs.LastTerminationState.Terminated != nil {
+								g.Expect(cs.LastTerminationState.Terminated.Reason).NotTo(Equal("OOMKilled"), "pod %s/%s container %s previously OOMKilled", p.Namespace, p.Name, cs.Name)
+							}
+						}
+					}
+				}
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "csi-local pods should not be OOMKilled")
+		})
+	})
+})
+
+// deleteAllInParallel paginates a List of objects matching listOpts and
+// deletes each item in parallel (capped at parallelism). For each item it
+// issues a Delete and moves on; the outer loop re-lists until empty, so
+// the function only returns after every targeted object has been fully
+// removed from etcd (finalizers cleared, deletionTimestamp processed).
+//
+// The collection-level DeleteAllOf can hit the apiserver --request-timeout
+// (504) at scale - this avoids that by issuing many small per-item DELETEs
+// while still bounding total time.
+//
+// listFn must return a fresh empty list each call. delOpts apply to every
+// Delete call.
+func deleteAllInParallel(
+	ctx context.Context,
+	kind string,
+	listFn func() client.ObjectList,
+	listOpts []client.ListOption,
+	delOpts ...client.DeleteOption,
+) {
+	GinkgoHelper()
+
+	const pageSize = 500
+	var totalDeleted int
+	var rounds int
+
+	for {
+		rounds++
+		list := listFn()
+		opts := append([]client.ListOption{client.Limit(pageSize)}, listOpts...)
+		err := retry.OnError(retry.DefaultBackoff, isTransient, func() error {
+			return k8sClient.List(ctx, list, opts...)
+		})
+		Expect(err).NotTo(HaveOccurred(), "listing %ss for delete (round %d)", kind, rounds)
+
+		items, err := meta.ExtractList(list)
+		Expect(err).NotTo(HaveOccurred(), "extracting %s list items", kind)
+		if len(items) == 0 {
+			By(fmt.Sprintf("deleted %d %ss in %d rounds", totalDeleted, kind, rounds))
+			return
+		}
+
+		By(fmt.Sprintf("deleting %ss: round %d page=%d total-so-far=%d", kind, rounds, len(items), totalDeleted))
+
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(parallelism)
+		for _, raw := range items {
+			obj, ok := raw.(client.Object)
+			Expect(ok).To(BeTrue(), "list item is not a client.Object: %T", raw)
+			g.Go(func() error {
+				// Strip finalizers first so kube protection controllers
+				// (pvc-protection, pv-protection) don't serially gate
+				// deletion. The pvc-protection-controller is a single-worker
+				// loop in upstream KCM and cannot keep up at 50k+ scale.
+				// Safe in test cleanup: we don't care about graceful drain.
+				if len(obj.GetFinalizers()) > 0 {
+					patch := []byte(`{"metadata":{"finalizers":null}}`)
+					if err := retry.OnError(retry.DefaultBackoff, isTransient, func() error {
+						return client.IgnoreNotFound(k8sClient.Patch(gctx, obj,
+							client.RawPatch(types.MergePatchType, patch)))
+					}); err != nil {
+						return fmt.Errorf("clearing finalizers on %s %s: %w", kind, obj.GetName(), err)
+					}
+				}
+				if err := retry.OnError(retry.DefaultBackoff, isTransient, func() error {
+					return client.IgnoreNotFound(k8sClient.Delete(gctx, obj, delOpts...))
+				}); err != nil {
+					return fmt.Errorf("deleting %s %s: %w", kind, obj.GetName(), err)
+				}
+				return nil
+			})
+		}
+		Expect(g.Wait()).To(Succeed(), "deleting %ss (round %d)", kind, rounds)
+		totalDeleted += len(items)
+	}
+}
+
+// createInParallel creates n objects via k8sClient.Create using an errgroup
+// capped at parallelism. Already-existing objects are ignored to keep
+// BeforeAll idempotent across re-runs.
+//
+//nolint:unparam // n is fixed at the current scale but kept parameterized for future callers.
+func createInParallel(ctx context.Context, n int, kind string, build func(i int) client.Object) {
+	GinkgoHelper()
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(parallelism)
+	for i := range n {
+		if gctx.Err() != nil {
+			break
+		}
+		if i%logInterval == 0 {
+			By(fmt.Sprintf("creating %s %d", kind, i))
+		}
+		obj := build(i)
+		g.Go(func() error {
+			err := retry.OnError(retry.DefaultBackoff, isTransient, func() error {
+				return client.IgnoreAlreadyExists(k8sClient.Create(gctx, obj))
+			})
+			if err != nil {
+				return fmt.Errorf("creating %s %s: %w", kind, obj.GetName(), err)
+			}
+			return nil
+		})
+	}
+	Expect(g.Wait()).To(Succeed(), "creating %d %ss", n, kind)
+}
+
+// isTransient returns true for API errors that are worth retrying:
+// rate limiting, timeouts, brief unavailability, and internal errors.
+func isTransient(err error) bool {
+	return apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsInternalError(err)
+}
+
+// captureHeapDumps fetches /debug/pprof/heap from each csi-local-node and
+// csi-local-manager pod via `kubectl get --raw` (API server proxy) and
+// writes the gzipped profiles to outDir/heap-dumps/. Failures are logged
+// to GinkgoWriter and do not fail the test - this is best-effort diagnostics.
+func captureHeapDumps(ctx context.Context, outDir string) {
+	GinkgoHelper()
+
+	dir := filepath.Join(outDir, "heap-dumps")
+	Expect(os.MkdirAll(dir, 0o755)).To(Succeed(), "creating heap dump dir %s", dir)
+
+	selectors := map[string]client.MatchingLabels{
+		"driver":  {"app.kubernetes.io/component": "csi-local-node"},
+		"manager": {"app.kubernetes.io/component": "manager"},
+	}
+
+	for kind, sel := range selectors {
+		var pods corev1.PodList
+		if err := k8sClient.List(ctx, &pods, client.InNamespace("kube-system"), sel); err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "listing %s pods: %v\n", kind, err)
+			continue
+		}
+		for _, p := range pods.Items {
+			out := filepath.Join(dir, fmt.Sprintf("%s-%s.pb.gz", kind, p.Name))
+			path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s:6060/proxy/debug/pprof/heap?gc=1", p.Namespace, p.Name)
+			cmd := exec.CommandContext(ctx, "kubectl", "get", "--raw", path)
+			data, err := cmd.Output()
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "fetching heap for %s/%s: %v\n", p.Namespace, p.Name, err)
+				continue
+			}
+			if err := os.WriteFile(out, data, 0o644); err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "writing heap dump %s: %v\n", out, err)
+				continue
+			}
+			_, _ = fmt.Fprintf(GinkgoWriter, "wrote heap dump %s (%d bytes)\n", out, len(data))
+		}
+	}
+}
+
+// triggerNodeInformerPV returns a PV that the csi-local-manager
+// pvcleanup-controller will reconcile (real driver name, Delete reclaim,
+// PVProtection finalizer, hostname topology, and a claimRef to a
+// non-existent PVC). The first reconcile does a cached Get(Node{Name:hostname})
+// which lazily starts the manager's Node informer - causing it to stream
+// the full node list (10k+ in the kwok scale test) into the
+// controller-runtime cache.
+//
+// The claimRef is required: a Released PV with no claimRef is reverted to
+// Available by the kube PV controller, which would make the pvcleanup phase
+// guard short-circuit before the Node Get. Pointing at a PVC that does not
+// exist keeps Released durable.
+//
+// Caller must patch Status.Phase=Released after Create so the controller's
+// phase guard doesn't short-circuit.
+func triggerNodeInformerPV(name, hostname string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Finalizers: []string{"kubernetes.io/pv-protection"},
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Capacity:                      corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+			// A Released PV must reference a claim; without a claimRef the
+			// kube PV controller forces Phase back to Available, so the
+			// pvcleanup phase guard would bail before the Node Get. Point at
+			// a PVC that does not exist (stale UID) so Released is durable.
+			ClaimRef: &corev1.ObjectReference{
+				Kind:      "PersistentVolumeClaim",
+				Namespace: "kube-system",
+				Name:      name + "-gone",
+				UID:       types.UID(uuid.NewString()),
+			},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       lvm.DriverName,
+					VolumeHandle: name,
+				},
+			},
+			NodeAffinity: &corev1.VolumeNodeAffinity{
+				Required: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							// Must match lvm.TopologyKey: extractHostnamesFromPV
+							// in the pvcleanup controller only reads node names
+							// from this key. Using kubernetes.io/hostname here
+							// makes the controller skip the PV before it Gets the
+							// Node, so the Node informer never starts.
+							Key:      lvm.TopologyKey,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{hostname},
+						}},
+					}},
+				},
+			},
+		},
+	}
+}

--- a/test/kwok/values-kwok.yaml
+++ b/test/kwok/values-kwok.yaml
@@ -1,0 +1,40 @@
+# Values overrides for the kwok scale test.
+#
+# The default chart tolerates any NoSchedule/NoExecute taint via Exists,
+# which would let csi pods schedule onto the kwok-managed fake nodes
+# (tainted with kwok.x-k8s.io/node=fake:NoSchedule). Remove those broad
+# tolerations so csi-local-node and csi-local-manager only run on real
+# nodes during the kwok scale test.
+daemonset:
+  tolerations: []
+
+manager:
+  deployment:
+    tolerations: []
+
+# Bump memory limits well above the chart defaults so the driver and
+# manager don't OOMKill before we can capture heap profiles. Pair with
+# pprof enablement below to investigate memory growth.
+resources:
+  driver:
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 10m
+      memory: 60Mi
+  manager:
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+
+observability:
+  driver:
+    pprof:
+      enabled: true
+      port: 6060
+  manager:
+    pprof:
+      enabled: true
+      port: 6060

--- a/test/pkg/kwok/fixtures.go
+++ b/test/pkg/kwok/fixtures.go
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package kwok
+
+import "path/filepath"
+
+var (
+	basePath = filepath.Join("test", "pkg", "kwok", "fixtures")
+
+	KwokNode         = filepath.Join(basePath, "node.yaml")
+	KwokPod          = filepath.Join(basePath, "pod.yaml")
+	KwokPV           = filepath.Join(basePath, "pv.yaml")
+	KwokPVC          = filepath.Join(basePath, "pvc.yaml")
+	KwokStorageClass = filepath.Join(basePath, "storageclass.yaml")
+)

--- a/test/pkg/kwok/fixtures/node.yaml
+++ b/test/pkg/kwok/fixtures/node.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-0
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    topology.localdisk.csi.acstor.io/node: kwok-node-0
+    type: kwok
+  name: kwok-node-0
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+  - effect: NoSchedule
+    key: kwok.x-k8s.io/node
+    value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running

--- a/test/pkg/kwok/fixtures/pod.yaml
+++ b/test/pkg/kwok/fixtures/pod.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fake-pod
+  namespace: default
+  labels:
+    app: fake-pod
+    type: kwok
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: type
+                operator: In
+                values:
+                  - kwok
+  tolerations:
+    - key: "kwok.x-k8s.io/node"
+      operator: "Exists"
+      effect: "NoSchedule"
+  containers:
+    - name: fake-container
+      image: fake-image

--- a/test/pkg/kwok/fixtures/pv.yaml
+++ b/test/pkg/kwok/fixtures/pv.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kwok-pv-0
+  labels:
+    type: kwok
+spec:
+  storageClassName: kwok-synthetic
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: kwok.synthetic.local
+    volumeHandle: kwok-synthetic
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - kwok-synthetic-node

--- a/test/pkg/kwok/fixtures/pvc.yaml
+++ b/test/pkg/kwok/fixtures/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kwok-pvc-0
+  labels:
+    type: kwok
+spec:
+  storageClassName: kwok-noop
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/pkg/kwok/fixtures/storageclass.yaml
+++ b/test/pkg/kwok/fixtures/storageclass.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: kwok-noop
+# A real StorageClass with a no-op provisioner. Used by kwok fake PVCs so the
+# kube-controller-manager pv_controller resolves the StorageClass (instead of
+# logging "storageclass not found" on every reconcile) but never attempts to
+# provision a volume. WaitForFirstConsumer further suppresses pv-binder churn
+# until a pod actually schedules onto the PVC, which kwok PVCs never trigger.
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete

--- a/test/pkg/kwok/kwok.go
+++ b/test/pkg/kwok/kwok.go
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package kwok
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/yaml"
+
+	"local-csi-driver/internal/csi/core/lvm"
+	"local-csi-driver/test/pkg/common"
+	"local-csi-driver/test/pkg/utils"
+)
+
+// Install installs Kwok into the current cluster.
+func Install(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "make", "kwok")
+	if _, err := utils.Run(cmd); err != nil {
+		return fmt.Errorf("installing kwok: %w", err)
+	}
+	return nil
+}
+
+// Uninstall uninstalls Kwok from the current cluster.
+func Uninstall(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "make", "kwok-uninstall")
+	if _, err := utils.Run(cmd); err != nil {
+		return fmt.Errorf("uninstalling kwok: %w", err)
+	}
+	return nil
+}
+
+func loadFixture(path string, out any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	if err := yaml.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("unmarshalling %s: %w", path, err)
+	}
+	return nil
+}
+
+// NewNode returns a *corev1.Node populated from the kwok node fixture with the
+// given name (also applied to the kubernetes.io/hostname label).
+func NewNode(name string) (*corev1.Node, error) {
+	var node corev1.Node
+	if err := loadFixture(KwokNode, &node); err != nil {
+		return nil, err
+	}
+	node.Name = name
+	if node.Labels == nil {
+		node.Labels = make(map[string]string)
+	}
+	node.Labels[corev1.LabelHostname] = name
+	node.Labels[lvm.TopologyKey] = name
+	return &node, nil
+}
+
+// NewPV returns a *corev1.PersistentVolume populated from the kwok pv fixture.
+func NewPV(name string) (*corev1.PersistentVolume, error) {
+	var pv corev1.PersistentVolume
+	if err := loadFixture(KwokPV, &pv); err != nil {
+		return nil, err
+	}
+	pv.Name = name
+	return &pv, nil
+}
+
+// NewPVC returns a *corev1.PersistentVolumeClaim populated from the kwok pvc
+// fixture.
+func NewPVC(name, ns string) (*corev1.PersistentVolumeClaim, error) {
+	var pvc corev1.PersistentVolumeClaim
+	if err := loadFixture(KwokPVC, &pvc); err != nil {
+		return nil, err
+	}
+	pvc.Name = name
+	pvc.Namespace = ns
+	return &pvc, nil
+}
+
+// NewPod returns a *corev1.Pod populated from the kwok pod fixture.
+func NewPod(name, ns string) (*corev1.Pod, error) {
+	var pod corev1.Pod
+	if err := loadFixture(KwokPod, &pod); err != nil {
+		return nil, err
+	}
+	pod.Name = name
+	pod.Namespace = ns
+	return &pod, nil
+}
+
+// NewStorageClass returns the shared LVM storageclass fixture used by e2e and
+// scale tests.
+func NewStorageClass() (*storagev1.StorageClass, error) {
+	var sc storagev1.StorageClass
+	if err := loadFixture(common.LvmStorageClassFixture, &sc); err != nil {
+		return nil, err
+	}
+	return &sc, nil
+}
+
+// NewNoopStorageClass returns a no-op StorageClass referenced by the kwok PVC
+// fixture. The SC uses kubernetes.io/no-provisioner with
+// volumeBindingMode=WaitForFirstConsumer so kube-controller-manager's
+// pv_controller does not flood logs with "storageclass not found" or attempt
+// to provision the kwok fake PVCs.
+func NewNoopStorageClass() (*storagev1.StorageClass, error) {
+	var sc storagev1.StorageClass
+	if err := loadFixture(KwokStorageClass, &sc); err != nil {
+		return nil, err
+	}
+	return &sc, nil
+}
+
+// NewWarmupStatefulSet returns an *appsv1.StatefulSet built from the shared
+// LVM statefulset fixture, scaled down to a single replica, so the local-csi
+// driver's informers and gRPC paths are exercised before kwok scale load.
+func NewWarmupStatefulSet(ns string) (*appsv1.StatefulSet, error) {
+	var ss appsv1.StatefulSet
+	if err := loadFixture(common.LvmStatefulSetFixture, &ss); err != nil {
+		return nil, err
+	}
+	ss.Namespace = ns
+	one := int32(10)
+	ss.Spec.Replicas = &one
+	return &ss, nil
+}

--- a/test/pkg/utils/utils.go
+++ b/test/pkg/utils/utils.go
@@ -28,8 +28,25 @@ func warnError(err error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
 }
 
+// RunOption configures the behavior of Run.
+type RunOption func(*runOptions)
+
+type runOptions struct {
+	silent bool
+}
+
+// Silent suppresses logging of the command and its output to GinkgoWriter.
+func Silent() RunOption {
+	return func(o *runOptions) { o.silent = true }
+}
+
 // Run executes the provided command within this context.
-func Run(cmd *exec.Cmd) (string, error) {
+func Run(cmd *exec.Cmd, opts ...RunOption) (string, error) {
+	var o runOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	dir, _ := GetProjectDir()
 	cmd.Dir = dir
 	if err := os.Chdir(cmd.Dir); err != nil {
@@ -38,10 +55,14 @@ func Run(cmd *exec.Cmd) (string, error) {
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
-	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
+	if !o.silent {
+		_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "%s failed with error: (%v) %s\n", command, err, string(output))
+		if !o.silent {
+			_, _ = fmt.Fprintf(GinkgoWriter, "%s failed with error: (%v) %s\n", command, err, string(output))
+		}
 		return string(output), err
 	}
 
@@ -137,6 +158,7 @@ func GetProjectDir() (string, error) {
 	wd = strings.ReplaceAll(wd, "/test/sanity", "")
 	wd = strings.ReplaceAll(wd, "/test/scale", "")
 	wd = strings.ReplaceAll(wd, "/test/aks", "")
+	wd = strings.ReplaceAll(wd, "/test/kwok", "")
 	return wd, nil
 }
 


### PR DESCRIPTION
This pull request introduces support for running end-to-end scale tests using a kwok-tuned kind cluster, alongside several improvements to observability and test infrastructure. The most significant changes are the addition of the Kwok cluster type and associated Makefile targets, enhancements to pprof profiling configuration for both the driver and manager, and improvements to test job configuration and cluster management.

**Kwok Cluster Support and Test Infrastructure:**

* Added a new `KwokCluster` class to `.github/workflows/scripts/run_tests.py` to manage kwok-tuned kind clusters for scale testing, including setup and cleanup logic. The cluster is created with `make kwok-bootstrap` and is designed for high-scale fake node scenarios.
* Updated the test matrix and job definitions in `.github/workflows/test-e2e-pr.yml` to add a "Kwok Scale" test job, which uses the new `kwok` cluster type and appropriate Makefile targets and environment variables. This ensures scale tests run in CI using the kwok-tuned cluster. [[1]](diffhunk://#diff-9a93506f97e62db8ec3b1b9d6bfa83f7dd343544a3ca27f29d8d8e8432fbef59R53-R88) [[2]](diffhunk://#diff-9a93506f97e62db8ec3b1b9d6bfa83f7dd343544a3ca27f29d8d8e8432fbef59R171-R184)
* Extended the test runner and argument parsing to support the `kwok` cluster type, allowing selection via the `--cluster-type` flag. [[1]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1R475-R476) [[2]](diffhunk://#diff-b0645f4ba81dcc85bb52f6235fb0d279bc3678d8127de02112213611ea4c29a1L524-R551)

**Makefile Enhancements for Kwok and Cluster Management:**

* Added new Makefile targets for kwok cluster management: `kwok-cluster`, `kwok-bootstrap`, `kwok`, and `kwok-uninstall`, as well as improved cluster creation logic for kind and kwok clusters. These targets streamline setup, teardown, and installation of kwok and its dependencies. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L418-R451) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R576-R589)
* Improved Makefile logic for loading Docker images, deploying with Helm, and managing the PATH for local binaries, ensuring compatibility with kwok and kind clusters. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L274-R288) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R490-R491) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L363-R372)

**Observability Improvements:**

* Added support for configuring pprof profiling for both the driver and manager via new Helm values (`pprof.enabled` and `pprof.port`) and command-line flags (`--pprof-bind-address`). The deployment templates and Go binaries now expose pprof endpoints when enabled, aiding in performance diagnostics. [[1]](diffhunk://#diff-fcc631e58f1d911bbb1909e7edef4d9a41a03bae29c7467d6ac83b83a062b6f0R83-R85) [[2]](diffhunk://#diff-3022985828c4e2df4f6f02a0f503429c17e1c0f6903248ef15cbbe6406d70ea2R56-R58) [[3]](diffhunk://#diff-d29b314008db700bde7facdb68fc5dcd58008824558728002e8d9b436fb0fc04R245-R257) [[4]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943R71) [[5]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943R97-R98) [[6]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943R205) [[7]](diffhunk://#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633R61) [[8]](diffhunk://#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633R90-R91) [[9]](diffhunk://#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633R203)

**Other Improvements and Fixes:**

* Updated test and cluster setup scripts to ensure environment consistency, such as setting the PATH for local binaries and improving comments for clarity. [[1]](diffhunk://#diff-9a93506f97e62db8ec3b1b9d6bfa83f7dd343544a3ca27f29d8d8e8432fbef59R156) [[2]](diffhunk://#diff-989ca650f20e4a3111117104433c2f08d16b1826b8c724ac48d123c6d252bf0aR34)
* Adjusted Helm deployment defaults to use `IfNotPresent` pull policy for images, optimizing for local development and CI runs.

These changes collectively enable scalable, efficient CI testing using kwok, improve profiling capabilities, and streamline cluster management for both development and automated testing.