### PR TITLE
fix: remove stale VG/LV metadata during VG create

### DIFF
--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,7 @@ const (
 	provisioningPhysicalVolumeFailed = "ProvisioningPhysicalVolumeFailed"
 
 	// Volume Group (VG) related event reasons.
+	provisioningVolumeGroup       = "ProvisioningVolumeGroup"
 	provisionedVolumeGroup        = "ProvisionedVolumeGroup"
 	provisioningVolumeGroupFailed = "ProvisioningVolumeGroupFailed"
 
@@ -163,6 +165,10 @@ type LVM struct {
 	probe            probe.Interface
 	lvm              lvm.Manager
 	tracer           trace.Tracer
+
+	// vgGroup deduplicates concurrent EnsureVolumeGroup calls for the same
+	// volume group so that only one goroutine provisions it at a time.
+	vgGroup singleflight.Group
 }
 
 // New creates a new LVM volume manager.
@@ -242,7 +248,6 @@ func (l *LVM) GetVolumeName(volumeId string) (string, error) {
 // returns an error.
 func (l *LVM) EnsureVolumeGroup(ctx context.Context, name string, devices []string) (*lvm.VolumeGroup, error) {
 	log := log.FromContext(ctx).WithValues("vg", name)
-	recorder := events.FromContext(ctx)
 	ctx, span := l.tracer.Start(ctx, "volume.lvm.csi/EnsureVolumeGroup", trace.WithAttributes(
 		attribute.String("vol.group", name),
 	))
@@ -258,11 +263,40 @@ func (l *LVM) EnsureVolumeGroup(ctx context.Context, name string, devices []stri
 		return nil, fmt.Errorf("%w: no disks found", core.ErrResourceExhausted)
 	}
 
+	// Multiple workers may try to provision the same volume group at the same
+	// time. Use singleflight to ensure only one goroutine provisions a given
+	// volume group at a time; concurrent callers share the same result and
+	// avoid racing on vgcreate.
+	res, err, _ := l.vgGroup.Do(name, func() (any, error) {
+		return l.provisionVolumeGroup(ctx, name, devices)
+	})
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to provision volume group")
+		span.RecordError(err)
+		return nil, err
+	}
+	vg, ok := res.(*lvm.VolumeGroup)
+	if !ok {
+		err := fmt.Errorf("unexpected type %T returned for volume group %q", res, name)
+		log.Error(err, "unexpected singleflight result type")
+		span.SetStatus(codes.Error, "unexpected singleflight result type")
+		span.RecordError(err)
+		return nil, fmt.Errorf("unexpected singleflight result type %T for volume group %q", res, name)
+	}
+	return vg, nil
+}
+
+// provisionVolumeGroup returns the volume group with the given name, creating it
+// from devices if it does not already exist. It is intended to be called via
+// singleflight so that only one goroutine provisions a given volume group at a
+// time.
+func (l *LVM) provisionVolumeGroup(ctx context.Context, name string, devices []string) (*lvm.VolumeGroup, error) {
+	log := log.FromContext(ctx).WithValues("vg", name)
+	recorder := events.FromContext(ctx)
+
 	// Check if the volume group already exists.
 	vg, err := l.lvm.GetVolumeGroup(ctx, name)
 	if lvm.IgnoreNotFound(err) != nil {
-		span.SetStatus(codes.Error, "failed to get volume group")
-		span.RecordError(err)
 		return nil, fmt.Errorf("failed to get volume group: %w", err)
 	}
 	if vg != nil {
@@ -270,21 +304,38 @@ func (l *LVM) EnsureVolumeGroup(ctx context.Context, name string, devices []stri
 		return vg, nil
 	}
 
-	// Create the volume group.
+	recorder.Eventf(corev1.EventTypeNormal, provisioningVolumeGroup, "Provisioning volume group %s", name)
+
+	// Remove any leftover device-mapper nodes or /dev/<vg> directory from a
+	// previous removal or crash. With udev disabled these stale artifacts can
+	// block vgcreate ("/dev/<vg>: already exists in filesystem"). This runs
+	// immediately before CreateVolumeGroup and inside the per-volume-group
+	// singleflight, so cleanup can never race a concurrent create of the same
+	// volume group.
+	if err := l.lvm.RemoveStaleDeviceMapperNodes(ctx, name); err != nil {
+		log.Error(err, "failed to remove stale device-mapper nodes")
+		recorder.Eventf(corev1.EventTypeWarning, provisioningVolumeGroupFailed, "Failed to remove stale device-mapper nodes for volume group %s: %s", name, err)
+		return nil, fmt.Errorf("failed to remove stale device-mapper nodes: %w", err)
+	}
+
+	// Create the volume group. The per-volume-group singleflight already
+	// prevents concurrent callers in this process from racing on vgcreate, so
+	// AlreadyExists here means the volume group was created out of band by
+	// another process (e.g. a second driver instance briefly overlapping during
+	// a DaemonSet restart, or an admin). Treat that as success and fall through
+	// to fetch it. Note that a stale /dev/<vg> node blocking vgcreate maps to
+	// ErrStaleDeviceNode (not ErrAlreadyExists), so this does not mask a cleanup
+	// failure.
 	if err := l.lvm.CreateVolumeGroup(ctx, lvm.CreateVGOptions{
 		Name:    name,
 		PVNames: devices,
 		Tags:    []string{DefaultVolumeGroupTag},
-	}); err != nil {
-		// Multiple workers may try to create the same volume group at the same time,
-		// so ignore the already exists error and return the existing volume group.
-		if !errors.Is(err, lvm.ErrAlreadyExists) {
-			log.Error(err, "failed to create volume group")
-			span.SetStatus(codes.Error, "failed to create volume group")
-			span.RecordError(err)
-			recorder.Eventf(corev1.EventTypeWarning, provisioningVolumeGroupFailed, "Provisioning volume group %s failed: %s", name, err)
-			return nil, fmt.Errorf("failed to create volume group: %w", err)
-		}
+	}); lvm.IgnoreAlreadyExists(err) != nil {
+		log.Error(err, "failed to create volume group")
+		recorder.Eventf(corev1.EventTypeWarning, provisioningVolumeGroupFailed, "Provisioning volume group %s failed: %s", name, err)
+		return nil, fmt.Errorf("failed to create volume group: %w", err)
+	} else if err != nil {
+		log.V(1).Info("volume group already exists")
 	}
 	recorder.Eventf(corev1.EventTypeNormal, provisionedVolumeGroup, "Successfully provisioned volume group %s", name)
 	log.V(1).Info("created volume group")
@@ -292,8 +343,6 @@ func (l *LVM) EnsureVolumeGroup(ctx context.Context, name string, devices []stri
 	// Get the newly created volume group.
 	vg, err = l.lvm.GetVolumeGroup(ctx, name)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to get volume group after creation")
-		span.RecordError(err)
 		return nil, fmt.Errorf("failed to get volume group after creation: %w", err)
 	}
 	return vg, nil

--- a/internal/csi/core/lvm/lvm_test.go
+++ b/internal/csi/core/lvm/lvm_test.go
@@ -6,7 +6,9 @@ package lvm_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/mock/gomock"
@@ -394,27 +396,27 @@ func TestEnsureVolumeGroup(t *testing.T) {
 			expectedVG:  testVg,
 		},
 		{
-			name:    "create vg error",
+			name:    "stale device-mapper cleanup error",
 			vgName:  "vg",
 			devices: []string{"/dev/pv1", "/dev/pv2"},
 			expectLvm: func(m *lvmMgr.MockManager) {
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, nil)
-				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(errTestInternal)
+				m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(errTestInternal)
 			},
 			expectedErr: errTestInternal,
 			expectedVG:  nil,
 		},
 		{
-			name:    "create vg concurrent error, already exists",
+			name:    "create vg error",
 			vgName:  "vg",
 			devices: []string{"/dev/pv1", "/dev/pv2"},
 			expectLvm: func(m *lvmMgr.MockManager) {
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, nil)
-				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(lvmMgr.ErrAlreadyExists)
-				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(testVg, nil)
+				m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(errTestInternal)
 			},
-			expectedErr: nil,
-			expectedVG:  testVg,
+			expectedErr: errTestInternal,
+			expectedVG:  nil,
 		},
 		{
 			name:    "create vg success, get fails",
@@ -422,6 +424,7 @@ func TestEnsureVolumeGroup(t *testing.T) {
 			devices: []string{"/dev/pv1", "/dev/pv2"},
 			expectLvm: func(m *lvmMgr.MockManager) {
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, nil)
+				m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(nil)
 				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(nil)
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, errTestInternal)
 			},
@@ -434,11 +437,41 @@ func TestEnsureVolumeGroup(t *testing.T) {
 			devices: []string{"/dev/pv1", "/dev/pv2"},
 			expectLvm: func(m *lvmMgr.MockManager) {
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, nil)
+				m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(nil)
 				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(nil)
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(testVg, nil)
 			},
 			expectedErr: nil,
 			expectedVG:  testVg,
+		},
+		{
+			// The volume group was created concurrently between our existence
+			// check and CreateVolumeGroup; AlreadyExists is treated as success.
+			name:    "create vg already exists is not an error",
+			vgName:  "vg",
+			devices: []string{"/dev/pv1", "/dev/pv2"},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, nil)
+				m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(lvmMgr.ErrAlreadyExists)
+				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(testVg, nil)
+			},
+			expectedErr: nil,
+			expectedVG:  testVg,
+		},
+		{
+			// A stale /dev/<vg> node blocking vgcreate must NOT be swallowed
+			// like AlreadyExists; it surfaces as an error.
+			name:    "create vg stale device node is an error",
+			vgName:  "vg",
+			devices: []string{"/dev/pv1", "/dev/pv2"},
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, nil)
+				m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(lvmMgr.ErrStaleDeviceNode)
+			},
+			expectedErr: lvmMgr.ErrStaleDeviceNode,
+			expectedVG:  nil,
 		},
 	}
 
@@ -460,6 +493,58 @@ func TestEnsureVolumeGroup(t *testing.T) {
 				t.Errorf("EnsureVolumeGroup() = %v, want %v", vg, tt.expectedVG)
 			}
 		})
+	}
+}
+
+// TestEnsureVolumeGroupConcurrent verifies that concurrent EnsureVolumeGroup
+// calls for the same volume group are deduplicated by singleflight, so the
+// volume group is only provisioned once even under a create race.
+func TestEnsureVolumeGroupConcurrent(t *testing.T) {
+	t.Parallel()
+	testVg := &lvmMgr.VolumeGroup{Name: "vg"}
+	devices := []string{"/dev/pv1", "/dev/pv2"}
+
+	l, _, m, err := initTestLVM(gomock.NewController(t))
+	if err != nil {
+		t.Fatalf("failed to initialize LVM: %v", err)
+	}
+
+	// release blocks the in-flight provision until all callers have parked in
+	// singleflight, guaranteeing they share the single flight.
+	release := make(chan struct{})
+	m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, string) (*lvmMgr.VolumeGroup, error) {
+			<-release
+			return nil, nil
+		}).Times(1)
+	m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(testVg, nil).Times(1)
+
+	const workers = 8
+	var wg sync.WaitGroup
+	results := make([]*lvmMgr.VolumeGroup, workers)
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = l.EnsureVolumeGroup(context.Background(), "vg", devices)
+		}(i)
+	}
+
+	// Give all workers time to park in the singleflight before releasing.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i := range workers {
+		if errs[i] != nil {
+			t.Errorf("worker %d: EnsureVolumeGroup() error = %v, want nil", i, errs[i])
+		}
+		if results[i] != testVg {
+			t.Errorf("worker %d: EnsureVolumeGroup() = %v, want %v", i, results[i], testVg)
+		}
 	}
 }
 
@@ -622,6 +707,7 @@ func TestEnsureVolume(t *testing.T) {
 				m.EXPECT().GetPhysicalVolume(gomock.Any(), gomock.Any()).Return(&lvmMgr.PhysicalVolume{Name: "/dev/pv1"}, nil)
 				m.EXPECT().GetPhysicalVolume(gomock.Any(), gomock.Any()).Return(&lvmMgr.PhysicalVolume{Name: "/dev/pv2"}, nil)
 				m.EXPECT().GetVolumeGroup(gomock.Any(), gomock.Any()).Return(nil, lvmMgr.ErrNotFound)
+				m.EXPECT().RemoveStaleDeviceMapperNodes(gomock.Any(), gomock.Any()).Return(nil)
 				m.EXPECT().CreateVolumeGroup(gomock.Any(), gomock.Any()).Return(errTestInternal)
 
 			},

--- a/internal/pkg/lvm/errors_internal_test.go
+++ b/internal/pkg/lvm/errors_internal_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestGetErrorType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{
+			name:    "volume group not found",
+			input:   "Volume group \"vg0\" not found",
+			wantErr: ErrNotFound,
+		},
+		{
+			name:    "failed to find logical volume",
+			input:   "Failed to find logical volume vg0/lv0",
+			wantErr: ErrNotFound,
+		},
+		{
+			// vgcreate blocked by a leftover /dev node with no LVM metadata.
+			name:    "stale device node blocks vgcreate",
+			input:   "/dev/vg0: already exists in filesystem",
+			wantErr: ErrStaleDeviceNode,
+		},
+		{
+			// A genuine duplicate volume group in LVM metadata.
+			name:    "volume group already exists in metadata",
+			input:   "A volume group called vg0 already exists.",
+			wantErr: ErrAlreadyExists,
+		},
+		{
+			name:    "filesystem in use",
+			input:   "Can't open /dev/loop0 exclusively. Device contains a filesystem in use.",
+			wantErr: ErrInUse,
+		},
+		{
+			name:    "insufficient free space",
+			input:   "Volume group \"vg0\" has insufficient free space",
+			wantErr: ErrResourceExhausted,
+		},
+		{
+			name:    "physical volume already in volume group",
+			input:   "Physical volume /dev/loop0 is already in volume group vg0",
+			wantErr: ErrPVAlreadyInVolumeGroup,
+		},
+		{
+			name:    "unrecognized error is passed through",
+			input:   "some unexpected lvm failure",
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getErrorType(errors.New(tt.input))
+			if tt.wantErr == nil {
+				if got.Error() != tt.input {
+					t.Fatalf("expected passthrough %q, got %q", tt.input, got.Error())
+				}
+				return
+			}
+			if !errors.Is(got, tt.wantErr) {
+				t.Fatalf("expected error to wrap %v, got %v", tt.wantErr, got)
+			}
+			// The stale-node case must not be conflated with ErrAlreadyExists.
+			if tt.wantErr == ErrStaleDeviceNode && errors.Is(got, ErrAlreadyExists) {
+				t.Fatalf("stale device node error must not be categorized as ErrAlreadyExists: %v", got)
+			}
+		})
+	}
+}
+
+// Ensure the sentinel errors remain distinct.
+func TestStaleDeviceNodeDistinctFromAlreadyExists(t *testing.T) {
+	wrapped := fmt.Errorf("%w: detail", ErrStaleDeviceNode)
+	if errors.Is(wrapped, ErrAlreadyExists) {
+		t.Fatal("ErrStaleDeviceNode must not match ErrAlreadyExists")
+	}
+	if !errors.Is(wrapped, ErrStaleDeviceNode) {
+		t.Fatal("wrapped error should match ErrStaleDeviceNode")
+	}
+}

--- a/internal/pkg/lvm/fake.go
+++ b/internal/pkg/lvm/fake.go
@@ -169,3 +169,8 @@ func (f *Fake) IsLogicalVolumeCorrupted(ctx context.Context, vgName string, lvNa
 	// For fake implementation, we never simulate corruption by default
 	return false, nil
 }
+
+// RemoveStaleDeviceMapperNodes is a no-op for the fake implementation.
+func (f *Fake) RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error {
+	return f.Err
+}

--- a/internal/pkg/lvm/lvm.go
+++ b/internal/pkg/lvm/lvm.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/dpeckett/args"
@@ -51,6 +52,13 @@ var (
 
 	// AlreadyExists is returned when the lvm object already exists.
 	ErrAlreadyExists = errors.New("already exists")
+
+	// ErrStaleDeviceNode is returned when a leftover /dev node or directory
+	// blocks an LVM operation even though no matching LVM metadata exists (for
+	// example, vgcreate failing with "/dev/<vg>: already exists in filesystem"
+	// after udev-disabled cleanup left a stale node behind). This is distinct
+	// from ErrAlreadyExists, which means the object exists in LVM metadata.
+	ErrStaleDeviceNode = errors.New("stale device node")
 
 	// ErrTooMany is returned when multiple objects are found with the same
 	// name, when only one is expected. This should never happen.
@@ -841,13 +849,17 @@ func (c *Client) RenameLogicalVolume(ctx context.Context, opts RenameLVOptions) 
 }
 
 func (c *Client) run(ctx context.Context, cmdArgs ...string) ([]byte, error) {
-	ctx, span := c.tracer.Start(ctx, "lvm/run", trace.WithAttributes(
-		attribute.String("cmd.name", c.lvmPath),
+	return c.runCmd(ctx, "lvm/run", c.lvmPath, cmdArgs...)
+}
+
+func (c *Client) runCmd(ctx context.Context, spanName, binary string, cmdArgs ...string) ([]byte, error) {
+	ctx, span := c.tracer.Start(ctx, spanName, trace.WithAttributes(
+		attribute.String("cmd.name", binary),
 		attribute.StringSlice("cmd.args", cmdArgs),
 	))
 	defer span.End()
 
-	cmd := exec.CommandContext(ctx, c.lvmPath, cmdArgs...)
+	cmd := exec.CommandContext(ctx, binary, cmdArgs...)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -867,7 +879,7 @@ func (c *Client) run(ctx context.Context, cmdArgs ...string) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
-	span.SetStatus(codes.Ok, "lvm command succeeded")
+	span.SetStatus(codes.Ok, "command succeeded")
 	return stdout.Bytes(), nil
 }
 
@@ -893,6 +905,11 @@ func getErrorType(err error) error {
 		return fmt.Errorf("%w: %s", ErrNotFound, err.Error())
 	case containsIgnoreCase(err.Error(), "contains a filesystem in use"):
 		return fmt.Errorf("%w: %s", ErrInUse, err.Error())
+	case containsIgnoreCase(err.Error(), "already exists in filesystem"):
+		// A stale /dev node or directory is blocking the operation even though
+		// no matching LVM metadata exists. Distinct from ErrAlreadyExists,
+		// which means the object exists in LVM metadata.
+		return fmt.Errorf("%w: %s", ErrStaleDeviceNode, err.Error())
 	case containsIgnoreCase(err.Error(), "already exists") || (containsIgnoreCase(err.Error(), "of volume group") && containsIgnoreCase(err.Error(), "Can't initialize physical volume")):
 		return fmt.Errorf("%w: %s", ErrAlreadyExists, err.Error())
 	case containsIgnoreCase(err.Error(), "insufficient free space"):
@@ -962,4 +979,103 @@ func (c *Client) IsLogicalVolumeCorrupted(ctx context.Context, vgName string, lv
 
 	// LV exists in metadata and device file exists - not corrupted
 	return false, nil
+}
+
+// RemoveStaleDeviceMapperNodes removes leftover LVM device nodes and the
+// /dev/<vg> directory for a volume group that has no backing LVM metadata.
+//
+// With udev disabled (DM_DISABLE_UDEV=1) LVM manages device nodes itself and
+// can leave behind stale /dev/<vg>/<lv> nodes or an empty /dev/<vg> directory
+// after a removal or a crash. These leaked artifacts can block a subsequent
+// vgcreate for the same volume group name ("/dev/<vg>: already exists in
+// filesystem").
+//
+// Cleanup runs vgmknodes to let LVM reconcile device nodes against its
+// metadata (removing nodes for logical volumes that no longer exist), then
+// removes any residual node files and the now-empty /dev/<vg> directory. The
+// directory removal is best-effort: if it cannot be emptied it is left in
+// place rather than forcibly recursed.
+//
+// It is a no-op when the volume group still exists in LVM metadata.
+//
+// Callers must ensure this does not run concurrently with CreateVolumeGroup for
+// the same volume group. The CSI provisioning path guarantees this by calling
+// cleanup immediately before CreateVolumeGroup within a per-volume-group
+// singleflight, so a concurrent provision cannot create the volume group (and
+// its logical volumes) midway through cleanup and have a live node removed.
+func (c *Client) RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error {
+	ctx, span := c.tracer.Start(ctx, "lvm/RemoveStaleDeviceMapperNodes", trace.WithAttributes(
+		attribute.String("vg.name", vgName),
+	))
+	defer span.End()
+
+	if vgName == "" {
+		return fmt.Errorf("%w: volume group name cannot be empty", ErrInvalidInput)
+	}
+
+	// Guard against path traversal. filepath.Join cleans the path, so requiring
+	// the result to be a direct child of /dev rejects empty, ".", "..", names
+	// containing separators, and any traversal that would resolve to /dev
+	// itself or escape it.
+	devDir := filepath.Join("/dev", vgName)
+	if filepath.Dir(devDir) != "/dev" {
+		return fmt.Errorf("%w: invalid volume group name %q", ErrInvalidInput, vgName)
+	}
+
+	// Safety: if the volume group still exists in LVM metadata, its device
+	// nodes are legitimate and must not be removed.
+	vg, err := c.GetVolumeGroup(ctx, vgName)
+	if IgnoreNotFound(err) != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to check volume group %s: %w", vgName, err)
+	}
+	if vg != nil {
+		span.SetAttributes(attribute.Bool("vg.exists", true))
+		return nil
+	}
+
+	// Reconcile device nodes against LVM metadata. With udev disabled this
+	// removes nodes for logical volumes that no longer exist. Since this volume
+	// group has no metadata, its stale nodes are reclaimed.
+	if err := c.MakeVolumeGroupDeviceNodes(ctx, MakeVGDeviceNodesOptions{}); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to reconcile device nodes: %w", err)
+	}
+
+	// Remove any residual node files left under /dev/<vg>, then remove the
+	// directory itself so a subsequent vgcreate does not fail on it.
+	entries, err := os.ReadDir(devDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			span.SetStatus(codes.Ok, "no stale device directory")
+			return nil
+		}
+		span.RecordError(err)
+		return fmt.Errorf("failed to read device directory %s: %w", devDir, err)
+	}
+	removed := 0
+	for _, entry := range entries {
+		p := filepath.Join(devDir, entry.Name())
+		if err := os.Remove(p); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to remove stale device node %s: %w", p, err)
+		}
+		removed++
+	}
+
+	// Best-effort removal of the /dev/<vg> directory. os.Remove only removes an
+	// empty directory, so it can never recurse into unexpected contents. If it
+	// is not empty (a node vgmknodes could not reclaim), leave it in place.
+	dirRemoved := true
+	if err := os.Remove(devDir); err != nil && !os.IsNotExist(err) {
+		dirRemoved = false
+		span.RecordError(err)
+	}
+
+	span.SetAttributes(
+		attribute.Int("dev.nodes.removed", removed),
+		attribute.Bool("dev.dir.removed", dirRemoved),
+	)
+	span.SetStatus(codes.Ok, "removed stale device nodes")
+	return nil
 }

--- a/internal/pkg/lvm/lvm_test.go
+++ b/internal/pkg/lvm/lvm_test.go
@@ -26,11 +26,13 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"os/exec"
 	"os/user"
 	"strings"
 	"testing"
 
+	"local-csi-driver/internal/pkg/block"
 	"local-csi-driver/internal/pkg/lvm"
 	testUtils "local-csi-driver/test/pkg/utils/device"
 )
@@ -680,4 +682,119 @@ func mustRandomInt(max int) int {
 		panic(err)
 	}
 	return int(n.Int64())
+}
+
+// TestRemoveStaleDeviceMapperNodesValidation covers input validation that does
+// not require LVM or root privileges.
+func TestRemoveStaleDeviceMapperNodesValidation(t *testing.T) {
+	c := lvm.NewClient()
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		vgName string
+	}{
+		{"empty", ""},
+		{"slash", "foo/bar"},
+		{"absolute", "/dev/foo"},
+		{"dot", "."},
+		{"dotdot", ".."},
+		{"traversal", "foo/../.."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.RemoveStaleDeviceMapperNodes(ctx, tc.vgName)
+			if !errors.Is(err, lvm.ErrInvalidInput) {
+				t.Fatalf("expected ErrInvalidInput for vg name %q, got: %v", tc.vgName, err)
+			}
+		})
+	}
+}
+
+// TestRemoveStaleDeviceMapperNodes verifies that leaked device nodes and the
+// /dev/<vg> directory are reclaimed for a volume group that no longer has
+// backing LVM metadata, while volume groups that still exist are left alone.
+func TestRemoveStaleDeviceMapperNodes(t *testing.T) {
+	if !isRoot() {
+		t.Skip("Skipping TestRemoveStaleDeviceMapperNodes as it requires root permissions.")
+	}
+
+	if _, err := os.Stat("/sbin/lvm"); err != nil {
+		t.Skip("Skipping TestRemoveStaleDeviceMapperNodes as /sbin/lvm is not available.")
+	}
+
+	c := lvm.NewClient(lvm.WithBlockDeviceUtilities(block.New()))
+	ctx := context.Background()
+
+	// Leaked empty /dev/<vg> directory for a non-existent volume group is
+	// removed.
+	t.Run("RemovesLeakedDevDirectory", func(t *testing.T) {
+		vgName := fmt.Sprintf("stalevg%d", mustRandomInt(100000))
+		devDir := "/dev/" + vgName
+		if err := os.MkdirAll(devDir, 0o755); err != nil {
+			t.Fatalf("failed to create leaked dev dir %s: %v", devDir, err)
+		}
+		defer func() { _ = os.RemoveAll(devDir) }()
+
+		if err := c.RemoveStaleDeviceMapperNodes(ctx, vgName); err != nil {
+			t.Fatalf("RemoveStaleDeviceMapperNodes returned error: %v", err)
+		}
+		if _, err := os.Stat(devDir); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, stat err: %v", devDir, err)
+		}
+	})
+
+	// Residual node files under /dev/<vg> for a non-existent volume group are
+	// removed along with the directory.
+	t.Run("RemovesResidualNodeFiles", func(t *testing.T) {
+		vgName := fmt.Sprintf("stalevg%d", mustRandomInt(100000))
+		devDir := "/dev/" + vgName
+		if err := os.MkdirAll(devDir, 0o755); err != nil {
+			t.Fatalf("failed to create leaked dev dir %s: %v", devDir, err)
+		}
+		defer func() { _ = os.RemoveAll(devDir) }()
+
+		node := devDir + "/pvc-leak"
+		if err := os.WriteFile(node, nil, 0o600); err != nil {
+			t.Fatalf("failed to create residual node file %s: %v", node, err)
+		}
+
+		if err := c.RemoveStaleDeviceMapperNodes(ctx, vgName); err != nil {
+			t.Fatalf("RemoveStaleDeviceMapperNodes returned error: %v", err)
+		}
+		if _, err := os.Stat(devDir); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, stat err: %v", devDir, err)
+		}
+	})
+
+	// An existing volume group must not be touched.
+	t.Run("NoOpWhenVolumeGroupExists", func(t *testing.T) {
+		device, cleanup, err := testUtils.CreateLoopDevWithSize(int64(GiB))
+		if err != nil {
+			t.Fatalf("failed to create loop device: %v", err)
+		}
+		defer cleanup()
+
+		vgName := fmt.Sprintf("livevg%d", mustRandomInt(100000))
+
+		if err := c.CreatePhysicalVolume(ctx, lvm.CreatePVOptions{Name: device}); err != nil {
+			t.Fatalf("failed to create PV: %v", err)
+		}
+		defer func() { _ = c.RemovePhysicalVolume(ctx, lvm.RemovePVOptions{Name: device}) }()
+
+		if err := c.CreateVolumeGroup(ctx, lvm.CreateVGOptions{Name: vgName, PVNames: []string{device}}); err != nil {
+			t.Fatalf("failed to create VG: %v", err)
+		}
+		defer func() { _ = c.RemoveVolumeGroup(ctx, lvm.RemoveVGOptions{Name: vgName}) }()
+
+		// Cleanup must be a no-op for a volume group that exists in metadata.
+		if err := c.RemoveStaleDeviceMapperNodes(ctx, vgName); err != nil {
+			t.Fatalf("RemoveStaleDeviceMapperNodes returned error: %v", err)
+		}
+
+		// The live volume group must still be present.
+		if _, err := c.GetVolumeGroup(ctx, vgName); err != nil {
+			t.Fatalf("expected volume group %s to remain after no-op cleanup: %v", vgName, err)
+		}
+	})
 }

--- a/internal/pkg/lvm/manager.go
+++ b/internal/pkg/lvm/manager.go
@@ -57,4 +57,10 @@ type Manager interface {
 	// A logical volume is considered corrupted if it exists in LVM metadata
 	// but the device file (/dev/<vg>/<lv>) does not exist.
 	IsLogicalVolumeCorrupted(ctx context.Context, vgName string, lvName string) (bool, error)
+	// RemoveStaleDeviceMapperNodes removes leftover device-mapper nodes and the
+	// /dev/<vg> directory for a volume group that has no backing LVM metadata.
+	//
+	// It is a no-op when the volume group still exists in LVM metadata (the
+	// nodes are not stale) or when there is nothing to clean up.
+	RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error
 }

--- a/internal/pkg/lvm/mock.go
+++ b/internal/pkg/lvm/mock.go
@@ -248,6 +248,20 @@ func (mr *MockManagerMockRecorder) RemovePhysicalVolume(ctx, opts any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePhysicalVolume", reflect.TypeOf((*MockManager)(nil).RemovePhysicalVolume), ctx, opts)
 }
 
+// RemoveStaleDeviceMapperNodes mocks base method.
+func (m *MockManager) RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveStaleDeviceMapperNodes", ctx, vgName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveStaleDeviceMapperNodes indicates an expected call of RemoveStaleDeviceMapperNodes.
+func (mr *MockManagerMockRecorder) RemoveStaleDeviceMapperNodes(ctx, vgName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStaleDeviceMapperNodes", reflect.TypeOf((*MockManager)(nil).RemoveStaleDeviceMapperNodes), ctx, vgName)
+}
+
 // RemoveVolumeGroup mocks base method.
 func (m *MockManager) RemoveVolumeGroup(ctx context.Context, opts RemoveVGOptions) error {
 	m.ctrl.T.Helper()

--- a/internal/pkg/lvm/unsupported.go
+++ b/internal/pkg/lvm/unsupported.go
@@ -98,3 +98,8 @@ func (l *Noop) ExtendLogicalVolume(ctx context.Context, opts ExtendLVOptions) er
 func (l *Noop) IsLogicalVolumeCorrupted(ctx context.Context, vgName string, lvName string) (bool, error) {
 	return false, ErrUnsupported
 }
+
+// RemoveStaleDeviceMapperNodes implements Manager.
+func (l *Noop) RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error {
+	return ErrUnsupported
+}

--- a/test/e2e/lvm_storagepool_test.go
+++ b/test/e2e/lvm_storagepool_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -188,13 +189,8 @@ func lvmHyperconvergedTest(name, pvcFixture, podFixture string) {
 			Expect(err).NotTo(HaveOccurred(), "Failed to delete pod")
 		})
 
-		By("Waiting for pod to be Running")
-		Eventually(func(g Gomega, ctx context.Context) {
-			cmd := exec.CommandContext(ctx, "kubectl", "get", "pod", "-l", "part-of=e2e-test", "-o", "jsonpath={.items[0].status.phase}")
-			out, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod status")
-			g.Expect(out).To(Equal("Running"), "Pod should be in Running state")
-		}).WithContext(ctx).Should(Succeed(), "Failed to wait for pod to be Running")
+		By("Waiting for pod to be Ready")
+		waitForE2EPodReady(ctx)
 
 		By("Deleting pod to test recreation with the same PVC")
 		cmd = exec.CommandContext(ctx, "kubectl", "delete", "--wait", "--ignore-not-found", "-f", podFixture)
@@ -206,13 +202,8 @@ func lvmHyperconvergedTest(name, pvcFixture, podFixture string) {
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to apply pod fixture")
 
-		By("Waiting for pod to be Running after recreation")
-		Eventually(func(g Gomega, ctx context.Context) {
-			cmd := exec.CommandContext(ctx, "kubectl", "get", "pod", "-l", "part-of=e2e-test", "-o", "jsonpath={.items[0].status.phase}")
-			out, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod status")
-			g.Expect(out).To(Equal("Running"), "Pod should be in Running state after recreation")
-		}).WithContext(ctx).Should(Succeed(), "Failed to wait for pod to be Running after recreation")
+		By("Waiting for pod to be Ready after recreation")
+		waitForE2EPodReady(ctx)
 
 		// check thate spec.affinity.nodeAffinity is set
 		cmd = exec.CommandContext(ctx, "kubectl", "get", "pod", "-l", "part-of=e2e-test", "-o", "jsonpath={.items[0].spec.affinity.nodeAffinity}")
@@ -222,6 +213,24 @@ func lvmHyperconvergedTest(name, pvcFixture, podFixture string) {
 		Expect(out).To(ContainSubstring("preferredDuringSchedulingIgnoredDuringExecution"), "Node affinity should be required during scheduling")
 	})
 
+}
+
+// Volume provisioning for the "local" storageclass uses WaitForFirstConsumer,
+// so the bind, logical volume creation, mkfs, and mount only happen once the
+// pod is scheduled. Together with the busybox image pull, that whole chain can
+// take longer than the suite's default 2 minute Eventually timeout under CI
+// load, which made this test flaky. Wait on the Ready condition with an
+// explicit 5 minute budget (matching the statefulset rollout and AKS readiness
+// waits) and retry through the brief window after recreation where no pod
+// matches the selector yet.
+func waitForE2EPodReady(ctx context.Context) {
+	GinkgoHelper()
+	Eventually(func(g Gomega, ctx context.Context) {
+		cmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=Ready",
+			"pod", "-l", "part-of=e2e-test", "--timeout=30s")
+		_, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred(), "pod did not become Ready")
+	}).WithContext(ctx).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "Failed to wait for pod to be Ready")
 }
 
 // get the numbder of application pods that are on the same node as the pod passed in.

--- a/test/pkg/common/common.go
+++ b/test/pkg/common/common.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -412,10 +413,21 @@ func VerifyDriverUp(ctx context.Context, namespace string) {
 		g.Expect(err).NotTo(HaveOccurred(), "Failed to get daemonset ready status")
 		g.Expect(output).NotTo(BeEmpty(), "Empty output when checking daemonset readiness")
 
-		// Split and verify all pods are ready
+		// Parse the ready/desired counts. The daemonset controller may not
+		// have populated .status yet right after install, in which case
+		// jsonpath renders "0/0" (or "/"). A naive string compare treats that
+		// as "0 == 0" and passes, letting the suite proceed before any node
+		// plugin is actually running. Volume-provisioning specs then flake,
+		// timing out while waiting for pods to go Ready. Require at least one
+		// desired pod and an integer match instead.
 		readyCount := strings.Split(output, "/")
-		g.Expect(readyCount).To(HaveLen(2), "Unexpected format in daemonset ready count")
-		g.Expect(readyCount[0]).To(Equal(readyCount[1]), fmt.Sprintf("Not all daemonset pods are ready: %s/%s", readyCount[0], readyCount[1]))
+		g.Expect(readyCount).To(HaveLen(2), "Unexpected format in daemonset ready count: %q", output)
+		ready, err := strconv.Atoi(strings.TrimSpace(readyCount[0]))
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to parse daemonset numberReady: %q", output)
+		desired, err := strconv.Atoi(strings.TrimSpace(readyCount[1]))
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to parse daemonset desiredNumberScheduled: %q", output)
+		g.Expect(desired).To(BeNumerically(">", 0), "Daemonset has not scheduled any pods yet: %s", output)
+		g.Expect(ready).To(Equal(desired), fmt.Sprintf("Not all daemonset pods are ready: %d/%d", ready, desired))
 
 		// Verify that webhooks are available.
 		cmd = exec.CommandContext(ctx, "kubectl", "get", "endpoints", "csi-local-webhook-service",


### PR DESCRIPTION
This PR adds cleanup of stale dm and lv files that can be left over when lvremove is interrupted after removing LVM metadata but prior to removing these files. When we find a VG with no LV we clean up the VG when the pod is deleted. When the node is used again, we will hit an issue with re-creating the VG since `/dev/<vg>` will have file left over. 

Now, we will cleanup the stale files when creating the VG to avoid this issue. I added a call to create the vg using singleflight as there could be some scenarios tricky scenarios related to creating the VG while cleaning up the directory. This is a good change anyway since we will only ever make one call to vgcreate for concurrent CreateVolume calls. 

https://pkg.go.dev/golang.org/x/sync@v0.21.0/singleflight#Group.Do

> Do executes and returns the results of the given function, making sure that only one execution is in-flight for a given key at a time. If a duplicate comes in, the duplicate caller waits for the original to complete and receives the same results. The return value shared indicates whether v was given to multiple callers.


