### PR TITLE
chore: enable partialobjectmetadata node informer

### DIFF
--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -219,9 +219,6 @@ func main() {
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{
 					&storagev1.CSIDriver{},
-					&metav1.PartialObjectMetadata{
-						TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Node"},
-					},
 				},
 			},
 		},

--- a/test/kwok/values-kwok.yaml
+++ b/test/kwok/values-kwok.yaml
@@ -12,22 +12,9 @@ manager:
   deployment:
     tolerations: []
 
-# Bump memory limits well above the chart defaults so the driver and
-# manager don't OOMKill before we can capture heap profiles. Pair with
-# pprof enablement below to investigate memory growth.
-resources:
-  driver:
-    limits:
-      memory: 4Gi
-    requests:
-      cpu: 10m
-      memory: 60Mi
-  manager:
-    limits:
-      memory: 4Gi
-    requests:
-      cpu: 10m
-      memory: 64Mi
+# Use the chart default memory limits (driver 600Mi, manager 500Mi) so the
+# kwok scale test verifies the driver and manager stay within their shipped
+# limits at scale. pprof is enabled below to investigate memory growth.
 
 observability:
   driver:


### PR DESCRIPTION
Re-enable the partialobjectmetadata node informer to keep behavior the same as the previous related for apiserver use. In the future, we can move cleanup of delete volumes for nodes that don't exist to the manager. 