### PR TITLE
feat: optimize memory and apiserver use

### DIFF
--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -72,6 +72,7 @@ spec:
         args:
         - --node-name=$(NODE_NAME)
         - --pod-name=$(POD_NAME)
+        - --pod-uid=$(POD_UID)
         - --namespace=$(POD_NAMESPACE)
         - --csi-bind-address=unix:///csi/csi.sock
         - --worker-threads={{ .Values.scalability.driver.workerThreads }}
@@ -96,6 +97,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -224,7 +224,7 @@ resources:
       memory: 20Mi
   manager:
     limits:
-      memory: 128Mi
+      memory: 500Mi
     requests:
       cpu: 10m
       memory: 64Mi

--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -26,13 +26,17 @@ import (
 	"local-csi-driver/internal/pkg/raid"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2/textlogger"
 	"k8s.io/utils/exec"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -64,6 +68,7 @@ func init() {
 func main() {
 	var nodeName string
 	var podName string
+	var podUID string
 	var namespace string
 	var csiAddr string
 	var metricsAddr string
@@ -86,6 +91,8 @@ func main() {
 		"The name of the node this agent is running on.")
 	flag.StringVar(&podName, "pod-name", "",
 		"The name of the pod this agent is running on.")
+	flag.StringVar(&podUID, "pod-uid", "",
+		"The UID of the pod this agent is running on. Used as the subject for node-scoped events.")
 	flag.StringVar(&namespace, "namespace", "default",
 		"The namespace to use for creating objects.")
 	flag.StringVar(&csiAddr, "csi-bind-address", "unix:///tmp/csi.sock",
@@ -201,11 +208,17 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         false, // No webhooks, no leader election needed
 		LeaderElectionID:       "local-csi-driver",
-		// Pod is only read once at startup (StartupDiagnostic). Bypass the
-		// cache so we don't start a cluster-wide Pod informer on every node.
+		Cache: cache.Options{
+			DefaultTransform: cache.TransformStripManagedFields(),
+		},
 		Client: client.Options{
 			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{&corev1.Pod{}},
+				DisableFor: []client.Object{
+					&storagev1.CSIDriver{},
+					&metav1.PartialObjectMetadata{
+						TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Node"},
+					},
+				},
 			},
 		},
 	})
@@ -258,9 +271,11 @@ func main() {
 		recorder = mgr.GetEventRecorder("local-csi-driver")
 	}
 
+	selfPod := getPod(podName, namespace, podUID)
+
 	// Run startup diagnostic to check disk availability and emit a Warning
 	// event on the pod if no disks are available for volume group creation.
-	startupDiag := lvm.NewStartupDiagnostic(deviceProbe, blockDevUtils, probe.EphemeralDiskFilter, recorder, mgr.GetClient(), podName, namespace)
+	startupDiag := lvm.NewStartupDiagnostic(deviceProbe, blockDevUtils, probe.EphemeralDiskFilter, recorder, selfPod)
 	if err := mgr.Add(startupDiag); err != nil {
 		logAndExit(err, "unable to add startup diagnostic to manager")
 	}
@@ -314,7 +329,7 @@ func main() {
 	}
 
 	// Create the CSI server.
-	csiServer, err := server.NewCombined(csiAddr, driver.NewCombined(nodeName, volumeClient, mgr.GetClient(), runAlongsideWebhook, recorder, tp), t)
+	csiServer, err := server.NewCombined(csiAddr, driver.NewCombined(nodeName, selfPod, volumeClient, mgr.GetClient(), runAlongsideWebhook, recorder, tp), t)
 	if err != nil {
 		logAndExit(err, "unable to create csi server")
 	}
@@ -333,6 +348,20 @@ func main() {
 	span.AddEvent("starting manager")
 	if err := mgr.Start(ctx); err != nil {
 		logAndExit(err, "problem running manager")
+	}
+}
+
+func getPod(name, ns, uid string) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			UID:       types.UID(uid),
+		},
 	}
 }
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"local-csi-driver/internal/manager/pvcleanup"
+	"local-csi-driver/internal/manager/transform"
 	"local-csi-driver/internal/pkg/events"
 	"local-csi-driver/internal/pkg/version"
 	"local-csi-driver/internal/webhook/enforceEphemeral"
@@ -211,6 +212,7 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		LeaderElectionReleaseOnCancel: true,
+		Cache:                         transform.ManagerCacheOptions(),
 	})
 	if err != nil {
 		logAndExit(err, "unable to start manager")

--- a/internal/csi/controller/controller.go
+++ b/internal/csi/controller/controller.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kevents "k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,6 +36,7 @@ type Server struct {
 	mounter                  mounter.Interface
 	k8sClient                client.Client
 	nodeId                   string
+	selfPod                  *corev1.Pod
 	selectedNodeAnnotation   string
 	selectedInitialNodeParam string
 	removePvNodeAffinity     bool
@@ -47,7 +50,7 @@ type Server struct {
 // Server must implement the csi.ControllerServer interface.
 var _ csi.ControllerServer = &Server{}
 
-func New(volume core.ControllerInterface, caps []*csi.ControllerServiceCapability, modes []*csi.VolumeCapability_AccessMode, mounter mounter.Interface, k8sClient client.Client, nodeID, selectedNodeAnnotation string, selectedInitialNodeParam string, removePvNodeAffinity bool, recorder kevents.EventRecorder, tp trace.TracerProvider) *Server {
+func New(volume core.ControllerInterface, caps []*csi.ControllerServiceCapability, modes []*csi.VolumeCapability_AccessMode, mounter mounter.Interface, k8sClient client.Client, nodeID string, selfPod *corev1.Pod, selectedNodeAnnotation string, selectedInitialNodeParam string, removePvNodeAffinity bool, recorder kevents.EventRecorder, tp trace.TracerProvider) *Server {
 	return &Server{
 		caps:                     caps,
 		modes:                    modes,
@@ -55,6 +58,7 @@ func New(volume core.ControllerInterface, caps []*csi.ControllerServiceCapabilit
 		mounter:                  mounter,
 		k8sClient:                k8sClient,
 		nodeId:                   nodeID,
+		selfPod:                  selfPod,
 		selectedNodeAnnotation:   selectedNodeAnnotation,
 		selectedInitialNodeParam: selectedInitialNodeParam,
 		removePvNodeAffinity:     removePvNodeAffinity,
@@ -96,20 +100,7 @@ func (cs *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 	if limit > 0 && capacity > limit {
 		return nil, status.Error(codes.InvalidArgument, "capacity cannot exceed limit")
 	}
-
-	// Fetch PVC to be used as reference object in events.
-	var pvc *corev1.PersistentVolumeClaim
-	if req.Parameters[core.PVCNameParam] != "" && req.Parameters[core.PVCNamespaceParam] != "" {
-		pvc = &corev1.PersistentVolumeClaim{}
-		if err := cs.k8sClient.Get(ctx, client.ObjectKey{Namespace: req.Parameters[core.PVCNamespaceParam], Name: req.Parameters[core.PVCNameParam]}, pvc); err != nil {
-			// We error in this scenario because we need the PVC to be able to
-			// check the owner references and set the volume to be
-			// accessible from all nodes if it is not a generic ephemeral volume.
-			log.Error(err, "failed to get pvc", "name", req.Parameters[core.PVCNameParam], "namespace", req.Parameters[core.PVCNamespaceParam])
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		ctx = events.WithObjectIntoContext(ctx, cs.recorder, pvc)
-	}
+	ctx = events.WithObjectIntoContext(ctx, cs.recorder, cs.selfPod)
 
 	// Create using the volume api.
 	vol, err := cs.volume.Create(ctx, req)
@@ -126,9 +117,11 @@ func (cs *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 	// This approach works effectively when a webhook enforces hyperconvergence of workloads
 	// and volumes; otherwise, it may not be suitable.
 	if cs.removePvNodeAffinity {
-		if pvc == nil {
-			// We get the pvc from the request above, if we skip it will be nil
-			// and we will not be able to set the volume to be accessible from all nodes.
+		if req.Parameters[core.PVCNameParam] == "" || req.Parameters[core.PVCNamespaceParam] == "" {
+			// The external-provisioner injects these parameters when
+			// `--extra-create-metadata=true` is set. Without them we have no
+			// way to associate the volume with its claim, so we leave node
+			// affinity intact (the volume stays single-node).
 			log.V(2).Info("CreateVolume succeeded but pvc namespace or name not found")
 			span.SetStatus(otcodes.Ok, "CreateVolume succeeded but pvc namespace or name not found")
 			return &csi.CreateVolumeResponse{Volume: vol}, nil
@@ -217,7 +210,10 @@ func (cs *Server) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest
 			// Check if the node exists in the cluster.
 			// If it does not exist, we can return success without deleting the volume
 			// since the PV cleanup controller will handle finalizer removal.
-			if err := cs.k8sClient.Get(ctx, client.ObjectKey{Name: selectedNode}, &corev1.Node{}); err != nil {
+			// TODO(jlong): move cleanup to csi-manager to avoid PartialObjectMetadata GET in driver
+			nodeMeta := &metav1.PartialObjectMetadata{}
+			nodeMeta.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Node"})
+			if err := cs.k8sClient.Get(ctx, client.ObjectKey{Name: selectedNode}, nodeMeta); err != nil {
 				if client.IgnoreNotFound(err) == nil { // node not found
 					log.V(2).Info("node not found, assuming it has been deleted", "name", selectedNode)
 					span.SetStatus(otcodes.Ok, "node not found")

--- a/internal/csi/controller/controller_test.go
+++ b/internal/csi/controller/controller_test.go
@@ -199,7 +199,11 @@ func initTestControllerServer(ctrl *gomock.Controller) *Server {
 		{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
 	}
 
-	return New(vc, caps, modes, m, client, "test-node", selectedNodeAnnotation, selectedInitialNodeAnnotation, true, r, tp)
+	selfPod := &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "test-namespace"},
+	}
+	return New(vc, caps, modes, m, client, "test-node", selfPod, selectedNodeAnnotation, selectedInitialNodeAnnotation, true, r, tp)
 }
 
 func TestServer_CreateVolume(t *testing.T) {

--- a/internal/csi/core/lvm/controller.go
+++ b/internal/csi/core/lvm/controller.go
@@ -26,8 +26,6 @@ import (
 
 const (
 	// Logical Volume (LV) related event reasons.
-	deletingLogicalVolume       = "DeletingLogicalVolume"
-	deletedLogicalVolume        = "DeletedLogicalVolume"
 	deletingLogicalVolumeFailed = "DeletingLogicalVolumeFailed"
 
 	defaultPeSize        = 4 * 1024 * 1024 // 4 MiB
@@ -161,7 +159,6 @@ func (l *LVM) Delete(ctx context.Context, req *csi.DeleteVolumeRequest) error {
 	ticker := time.NewTicker(removeVolumeRetryPoll)
 	defer ticker.Stop()
 
-	recorder.Eventf(corev1.EventTypeNormal, deletingLogicalVolume, "Starting deletion of logical volume %s", volumeId)
 	var lastErr error
 	for {
 		select {
@@ -174,7 +171,6 @@ func (l *LVM) Delete(ctx context.Context, req *csi.DeleteVolumeRequest) error {
 		case <-ticker.C:
 			err := l.lvm.RemoveLogicalVolume(ctx, deleteOps)
 			if lvm.IgnoreNotFound(err) == nil {
-				recorder.Eventf(corev1.EventTypeNormal, deletedLogicalVolume, "Successfully deleted logical volume %s", volumeId)
 				span.AddEvent("deleted logical volume")
 				span.SetStatus(codes.Ok, "deleted logical volume")
 				return nil

--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -51,18 +51,14 @@ const (
 	ID = "lvm"
 
 	// Physical Volume (PV) related event reasons.
-	provisioningPhysicalVolume       = "ProvisioningPhysicalVolume"
 	provisionedPhysicalVolume        = "ProvisionedPhysicalVolume"
 	provisioningPhysicalVolumeFailed = "ProvisioningPhysicalVolumeFailed"
 
 	// Volume Group (VG) related event reasons.
-	provisioningVolumeGroup       = "ProvisioningVolumeGroup"
 	provisionedVolumeGroup        = "ProvisionedVolumeGroup"
 	provisioningVolumeGroupFailed = "ProvisioningVolumeGroupFailed"
 
 	// Logical Volume (LV) related event reasons.
-	provisioningLogicalVolume            = "ProvisioningLogicalVolume"
-	provisionedLogicalVolume             = "ProvisionedLogicalVolume"
 	provisioningLogicalVolumeFailed      = "ProvisioningLogicalVolumeFailed"
 	provisionedLogicalVolumeSizeMismatch = "ProvisionedLogicalVolumeSizeMismatch"
 	provisionedEmptyVolume               = "ProvisionedEmptyVolume"
@@ -268,7 +264,6 @@ func (l *LVM) EnsureVolumeGroup(ctx context.Context, name string, devices []stri
 		return vg, nil
 	}
 
-	recorder.Eventf(corev1.EventTypeNormal, provisioningVolumeGroup, "Provisioning volume group %s", name)
 	// Create the volume group.
 	if err := l.lvm.CreateVolumeGroup(ctx, lvm.CreateVGOptions{
 		Name:    name,
@@ -485,7 +480,6 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity int64,
 		return lvSize, nil
 	}
 
-	recorder.Eventf(corev1.EventTypeNormal, provisioningLogicalVolume, "Provisioning logical volume %s/%s", id.VolumeGroup, id.LogicalVolume)
 	log.V(2).Info("no existing volume found, creating new one")
 	// Check if the volume group already exists and create if needed.
 	vg, err := l.lvm.GetVolumeGroup(ctx, id.VolumeGroup)
@@ -546,7 +540,6 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity int64,
 
 	log.V(1).Info("created logical volume", "capacity", allocatedSize)
 	span.AddEvent("created logical volume", trace.WithAttributes(attribute.Int64("capacity", allocatedSize)))
-	recorder.Eventf(corev1.EventTypeNormal, provisionedLogicalVolume, "Successfully provisioned logical volume %s/%s", id.VolumeGroup, id.LogicalVolume)
 	if isMountOperation {
 		recorder.Eventf(corev1.EventTypeNormal, provisionedEmptyVolume, "A new empty volume was created during mount because the logical volume %s/%s was not found on the node. This may indicate the volume was not previously provisioned on this node.", id.VolumeGroup, id.LogicalVolume)
 	}

--- a/internal/csi/core/lvm/startup.go
+++ b/internal/csi/core/lvm/startup.go
@@ -11,7 +11,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	kevents "k8s.io/client-go/tools/events"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"local-csi-driver/internal/pkg/block"
@@ -29,33 +28,32 @@ const (
 // event if no disks are available, or a Normal event listing available and
 // in-use disks.
 type StartupDiagnostic struct {
-	probe     probe.Interface
-	block     block.Interface
-	filter    *probe.Filter
-	recorder  kevents.EventRecorder
-	k8sClient client.Client
-	podName   string
-	namespace string
+	probe    probe.Interface
+	block    block.Interface
+	filter   *probe.Filter
+	recorder kevents.EventRecorder
+	pod      *corev1.Pod
 }
 
 // NewStartupDiagnostic creates a new StartupDiagnostic instance.
+//
+// pod is an ObjectReference to the driver Pod itself (built from downward-API
+// env vars at startup, not fetched from the apiserver). It is used as the
+// event subject so the diagnostic result is visible via `kubectl describe
+// pod`.
 func NewStartupDiagnostic(
 	p probe.Interface,
 	b block.Interface,
 	filter *probe.Filter,
 	recorder kevents.EventRecorder,
-	k8sClient client.Client,
-	podName string,
-	namespace string,
+	pod *corev1.Pod,
 ) *StartupDiagnostic {
 	return &StartupDiagnostic{
-		probe:     p,
-		block:     b,
-		filter:    filter,
-		recorder:  recorder,
-		k8sClient: k8sClient,
-		podName:   podName,
-		namespace: namespace,
+		probe:    p,
+		block:    b,
+		filter:   filter,
+		recorder: recorder,
+		pod:      pod,
 	}
 }
 
@@ -63,13 +61,6 @@ func NewStartupDiagnostic(
 // once at startup and emits a Kubernetes event on the pod with the results.
 func (s *StartupDiagnostic) Start(ctx context.Context) error {
 	log := log.FromContext(ctx).WithName("startup-diagnostic")
-
-	// Fetch the pod for event emission.
-	var pod corev1.Pod
-	if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: s.namespace, Name: s.podName}, &pod); err != nil {
-		log.Error(err, "failed to get pod for event emission", "pod", s.podName, "namespace", s.namespace)
-		return nil
-	}
 
 	// Check if there are any available disks.
 	devices, err := s.probe.ScanAvailableDevices(ctx)
@@ -84,13 +75,13 @@ func (s *StartupDiagnostic) Start(ctx context.Context) error {
 	if devices == nil || len(devices.Devices) == 0 {
 		log.Info("no available disks found", "totalNVMeDisks", summary.total, "nonLVM2FormattedDisks", summary.nonLVM2Formatted)
 		msg := buildNoDiskMessage(summary)
-		s.recorder.Eventf(&pod, nil, corev1.EventTypeWarning, noDiskAvailable, noDiskAvailable, msg)
+		s.recorder.Eventf(s.pod, nil, corev1.EventTypeWarning, noDiskAvailable, noDiskAvailable, msg)
 		return nil
 	}
 
 	log.Info("startup disk discovery complete", "availableDisks", len(devices.Devices))
 	msg := buildDiskDiscoveryMessage(devices.Devices, summary)
-	s.recorder.Eventf(&pod, nil, corev1.EventTypeNormal, diskDiscoveryComplete, diskDiscoveryComplete, msg)
+	s.recorder.Eventf(s.pod, nil, corev1.EventTypeNormal, diskDiscoveryComplete, diskDiscoveryComplete, msg)
 	return nil
 }
 

--- a/internal/csi/core/lvm/startup_test.go
+++ b/internal/csi/core/lvm/startup_test.go
@@ -12,9 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	kevents "k8s.io/client-go/tools/events"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"local-csi-driver/internal/csi/core/lvm"
 	"local-csi-driver/internal/pkg/block"
@@ -28,17 +26,12 @@ const (
 
 func newTestPod() *corev1.Pod {
 	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: "test-namespace",
 		},
 	}
-}
-
-func newTestScheme() *runtime.Scheme {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	return scheme
 }
 
 func TestStartupDiagnostic_DisksAvailable(t *testing.T) {
@@ -67,9 +60,8 @@ func TestStartupDiagnostic_DisksAvailable(t *testing.T) {
 	mockBlock.EXPECT().IsFormatted("/dev/nvme1n1").Return(false, nil)
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -115,9 +107,8 @@ func TestStartupDiagnostic_DisksAvailable_NoInUse(t *testing.T) {
 	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(false, nil)
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -155,9 +146,8 @@ func TestStartupDiagnostic_NoDisks_AllFormattedNVMe(t *testing.T) {
 	mockBlock.EXPECT().IsLVM2("/dev/nvme0n1").Return(false, nil)
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -198,9 +188,8 @@ func TestStartupDiagnostic_NoDisks_NoNVMe(t *testing.T) {
 	}, nil)
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -232,9 +221,8 @@ func TestStartupDiagnostic_ScanError(t *testing.T) {
 
 	mockBlock := block.NewMock(ctrl)
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -244,30 +232,6 @@ func TestStartupDiagnostic_ScanError(t *testing.T) {
 	select {
 	case event := <-recorder.Events:
 		t.Fatalf("expected no event on scan error, got: %s", event)
-	default:
-	}
-}
-
-func TestStartupDiagnostic_PodNotFound(t *testing.T) {
-	t.Parallel()
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockProbe := probe.NewMock(ctrl)
-	mockBlock := block.NewMock(ctrl)
-	recorder := kevents.NewFakeRecorder(10)
-	// No pod object — simulates pod not found.
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
-
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
-
-	if err := diag.Start(context.Background()); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	select {
-	case event := <-recorder.Events:
-		t.Fatalf("expected no event when pod not found, got: %s", event)
 	default:
 	}
 }
@@ -292,9 +256,8 @@ func TestStartupDiagnostic_MultipleNVMe_SomeFormatted(t *testing.T) {
 	mockBlock.EXPECT().IsFormatted("/dev/nvme1n1").Return(false, nil)
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -318,7 +281,7 @@ func TestStartupDiagnostic_MultipleNVMe_SomeFormatted(t *testing.T) {
 
 func TestStartupDiagnostic_NeedLeaderElection(t *testing.T) {
 	t.Parallel()
-	diag := lvm.NewStartupDiagnostic(nil, nil, nil, nil, nil, "", "")
+	diag := lvm.NewStartupDiagnostic(nil, nil, nil, nil, nil)
 	if diag.NeedLeaderElection() {
 		t.Fatal("expected NeedLeaderElection to return false")
 	}
@@ -336,9 +299,8 @@ func TestStartupDiagnostic_GetDevicesError(t *testing.T) {
 	mockBlock.EXPECT().GetDevices(gomock.Any()).Return(nil, fmt.Errorf("lsblk failed"))
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -372,9 +334,8 @@ func TestStartupDiagnostic_IsFormattedError(t *testing.T) {
 	mockBlock.EXPECT().IsFormatted("/dev/nvme0n1").Return(false, fmt.Errorf("blkid failed"))
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -408,9 +369,8 @@ func TestStartupDiagnostic_IsLVM2Error(t *testing.T) {
 	mockBlock.EXPECT().IsLVM2("/dev/nvme0n1").Return(false, fmt.Errorf("check failed"))
 
 	recorder := kevents.NewFakeRecorder(10)
-	k8sClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(newTestPod()).Build()
 
-	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, k8sClient, "test-pod", "test-namespace")
+	diag := lvm.NewStartupDiagnostic(mockProbe, mockBlock, probe.EphemeralDiskFilter, recorder, newTestPod())
 
 	if err := diag.Start(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/csi/driver.go
+++ b/internal/csi/driver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	kevents "k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,10 +49,10 @@ type Driver struct {
 }
 
 // NewCombined creates a new CSI driver with controller and node capabilities.
-func NewCombined(nodeID string, volumeClient core.Interface, client client.Client, removePvNodeAffinity bool, recorder kevents.EventRecorder, tp trace.TracerProvider) *Driver {
+func NewCombined(nodeID string, selfPod *corev1.Pod, volumeClient core.Interface, client client.Client, removePvNodeAffinity bool, recorder kevents.EventRecorder, tp trace.TracerProvider) *Driver {
 	d := &Driver{
 		is:       identity.New(volumeClient.GetDriverName(), Version),
-		cs:       controller.New(volumeClient, volumeClient.GetControllerDriverCapabilities(), volumeClient.GetNodeAccessModes(), mounter.New(tp), client, nodeID, SelectedNodeAnnotation, SelectedInitialNodeParam, removePvNodeAffinity, recorder, tp),
+		cs:       controller.New(volumeClient, volumeClient.GetControllerDriverCapabilities(), volumeClient.GetNodeAccessModes(), mounter.New(tp), client, nodeID, selfPod, SelectedNodeAnnotation, SelectedInitialNodeParam, removePvNodeAffinity, recorder, tp),
 		ns:       node.New(volumeClient, nodeID, SelectedNodeAnnotation, SelectedInitialNodeParam, volumeClient.GetDriverName(), volumeClient.GetNodeDriverCapabilities(), mounter.New(tp), client, removePvNodeAffinity, recorder, tp),
 		client:   client,
 		volume:   volumeClient,
@@ -66,7 +67,7 @@ func NewCombined(nodeID string, volumeClient core.Interface, client client.Clien
 func NewController(volumeClient core.Interface, client client.Client, removePvNodeAffinity bool, recorder kevents.EventRecorder, tp trace.TracerProvider) *Driver {
 	return &Driver{
 		is:       identity.New(volumeClient.GetDriverName(), Version),
-		cs:       controller.New(volumeClient, volumeClient.GetControllerDriverCapabilities(), volumeClient.GetNodeAccessModes(), mounter.New(tp), client, "", SelectedNodeAnnotation, SelectedInitialNodeParam, removePvNodeAffinity, events.NewNoopRecorder(), tp),
+		cs:       controller.New(volumeClient, volumeClient.GetControllerDriverCapabilities(), volumeClient.GetNodeAccessModes(), mounter.New(tp), client, "", nil, SelectedNodeAnnotation, SelectedInitialNodeParam, removePvNodeAffinity, events.NewNoopRecorder(), tp),
 		ns:       nil,
 		client:   client,
 		volume:   volumeClient,

--- a/internal/csi/driver_test.go
+++ b/internal/csi/driver_test.go
@@ -24,7 +24,7 @@ func TestNewCombinedDriver(t *testing.T) {
 	recorder := events.NewNoopRecorder()
 	tracerProvider := telemetry.NewNoopTracerProvider()
 
-	driver := NewCombined("node1", fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
+	driver := NewCombined("node1", nil, fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
 
 	//nolint:staticcheck,nolintlint
 	if driver == nil {
@@ -115,7 +115,7 @@ func TestDriver_GetIdentityServer(t *testing.T) {
 	recorder := events.NewNoopRecorder()
 	tracerProvider := telemetry.NewNoopTracerProvider()
 
-	driver := NewCombined("node1", fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
+	driver := NewCombined("node1", nil, fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
 
 	identityServer := driver.GetIdentityServer()
 	if identityServer == nil {
@@ -131,7 +131,7 @@ func TestDriver_GetControllerServer(t *testing.T) {
 	recorder := events.NewNoopRecorder()
 	tracerProvider := telemetry.NewNoopTracerProvider()
 
-	driver := NewCombined("node1", fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
+	driver := NewCombined("node1", nil, fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
 
 	controllerServer := driver.GetControllerServer()
 	if controllerServer == nil {
@@ -147,7 +147,7 @@ func TestDriver_GetNodeServer(t *testing.T) {
 	recorder := events.NewNoopRecorder()
 	tracerProvider := telemetry.NewNoopTracerProvider()
 
-	driver := NewCombined("node1", fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
+	driver := NewCombined("node1", nil, fakeVolumeClient, fakeClient, false, recorder, tracerProvider)
 
 	nodeServer := driver.GetNodeServer()
 	if nodeServer == nil {

--- a/internal/manager/pvcleanup/suite_test.go
+++ b/internal/manager/pvcleanup/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"local-csi-driver/internal/csi/core/lvm"
+	"local-csi-driver/internal/manager/transform"
 )
 
 var (
@@ -70,6 +71,7 @@ var _ = BeforeSuite(func() {
 	// Start the controller
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		Cache:  transform.ManagerCacheOptions(),
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/manager/transform/cache.go
+++ b/internal/manager/transform/cache.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package transform provides controller-runtime cache transforms that
+// trim cached objects down to the field set the manager actually reads.
+//
+// IMPORTANT: callers must never pass a trimmed object to client.Update.
+// Update sends the entire object body to the API server; sending a
+// trimmed object would zero out every field the transform stripped on
+// the server. Use client.Patch with MergeFrom (which diffs the trimmed
+// snapshot against itself, so the wire payload contains only the
+// intended change) or client.Delete (which only uses
+// Name/UID/ResourceVersion).
+package transform
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ManagerCacheOptions returns the controller-runtime cache.Options used
+// by the manager binary and its envtest suites. Centralising the config
+// here ensures tests exercise the same trim transforms as production,
+// so a consumer that reads a stripped field will fail in tests instead
+// of silently misbehaving in the cluster.
+//
+// Why this shape:
+//
+//   - DefaultTransform strips ManagedFields from every cached object.
+//     Manager controllers and webhooks do not use server-side apply,
+//     and the per-writer entries from csi-provisioner, external-attacher,
+//     kube-controller-manager, and kubelet are the dominant share of
+//     cache memory at scale on PVs and PVCs.
+//
+//   - TrimNode is wired per-type because Node.Status.Images alone is
+//     5-50 KB per node (one entry per cached container image). At a
+//     thousand nodes that dwarfs the ManagedFields savings.
+//
+//   - PVs and PVCs intentionally have no per-type trimmer. The
+//     residual savings beyond ManagedFields stripping are small
+//     (~5-20 MB at 10K objects) and the coupling cost is high: any
+//     future controller or webhook that reads a stripped field via
+//     the cached client would silently see a zero value.
+//
+// Per-type transforms in ByObject replace (do not compose with)
+// DefaultTransform for matched types, so TrimNode strips ManagedFields
+// itself by constructing a fresh ObjectMeta.
+func ManagerCacheOptions() cache.Options {
+	return cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Node{}: {Transform: TrimNode},
+		},
+	}
+}

--- a/internal/manager/transform/node.go
+++ b/internal/manager/transform/node.go
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package transform contains controller-runtime cache transform functions
+// used by the manager to reduce memory usage for objects whose full
+// payloads are not needed by reconcilers.
+//
+// Each transform must preserve the fields the informer machinery needs
+// for cache bookkeeping (Name, Namespace, UID, ResourceVersion) and any
+// fields that are written back to the apiserver via Patch/Update calls
+// (notably Finalizers and DeletionTimestamp).
+package transform
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TrimNode is a controller-runtime cache transform that strips Node
+// objects down to only the fields the manager actually reads (the Ready
+// condition). This keeps memory usage proportional to the number of
+// nodes rather than the size of each Node object, which can be tens of
+// KB once labels, annotations, addresses, images, and managed fields
+// are included.
+//
+// The informer machinery requires Name, UID, and ResourceVersion to
+// remain intact for cache bookkeeping.
+func TrimNode(obj any) (any, error) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		// Pass through tombstones and anything else unchanged.
+		return obj, nil
+	}
+	var ready []corev1.NodeCondition
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			ready = []corev1.NodeCondition{c}
+			break
+		}
+	}
+	return &corev1.Node{
+		TypeMeta: node.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            node.Name,
+			Namespace:       node.Namespace,
+			UID:             node.UID,
+			ResourceVersion: node.ResourceVersion,
+		},
+		Status: corev1.NodeStatus{
+			Conditions: ready,
+		},
+	}, nil
+}

--- a/internal/manager/transform/node_test.go
+++ b/internal/manager/transform/node_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package transform
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	node = &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-node",
+			UID:             "12345678-1234-1234-1234-123456789012",
+			ResourceVersion: "1",
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.NodeMemoryPressure,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+)
+
+func TestTrimNode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   any
+		want    any
+		wantErr bool
+	}{
+		{
+			name:  "trim node",
+			input: node,
+			want: &corev1.Node{
+				TypeMeta: node.TypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            node.Name,
+					UID:             node.UID,
+					ResourceVersion: node.ResourceVersion,
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "trim non-node object",
+			input:   "not a node",
+			want:    "not a node",
+			wantErr: false,
+		},
+		{
+			name:    "trim nil object",
+			input:   nil,
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "trim node with no ready condition",
+			input:   &corev1.Node{},
+			want:    &corev1.Node{},
+			wantErr: false,
+		},
+		{
+			name:    "trim node with no conditions",
+			input:   &corev1.Node{Status: corev1.NodeStatus{}},
+			want:    &corev1.Node{Status: corev1.NodeStatus{}},
+			wantErr: false,
+		},
+		{
+			name:    "pass through delete tombstone",
+			input:   &cache.DeletedFinalStateUnknown{},
+			want:    &cache.DeletedFinalStateUnknown{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := TrimNode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TrimNode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TrimNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/enforceEphemeral/suite_test.go
+++ b/internal/webhook/enforceEphemeral/suite_test.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"local-csi-driver/internal/manager/transform"
 )
 
 const (
@@ -137,6 +139,7 @@ var _ = BeforeSuite(func() {
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		Cache:  transform.ManagerCacheOptions(),
 		Metrics: server.Options{
 			BindAddress: "0",
 		},

--- a/internal/webhook/hyperconverged/suite_test.go
+++ b/internal/webhook/hyperconverged/suite_test.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"local-csi-driver/internal/manager/transform"
 )
 
 const (
@@ -143,6 +145,7 @@ var _ = BeforeSuite(func() {
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		Cache:  transform.ManagerCacheOptions(),
 		Metrics: server.Options{
 			BindAddress: "0",
 		},


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the CSI driver, focusing on simplifying event recording, improving cache configuration, and cleaning up event emission logic. The most significant changes include refactoring how the driver's Pod is referenced for event logging, updating cache and client options for better performance and correctness, and removing unnecessary or redundant event emissions in the LVM code.

**Refactoring event subject and context:**
- The driver's Pod is now constructed at startup from downward-API environment variables and passed explicitly to components that need it, rather than being fetched from the API server. This simplifies event emission and ensures that events are always associated with the correct Pod. (`cmd/driver/main.go`, `internal/csi/controller/controller.go`, `internal/csi/core/lvm/startup.go`) [[1]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943R274-R278) [[2]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943L317-R332) [[3]](diffhunk://#diff-22fa5d5f84a2eb3319543e24d6b43ab31cdd3e433e6d56003b5e45a047ea1189R39) [[4]](diffhunk://#diff-22fa5d5f84a2eb3319543e24d6b43ab31cdd3e433e6d56003b5e45a047ea1189L50-R61) [[5]](diffhunk://#diff-22fa5d5f84a2eb3319543e24d6b43ab31cdd3e433e6d56003b5e45a047ea1189L99-R103) [[6]](diffhunk://#diff-7874fe955b69ac6fa1a0ea7eb99a3285b0fdaca900cd5b36567553a57c95bd29L202-R206) [[7]](diffhunk://#diff-9fb3ea90d7a630889f6f62f7cf131a0e3e3ebed8407af1bf355c4fdfa35f6284L36-R56)

**Kubernetes cache and client configuration:**
- The controller-runtime manager's cache and client options are updated to use `TransformStripManagedFields` and to disable caching for certain objects (like `CSIDriver` and `Node`), improving efficiency and correctness. (`cmd/driver/main.go`, `cmd/manager/main.go`) [[1]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943L204-R221) [[2]](diffhunk://#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633R215)

**LVM event emission cleanup:**
- Several event emissions related to provisioning and deleting logical volumes and volume groups are removed to reduce noise and redundancy. Only essential events (such as failures or empty volume creation) are now emitted. (`internal/csi/core/lvm/lvm.go`, `internal/csi/core/lvm/controller.go`) [[1]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL54-L65) [[2]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL271) [[3]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL488) [[4]](diffhunk://#diff-b73642e31569cb1a69dbe6249611ea6a220756baed47163c1a7010d6f3e595afL549) [[5]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L29-L30) [[6]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L164) [[7]](diffhunk://#diff-7d761490ef337dfc47bcf8324a9e53832275d97e4031d614a8f199eb2c912575L177)

**Pod UID propagation and downward-API usage:**
- The DaemonSet YAML and driver startup logic now propagate the Pod UID via environment variable and command-line argument, enabling accurate Pod object construction for event emission. (`charts/latest/templates/daemonset.yaml`, `cmd/driver/main.go`) [[1]](diffhunk://#diff-fcc631e58f1d911bbb1909e7edef4d9a41a03bae29c7467d6ac83b83a062b6f0R75) [[2]](diffhunk://#diff-fcc631e58f1d911bbb1909e7edef4d9a41a03bae29c7467d6ac83b83a062b6f0R100-R103) [[3]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943R71) [[4]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943R94-R95) [[5]](diffhunk://#diff-25da333e6a1913fea695a28166f4dc3feeadae50db59514bc694777d1a3fc943R354-R367)

**Resource limits adjustment:**
- The memory limit for the manager is increased from 128Mi to 500Mi to accommodate higher resource usage. (`charts/latest/values.yaml`)