### PR TITLE
ci: add zizmor GitHub Actions security scanner to pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
@@ -29,6 +31,8 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     directory: /
@@ -55,6 +59,8 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: pip
     directory: /.github/workflows
@@ -70,6 +76,8 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: pre-commit
     directory: /
@@ -85,3 +93,5 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      security-events: write
-      contents: read
-      actions: read
+      security-events: write # upload CodeQL analysis results (SARIF)
+      contents: read # checkout the repository source
+      actions: read # read workflow run metadata for private repos
 
     strategy:
       fail-fast: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,6 +19,7 @@ permissions: {}
 
 jobs:
   dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,7 +19,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    name: Dependency Review
+    name: dependency-review
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      security-events: write
-      contents: read
-      actions: read
+      security-events: write # upload DevSkim analysis results (SARIF)
+      contents: read # checkout the repository source
+      actions: read # read workflow run metadata for private repos
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/docker-build-template.yml
+++ b/.github/workflows/docker-build-template.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   build-docker:
+    name: Build Docker
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/docker-build-template.yml
+++ b/.github/workflows/docker-build-template.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   build-docker:
-    name: Build Docker
+    name: build-docker
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/docker-push-template.yml
+++ b/.github/workflows/docker-push-template.yml
@@ -23,12 +23,12 @@ on:
       AZURE_SUBSCRIPTION_ID:
         required: true
 
-permissions:
-  contents: read
-  id-token: write
+# No workflow-level privileges; each job grants exactly what it needs.
+permissions: {}
 
 jobs:
   push-arch:
+    name: Push Arch
     strategy:
       matrix:
         image:
@@ -41,8 +41,8 @@ jobs:
     timeout-minutes: 15
     environment: pull-request
     permissions:
-      contents: read
-      id-token: write
+      contents: read # checkout and load the built image artifact
+      id-token: write # federated Azure login to push to ACR
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -111,13 +111,14 @@ jobs:
           done <<< "${TAGS}"
 
   push-manifest:
+    name: Push Manifest
     needs: push-arch
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pull-request
     permissions:
-      contents: read
-      id-token: write
+      contents: read # required by harden-runner / checkout context
+      id-token: write # federated Azure login to push the manifest to ACR
     strategy:
       matrix:
         image:

--- a/.github/workflows/docker-push-template.yml
+++ b/.github/workflows/docker-push-template.yml
@@ -28,7 +28,7 @@ permissions: {}
 
 jobs:
   push-arch:
-    name: Push Arch
+    name: push-arch
     strategy:
       matrix:
         image:
@@ -111,7 +111,7 @@ jobs:
           done <<< "${TAGS}"
 
   push-manifest:
-    name: Push Manifest
+    name: push-manifest
     needs: push-arch
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/helm-build-template.yml
+++ b/.github/workflows/helm-build-template.yml
@@ -31,6 +31,7 @@ permissions:
 
 jobs:
   build-helm:
+    name: Build Helm
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/helm-build-template.yml
+++ b/.github/workflows/helm-build-template.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build-helm:
-    name: Build Helm
+    name: build-helm
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/helm-push-template.yml
+++ b/.github/workflows/helm-push-template.yml
@@ -34,7 +34,7 @@ permissions: {}
 
 jobs:
   push-helm:
-    name: Push Helm
+    name: push-helm
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pull-request

--- a/.github/workflows/helm-push-template.yml
+++ b/.github/workflows/helm-push-template.yml
@@ -29,18 +29,18 @@ on:
       AZURE_SUBSCRIPTION_ID:
         required: true
 
-permissions:
-  contents: read
-  id-token: write
+# No workflow-level privileges; the job grants exactly what it needs.
+permissions: {}
 
 jobs:
   push-helm:
+    name: Push Helm
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pull-request
     permissions:
-      contents: read
-      id-token: write
+      contents: read # checkout Makefile/hack scripts and chart artifact
+      id-token: write # federated Azure login to push the chart to ACR
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   linter:
+    name: Linter
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   linter:
-    name: Linter
+    name: linter
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build-vars:
-    name: Build Vars
+    name: build-vars
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   build-vars:
+    name: Build Vars
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -89,8 +90,8 @@ jobs:
     needs: [build-vars, build-docker]
     uses: ./.github/workflows/docker-push-template.yml
     permissions:
-      contents: read
-      id-token: write
+      contents: read # required by the reusable push workflow
+      id-token: write # federated Azure login to push images to ACR
     with:
       registry: "localcsidriver.azurecr.io"
       repo_base: "acstor"
@@ -118,8 +119,8 @@ jobs:
     needs: [build-vars, build-helm]
     uses: ./.github/workflows/helm-push-template.yml
     permissions:
-      contents: read
-      id-token: write
+      contents: read # required by the reusable push workflow
+      id-token: write # federated Azure login to push the chart to ACR
     with:
       registry: "localcsidriver.azurecr.io"
       repo_base: "acstor"

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -161,8 +161,10 @@ jobs:
         env:
           TAG_SUFFIX: ${{ matrix.arch.tag-suffix }}
           TEST_ID: ${{ matrix.test.id }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          TEST_RUN_ID="${{ github.run_id }}-kind-${TEST_ID}-${TAG_SUFFIX}-${{ github.run_attempt }}"
+          TEST_RUN_ID="${RUN_ID}-kind-${TEST_ID}-${TAG_SUFFIX}-${RUN_ATTEMPT}"
           echo "TestRunId=${TEST_RUN_ID}" >> "$GITHUB_ENV"
 
       - name: Run ${{ matrix.test.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ permissions: {}
 
 jobs:
   unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   unit-tests:
-    name: Unit Tests
+    name: unit-tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,13 @@ repos:
   rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
   hooks:
   - id: actionlint-docker
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: e3eebf65325ccc992422292cb7a4baee967cf815 # v1.26.1
+  hooks:
+  - id: zizmor
+    args:
+    - --no-progress
+    - --persona=auditor
 - repo: https://github.com/tcort/markdown-link-check
   rev: 3a8992dcbb083a248671812c7027b6995ef88523 # v3.14.2
   hooks:


### PR DESCRIPTION
Add the zizmor-pre-commit hook (v1.26.1) running the strictest "auditor" persona to catch security issues in GitHub Actions workflows and Dependabot config.

Clear the pre-existing findings so the hook passes clean:
- dependabot.yml: add a 7-day cooldown to every update ecosystem
- push workflows (docker-push-template, helm-push-template): drop the redundant workflow-level id-token: write (excessive-permissions); each job already grants its own
- document all job-level permissions with explanatory comments
- add explicit job names to satisfy anonymous-definition
- test-e2e-pr.yml: move github.run_id / github.run_attempt into env vars so they are no longer expanded directly into a run block (template-injection)