### PR TITLE
feat(csi): sanitize volume extents on delete

### DIFF
--- a/charts/latest/templates/daemonset.yaml
+++ b/charts/latest/templates/daemonset.yaml
@@ -92,6 +92,8 @@ spec:
         - --enable-lv-garbage-collection={{ .Values.cleanup.lvGarbageCollection.enabled }}
         - --enable-lvm-orphan-cleanup={{ .Values.cleanup.lvmOrphanCleanup.enabled }}
         - --lvm-orphan-cleanup-interval={{ .Values.cleanup.lvmOrphanCleanup.interval }}
+        - --volume-wipe-interval={{ .Values.cleanup.volumeWipe.interval }}
+        - --volume-wipe-concurrency={{ .Values.cleanup.volumeWipe.concurrency }}
         - --run-alongside-webhook={{ .Values.webhook.hyperconverged.enabled | default false }}
 
         - --disk-path-prefixes={{ join "," (.Values.diskSelection.addonPathPrefixes | default list) }}

--- a/charts/latest/values.yaml
+++ b/charts/latest/values.yaml
@@ -113,6 +113,23 @@ cleanup:
     # Interval for scanning and cleaning up orphaned LVM volumes
     interval: 5m
 
+  # Volume sanitization configuration.
+  #
+  # Deleted logical volumes are zeroed before their extents return to the
+  # volume group's free pool, so that a subsequent volume cannot read the
+  # previous tenant's data. This cannot be disabled: the party it protects is
+  # the next volume to be created, not the one being deleted.
+  #
+  # These settings pace the work; they do not control whether it happens.
+  volumeWipe:
+    # Backstop sweep interval. Deletions are signalled directly, so this only
+    # covers volumes inherited from a previous driver process.
+    interval: 60s
+    # Volumes sanitized concurrently per node. Zeroing is bound by device write
+    # bandwidth, so raising this increases interference with running workloads
+    # without increasing throughput.
+    concurrency: 1
+
   # PV cleanup controller configuration.
   # This controller watches for Released PersistentVolumes and removes finalizers
   # when nodes are unavailable, allowing PVs to be deleted.

--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -88,6 +88,8 @@ func main() {
 	var enableLVGarbageCollection bool
 	var enableLVMOrphanCleanup bool
 	var lvmOrphanCleanupInterval time.Duration
+	var volumeWipeInterval time.Duration
+	var volumeWipeConcurrency int
 	var runAlongsideWebhook bool
 	var diskPathPrefixes string
 	var diskModels string
@@ -131,6 +133,10 @@ func main() {
 		"If enabled, the LVM orphan cleanup controller will periodically scan and clean up orphaned LVM volumes on the node.")
 	flag.DurationVar(&lvmOrphanCleanupInterval, "lvm-orphan-cleanup-interval", 30*time.Minute,
 		"Interval for the LVM orphan cleanup controller to scan and clean up orphaned volumes.")
+	flag.DurationVar(&volumeWipeInterval, "volume-wipe-interval", lvm.DefaultReaperInterval,
+		"Backstop interval for the volume wipe reaper to sweep for volumes awaiting sanitization. Deletions are signalled directly, so this only covers volumes inherited from a previous process.")
+	flag.IntVar(&volumeWipeConcurrency, "volume-wipe-concurrency", lvm.DefaultReaperConcurrency,
+		"Number of volumes sanitized concurrently. Zeroing is bound by device write bandwidth, so raising this increases interference with running workloads without increasing throughput.")
 	flag.BoolVar(&runAlongsideWebhook, "run-alongside-webhook", false,
 		"If set, indicates that the driver is running alongside a separate webhook deployment. This affects PV node affinity behavior.")
 	flag.StringVar(&diskPathPrefixes, "disk-path-prefixes", "",
@@ -300,6 +306,26 @@ func main() {
 	if err := mgr.Add(startupDiag); err != nil {
 		logAndExit(err, "unable to add startup diagnostic to manager")
 	}
+
+	// Setup the wipe reaper to zero and remove volumes that have been
+	// quarantined by deletion or garbage collection.
+	//
+	// This is deliberately not behind a feature flag. It is a security
+	// control, and the party it protects is the next tenant to be given the
+	// extents, not the one whose volume was deleted, so there is no scope at
+	// which an opt-out would be coherent. Without it, quarantined volumes are
+	// never removed and the node leaks capacity.
+	wipeReaper, err := lvm.NewReaper(volumeClient, recorder, lvm.ReaperConfig{
+		Interval:    volumeWipeInterval,
+		Concurrency: volumeWipeConcurrency,
+	})
+	if err != nil {
+		logAndExit(err, "unable to create volume wipe reaper")
+	}
+	if err := wipeReaper.SetupWithManager(mgr); err != nil {
+		logAndExit(err, "unable to setup volume wipe reaper with manager")
+	}
+	log.Info("volume wipe reaper configured", "interval", volumeWipeInterval, "concurrency", volumeWipeConcurrency)
 
 	// Setup PV garbage collection controller to clean up orphaned LVM volumes
 	// when PV node annotations don't match the current node

--- a/docs/design/volume-sanitization.md
+++ b/docs/design/volume-sanitization.md
@@ -179,6 +179,16 @@ The driver does **not** fall back to a plain discard. `BLKDISCARD` permits, but
 does not require, a device to return zeroes for discarded blocks, so a discard
 that appears to succeed can leave data readable.
 
+Discard is issued once the zeroes have been written and flushed, purely to
+release the blocks again. The kernel issues `BLKZEROOUT` with `NOUNMAP`, so it
+writes real zeroes rather than deallocating; on thin-provisioned or file-backed
+storage that materializes every block a volume ever covered, and a volume group
+that was cheap to hold would grow to its full size through nothing but normal
+create and delete activity. Discarding afterwards cannot weaken the guarantee,
+because the zeroes are already on the device, and the worst outcome is that the
+blocks stay allocated. It is best effort: a device without discard support is
+sanitized just the same.
+
 Sizing uses the volume's actual size as reported by `lvs`, not the capacity
 originally requested, because LVM rounds allocations up to whole extents and
 the remainder is part of what must be cleared.

--- a/docs/design/volume-sanitization.md
+++ b/docs/design/volume-sanitization.md
@@ -1,0 +1,355 @@
+# local-csi-driver Volume Sanitization
+
+## Scenario Definition
+
+local-csi-driver provisions volumes as LVM logical volumes carved out of a
+shared volume group on each node. When a volume is deleted, the driver runs
+`lvremove`, which removes the logical volume from LVM metadata but does **not**
+overwrite the underlying physical extents. Those extents return to the volume
+group's free pool still carrying the previous volume's data.
+
+The next volume created on that node may be allocated the same extents. LVM
+zeroes only the first 4 KiB of a new logical volume, to clear filesystem
+signatures; the remainder is whatever the previous occupant left behind. A
+`volumeMode: Filesystem` volume is formatted before use, so the residual data
+sits in unallocated filesystem blocks, but a `volumeMode: Block` volume is
+handed to the container with no intervening filesystem.
+
+Because a volume group is shared by every workload on the node, extents are not
+partitioned by workload, namespace, or trust domain. Nothing in the current
+delete path prevents a volume's contents from remaining legible to whatever is
+allocated those extents next. On a node deliberately hosting a single trust
+domain this is immaterial, but the driver should not require that assumption to
+hold.
+
+This document describes sanitization on delete: overwriting a volume's extents
+with zeroes before returning them to the free pool.
+
+## Goals
+
+- Overwrite a deleted volume's extents with zeroes, and flush them to the
+  device, before those extents become available for reallocation.
+- Hold extents out of the free pool until that overwrite has completed, so that
+  a crash, restart, or timeout cannot release dirty capacity.
+- Apply the same guarantee regardless of volume mode, access type, or whether
+  the deletion came from `DeleteVolume` or from garbage collection.
+
+The resulting guarantee is forward-only: it applies to volumes deleted by a
+build that includes sanitization.
+
+## Non-goals
+
+- **Sanitizing pre-existing free space.** Extents already free at upgrade are
+  not tracked and are not wiped. This resolves itself as the free pool turns
+  over through normal create and delete activity. Operators needing the
+  guarantee immediately should wipe or recreate the volume group before
+  upgrading. Volume expansion draws from the same pool and is covered by the
+  same caveat.
+- **Forensic erasure below the device's block interface.** Zeroing writes
+  through the logical block address space and does not reach data retained in
+  NAND by wear levelling or over-provisioning. That would require
+  self-encrypting drives or cryptographic erase.
+- **Protecting against operators.** Node root access can read the volume group
+  directly at any time. Sanitization does not change the node's administrative
+  trust boundary.
+- **Sanitizing volumes removed outside the driver**, such as a manual
+  `lvremove`.
+- **Encryption.** Per-volume encryption is a stronger long-term answer, but is
+  a separate change with its own key management design. See
+  [Alternatives considered](#alternatives-considered).
+
+## Design
+
+### Overview
+
+```text
+                DeleteVolume                    Wipe Reaper (per node)
+              +---------------+                +----------------------+
+              | tag LV        |                | list tagged LVs      |
+              | rename LV     | -- signal -->  | activate             |
+              | return OK     |                | zero and flush       |
+              +---------------+                | lvremove             |
+                                               +----------------------+
+                      |                                    |
+                      v                                    v
+              extents still held                  extents released
+              by quarantined LV                   clean to free pool
+```
+
+Deletion is split in two. The synchronous phase moves the volume into
+quarantine and returns immediately. An asynchronous reaper performs the
+overwrite and only then removes the logical volume.
+
+The split is forced by the deletion deadline. `DeleteVolume` is invoked by the
+`csi-provisioner` sidecar, which applies a per-call timeout; the chart does not
+pass `--timeout`, so the sidecar default of 15 seconds applies. Only a few
+gigabytes can be zeroed in that window, while volumes are routinely hundreds of
+gigabytes. Since the driver must fail closed rather than release a partially
+zeroed volume, a synchronous wipe would be cancelled on every call, restart
+from offset zero, and never complete. Raising the timeout only moves the bet:
+any fixed deadline is a wager against volume size and device speed.
+
+### 1. Quarantine (synchronous)
+
+On `DeleteVolume`, the driver tags the logical volume `local-csi-wipe-pending`,
+renames it to `local-csi-wipe-<uuid>`, and returns success.
+
+The rename is the **commit point** for destruction, and the generated name is
+the marker the reaper acts on. A volume that is tagged but still under its
+original name is never a wipe target: it has not been taken out of service and
+may still be referenced by a PersistentVolume, so zeroing it would destroy live
+data. If the rename fails, the tag is rolled back and the caller retries the
+whole operation. Should a crash leave a tag behind, `EnsureVolume` clears it
+and reinstates the volume, which is safe because it is the same volume, for the
+same volume ID, being returned to the tenant that owns it.
+
+Commitment is deliberately keyed on the **name rather than the tag**, because
+each can be absent independently and only one of those states is safe to
+misread. A committed volume can legitimately lose its tag, if a concurrent
+reinstatement clears it between the tag and the rename; keying on the tag would
+make such a volume invisible to the reaper forever while it still held the
+tenant's data. The reverse is not true: a tagged volume under its own name is
+simply still in service.
+
+Tagging still happens first, because it is what tells the orphan scanner to
+leave the volume alone while quarantine is in progress.
+
+The name is trustworthy as a marker because only quarantine produces it: it is
+the fixed prefix followed by a generated UUID, and the CSI layer rejects volume
+handles that name themselves into that namespace, which a pre-provisioned
+PersistentVolume could otherwise do.
+
+Renaming also frees the original name so that a later `CreateVolume` for the
+same volume ID cannot collide with a volume still awaiting its wipe. A fresh
+UUID is used each time because the same volume ID can be created and deleted
+repeatedly while an earlier quarantined volume is still pending.
+
+The extents stay allocated to the quarantined volume throughout. LVM will not
+hand them to any other volume while it exists, so quarantine is what provides
+the safety property; the zeroing that follows is what makes it safe to end.
+
+Recovery state lives entirely in LVM metadata. No new persistent store, CRD, or
+on-disk journal is introduced, and quarantine survives a driver restart or node
+reboot.
+
+### 2. Wipe reaper (asynchronous)
+
+A node-local `manager.Runnable` in the driver DaemonSet, modelled on the
+existing `LVMOrphanScanner`. For each committed volume it runs these steps in
+order:
+
+1. **Activate** (`lvchange --activate y`), because a volume can be quarantined
+   while deactivated and one with no device node cannot be written to.
+2. **Re-check**: re-read the volume and skip it unless it is still committed to
+   destruction and reports itself closed (see below).
+3. **Sanitize**: zero the volume and flush the device.
+4. **Remove** (`lvremove`), releasing the now-clean extents.
+
+The reaper runs on a timer and is additionally signalled by `DeleteVolume`
+through a buffered channel, so the timer is only a backstop for volumes
+inherited from a previous process. It sweeps unconditionally at startup, which
+is what makes quarantine crash-safe, and wipes one volume at a time: zeroing is
+bound by device write bandwidth, so concurrency adds interference with
+foreground I/O without adding throughput.
+
+### 3. Zeroing primitive
+
+The device is opened `O_WRONLY|O_EXCL` and that descriptor is held for the
+whole operation. `O_EXCL` fails if the device is still mounted, which gives an
+in-use guard with no window between check and write.
+
+`O_EXCL` alone is not enough, because the driver also serves raw block volumes.
+Those are published as a device node rather than mounted, and a pod holding one
+open takes no exclusive claim, so the open would succeed while a workload was
+still using the device. The reaper therefore also consults LVM's own open state
+immediately before zeroing and defers to any volume reporting itself open. That
+check reads both `lv_device_open` and the open indicator in `lv_attr`, and
+treats an attribute string too short to carry it as open, so that a field that
+stops being reported degrades into "defer" rather than "safe to wipe".
+
+Zeroing prefers the `BLKZEROOUT` ioctl issued on that descriptor, letting the
+device satisfy the request with a write-zeroes command rather than transferring
+zeroes across the bus. Work is issued in bounded chunks so that cancellation is
+observed promptly. Where the ioctl is unsupported, the driver falls back to
+writing zeroes explicitly, resuming at the offset where the ioctl was rejected.
+The device is flushed before `lvremove`, so the zeroes cannot still be in the
+write cache while the extents are back in the free pool.
+
+The driver does **not** fall back to a plain discard. `BLKDISCARD` permits, but
+does not require, a device to return zeroes for discarded blocks, so a discard
+that appears to succeed can leave data readable.
+
+Sizing uses the volume's actual size as reported by `lvs`, not the capacity
+originally requested, because LVM rounds allocations up to whole extents and
+the remainder is part of what must be cleared.
+
+### 4. Failure handling
+
+Sanitization fails closed. A volume that could not be zeroed keeps its tag and
+its extents and is retried with backoff. It is never removed after a failed or
+partial wipe.
+
+A node with a persistently failing device therefore accumulates quarantined
+volumes and loses usable capacity. That is the intended trade: capacity is
+recoverable by an operator, disclosed data is not. The condition is surfaced
+through events, and operators have a manual release procedure (see
+[Releasing a stuck volume](#releasing-a-stuck-volume)).
+
+### 5. Deactivated volumes
+
+`EnsureVolume` treats a volume as corrupted when it exists in LVM metadata but
+its device node is missing, and previously removed and recreated it. That
+condition is rarely corruption; it is usually a **deactivated** volume, most
+often after a reboot. The extents are intact and still hold the previous
+contents, so removing the volume returns populated extents to the free pool,
+making this a remanence vector with no deletion involved at all.
+
+The driver now attempts `lvchange --activate y`, re-checks that the device node
+actually appeared (`lvchange` can report success while it is still missing),
+and uses the volume normally if it did. Otherwise it quarantines the volume and
+fails the request. It never plain-removes.
+
+This was checked against [PV Recovery](pv-recovery.md), which deliberately
+recreates volumes **empty** during `NodeStageVolume`. The two do not conflict:
+PV Recovery's empty recreation happens on a node the volume has moved *to*,
+where no logical volume exists locally, which is a different branch. The case
+that does change is a node that reboots and stages the same volume again, where
+the contents now survive. That is compatible with PV Recovery, whose contract
+is that applications must tolerate data loss, not that data must be destroyed.
+
+### 6. Deletion paths that bypass DeleteVolume
+
+Every path that removes a logical volume routes through quarantine:
+
+| Path | Component |
+| --- | --- |
+| CSI delete | `internal/csi/core/lvm/controller.go` |
+| Orphan cleanup and PV failover GC | `internal/gc/volume_manager_adapter.go` |
+| Deactivated volume replacement | `internal/csi/core/lvm/lvm.go` |
+
+The orphan scanner must skip volumes that are committed to sanitization. They
+have no corresponding PV by construction, so without an explicit exclusion the
+scanner would treat every one as an orphan and race the reaper to remove it
+unwiped.
+
+A volume that carries only the tag is deliberately **not** skipped. Its
+quarantine was never committed, so it is still under its own name and still has
+a volume ID: if it has a PersistentVolume the normal orphan check leaves it
+alone, and if it does not, it is a genuine orphan, and routing it through
+quarantine both commits it and gets it wiped. Skipping it instead would leave
+it reclaimable by no component at all.
+
+Deletion also has to fail closed on ambiguous evidence. `DeleteVolume` must be
+idempotent, so a volume that is already gone is a success, but that conclusion
+must be about the volume itself. LVM reports an invisible volume group with the
+same not-found wording, and a group can be temporarily invisible, for example
+before device scanning has finished after a reboot. The driver distinguishes
+the two and retries rather than reporting success, which would otherwise let a
+PersistentVolume be removed while a populated volume survived on disk with
+nothing left referencing it.
+
+### CSI conformance
+
+Checked against CSI v1.12.0, the version pinned in `go.mod`. `DeleteVolume`
+remains idempotent, and no capabilities or error codes change. The
+specification places no requirement on data remanence and does not require
+capacity to be reclaimed by the time `DeleteVolume` returns.
+
+`DeleteVolume` now returns before capacity is available for reuse.
+`GetCapacity` continues to report correctly, because quarantined volumes
+genuinely occupy the volume group.
+
+## Alternatives considered
+
+| Option | Why not |
+| --- | --- |
+| Zero synchronously in `DeleteVolume` | Exceeds the sidecar timeout at realistic volume sizes; fails closed, retries from zero, never completes. |
+| `issue_discards=1`, or `blkdiscard` on delete | Discard does not guarantee zero reads. Silently ineffective where unsupported. |
+| Zero at create time instead | Puts the cost on the provisioning critical path, where a timeout is visible as a failed Pod start. |
+| Thin provisioning (dm-thin) | `zero_new_blocks` would cover expansion and pre-existing free space too, but adds a device-mapper layer to the hot path of a fast-local-NVMe driver, plus write amplification, overcommit accounting, and metadata exhaustion as a new failure mode. |
+| Per-volume encryption (dm-crypt) | Stronger, and covers pre-existing free space, but needs a key management design and costs CPU on every I/O. A possible future direction, not a substitute. |
+| Disable raw block volumes | Narrows the most direct exposure without addressing the underlying remanence, and removes a supported feature. |
+
+## How to Enable
+
+Sanitization is always on; there is no flag to disable it.
+
+An opt-out cannot be scoped safely, because the beneficiary is the **next**
+tenant to receive the extents, not the one whose volume is being deleted. A
+per-volume or StorageClass opt-out would let one workload weaken a control
+protecting a different one, leaving a node-global switch as the only coherent
+scope -- exactly the kind of setting that gets turned off for a benchmark and
+never restored. The performance argument is weak in any case: capacity is not
+reclaimed until the wipe completes either way.
+
+### Driver flags
+
+These pace the work; they do not control whether it happens.
+
+```bash
+# Backstop sweep interval (default 60s). Deletions are signalled directly, so
+# this only covers volumes inherited from a previous process.
+--volume-wipe-interval=60s
+
+# Volumes wiped concurrently per node (default 1). Zeroing is bound by device
+# write bandwidth, so raising this adds interference without adding throughput.
+--volume-wipe-concurrency=1
+```
+
+### Releasing a stuck volume
+
+If a device is failing, volumes can stay quarantined indefinitely. Operators
+can release one manually, accepting that its extents return to the free pool
+**without** being sanitized:
+
+```bash
+# List volumes awaiting a wipe. Select on the name, not the tag: the name is
+# the commit marker, and a committed volume may no longer carry the tag.
+lvs -o lv_name,vg_name,lv_size,lv_tags --select 'lv_name=~^local-csi-wipe-'
+
+# Release one, forfeiting the guarantee for its extents.
+lvremove --yes <vg>/local-csi-wipe-<uuid>
+```
+
+This is deliberately a per-volume, auditable action rather than a configuration
+setting, so it cannot be applied fleet-wide and forgotten.
+
+### Observability
+
+Implemented:
+
+- A Kubernetes event on each successful wipe, and a warning event on each
+  failed attempt carrying the attempt count, the retry delay and the
+  underlying error, so quarantined capacity that is not draining is visible
+  without reading node logs. Events are recorded against the node, because by
+  the time a volume is quarantined its PersistentVolume is already gone.
+- Tracing spans for quarantine, each sweep, and each individual wipe.
+
+Not yet implemented, and tracked as follow-up work:
+
+- Metrics for volumes awaiting wipe, wipe duration, bytes zeroed, and failures.
+- A startup diagnostic recording whether `BLKZEROOUT` is supported on each
+  managed device, so the fallback path is visible before it is needed.
+
+## Pain Points
+
+- **Capacity is reclaimed later than deletion reports.** A workload that
+  deletes a large volume and immediately creates another of the same size on
+  the same node may fail to provision until the wipe finishes.
+- **Wiping competes with running workloads** for device write bandwidth.
+  Concurrency is bounded to limit this, which in turn bounds how quickly
+  capacity drains.
+- **Persistent device failure consumes capacity.** Volumes that cannot be
+  zeroed stay quarantined by design and need operator attention.
+- **Provisioning failures replace self-healing.** A volume whose device node
+  cannot be reactivated is no longer silently recreated.
+- **Pre-existing free space is unprotected** until the pool turns over.
+
+## Related Documentation
+
+- [PV Recovery Design](pv-recovery.md) - Volume recreation and orphan
+  collection
+- [PV Cleanup Design](pv-cleanup.md) - PV deletion when a node is lost
+- [GC Controllers README](../../internal/gc/README.md) - Garbage collection
+  implementation
+- [Security Policy](../../SECURITY.md) - Reporting security issues

--- a/docs/design/volume-sanitization.md
+++ b/docs/design/volume-sanitization.md
@@ -214,10 +214,31 @@ often after a reboot. The extents are intact and still hold the previous
 contents, so removing the volume returns populated extents to the free pool,
 making this a remanence vector with no deletion involved at all.
 
-The driver now attempts `lvchange --activate y`, re-checks that the device node
-actually appeared (`lvchange` can report success while it is still missing),
-and uses the volume normally if it did. Otherwise it quarantines the volume and
-fails the request. It never plain-removes.
+The driver attempts `lvchange --activate y`, then runs `vgmknodes` and
+re-checks that the device node actually appeared: `lvchange` can report
+success while the node is still missing, and `vgmknodes` closes that specific
+gap by synchronously reconciling device nodes against LVM metadata rather than
+racing whatever would otherwise create them.
+
+If the volume is still unusable after that, the request fails and the volume
+is left **untouched** rather than quarantined. Unlike a `DeleteVolume` call,
+"unusable" here is the driver's own inference, not a signal from the CO that
+the data should be destroyed, and that inference can be wrong (transient
+device timing, a slow node, and so on). Quarantining on a guess would risk
+destroying a volume nobody asked to delete, which is worse than failing a
+request the CO will retry on its own schedule. The volume is neither
+quarantined nor recreated: it is simply reported as unusable, repeatedly, until
+either it recovers or an operator intervenes.
+
+If a volume is confirmed to be genuinely and permanently unrecoverable, the
+existing remediation path handles it without any special-casing: deleting its
+PersistentVolume routes through the normal `DeleteVolume` path (see
+[Deletion paths that bypass DeleteVolume](#6-deletion-paths-that-bypass-deletevolume)
+below), which quarantines and wipes the volume regardless of its activation
+state, since `Quarantine` is a metadata-only operation. If the volume truly
+cannot be brought online even for wiping, it becomes a stuck quarantined
+volume like any other, covered by the same manual release procedure (see
+[Releasing a stuck volume](#releasing-a-stuck-volume)).
 
 This was checked against [PV Recovery](pv-recovery.md), which deliberately
 recreates volumes **empty** during `NodeStageVolume`. The two do not conflict:
@@ -235,7 +256,6 @@ Every path that removes a logical volume routes through quarantine:
 | --- | --- |
 | CSI delete | `internal/csi/core/lvm/controller.go` |
 | Orphan cleanup and PV failover GC | `internal/gc/volume_manager_adapter.go` |
-| Deactivated volume replacement | `internal/csi/core/lvm/lvm.go` |
 
 The orphan scanner must skip volumes that are committed to sanitization. They
 have no corresponding PV by construction, so without an explicit exclusion the

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.uber.org/mock v0.6.0
 	golang.org/x/mod v0.40.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12
 	k8s.io/api v0.36.4
@@ -140,7 +141,6 @@ require (
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/internal/csi/core/lvm/controller.go
+++ b/internal/csi/core/lvm/controller.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"go.opentelemetry.io/otel/attribute"
@@ -150,44 +149,42 @@ func (l *LVM) Delete(ctx context.Context, req *csi.DeleteVolumeRequest) error {
 		attribute.String("vol.name", id.LogicalVolume),
 	)
 
-	// Cleanup the volume on the node.
-	deleteOps := lvm.RemoveLVOptions{Name: volumeId}
-
-	ctx, cancel := context.WithTimeout(ctx, removeVolumeRetryTimeout)
-	defer cancel()
-
-	ticker := time.NewTicker(removeVolumeRetryPoll)
-	defer ticker.Stop()
-
-	var lastErr error
-	for {
-		select {
-		case <-ctx.Done():
-			err := errors.Join(lastErr, ctx.Err())
-			recorder.Eventf(corev1.EventTypeWarning, deletingLogicalVolumeFailed, "Failed to delete logical volume %s: %s", volumeId, err.Error())
-			span.SetStatus(codes.Error, "failed to delete logical volume")
-			span.RecordError(err)
-			return fmt.Errorf("failed to remove logical volume %s: %w", volumeId, err)
-		case <-ticker.C:
-			err := l.lvm.RemoveLogicalVolume(ctx, deleteOps)
-			if lvm.IgnoreNotFound(err) == nil {
-				span.AddEvent("deleted logical volume")
-				span.SetStatus(codes.Ok, "deleted logical volume")
-				return nil
-			}
-			if !errors.Is(err, lvm.ErrInUse) {
-				recorder.Eventf(corev1.EventTypeWarning, deletingLogicalVolumeFailed, "Failed to delete logical volume %s: %s", volumeId, err.Error())
-				span.AddEvent("failed to delete logical volume", trace.WithAttributes(
-					attribute.String("error", err.Error()),
-				))
-				return err
-			}
-			span.AddEvent("failed to delete logical volume, retrying", trace.WithAttributes(
-				attribute.String("error", err.Error()),
-			))
-			lastErr = err
+	// Take the volume out of service and hand it to the wipe reaper.
+	//
+	// The volume is not removed here. DeleteVolume is called by the
+	// csi-provisioner sidecar under a timeout measured in seconds, while
+	// zeroing a volume is measured in minutes, so the wipe cannot be done
+	// inline. Quarantine keeps the extents allocated, so LVM cannot hand them
+	// to another tenant before they have been cleared, and the reaper zeroes
+	// and removes the volume afterwards with no deadline.
+	//
+	// This is why there is no retry loop here: quarantine is a metadata
+	// operation, and a volume that is still momentarily in use no longer has
+	// to be waited for. The reaper opens the device exclusively when it comes
+	// to wipe it, so it defers to any remaining consumer by itself.
+	if _, err := l.Quarantine(ctx, id.VolumeGroup, id.LogicalVolume); err != nil {
+		// DeleteVolume must be idempotent, so a volume that is already gone is
+		// a success.
+		//
+		// A volume group that cannot be seen is not such a case. It is usually
+		// temporary, for example before device scanning has finished after a
+		// reboot, and reporting success would let the PersistentVolume be
+		// removed while a populated logical volume survives on disk with
+		// nothing left referencing it. Retrying is the safe answer.
+		if lvm.IgnoreNotFound(err) == nil && !errors.Is(err, lvm.ErrVolumeGroupNotFound) {
+			span.AddEvent("logical volume already removed")
+			span.SetStatus(codes.Ok, "logical volume already removed")
+			return nil
 		}
+		recorder.Eventf(corev1.EventTypeWarning, deletingLogicalVolumeFailed, "Failed to delete logical volume %s: %s", volumeId, err.Error())
+		span.SetStatus(codes.Error, "failed to quarantine logical volume")
+		span.RecordError(err)
+		return err
 	}
+
+	span.AddEvent("quarantined logical volume for wiping")
+	span.SetStatus(codes.Ok, "quarantined logical volume for wiping")
+	return nil
 }
 
 func (l *LVM) List(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {

--- a/internal/csi/core/lvm/delete_internal_test.go
+++ b/internal/csi/core/lvm/delete_internal_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"go.uber.org/mock/gomock"
+
+	lvmMgr "local-csi-driver/internal/pkg/lvm"
+	"local-csi-driver/internal/pkg/probe"
+	"local-csi-driver/internal/pkg/telemetry"
+)
+
+// TestDeleteSignalsWipeReaper checks that a deletion wakes the reaper.
+//
+// Without the signal, a deleted volume's capacity would not be reclaimed until
+// the next backstop sweep, which is far longer than a workload that deletes
+// and immediately recreates a volume would tolerate.
+//
+// This test is internal because the signal is deliberately not exposed: the
+// deletion path signals unconditionally and nothing in the driver needs to
+// inspect it.
+func TestDeleteSignalsWipeReaper(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	m := lvmMgr.NewMockManager(ctrl)
+	m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+	m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+
+	l, err := New(
+		"test-pod", "test-node", "test-namespace", false,
+		probe.NewFake([]string{"device1"}, nil), m,
+		telemetry.NewNoopTracerProvider(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := l.Delete(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: "test-vg#test-lv",
+	}); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	select {
+	case <-l.wipeSignal:
+	default:
+		t.Error("Delete() did not signal the wipe reaper")
+	}
+}

--- a/internal/csi/core/lvm/delete_test.go
+++ b/internal/csi/core/lvm/delete_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"go.uber.org/mock/gomock"
+
+	"local-csi-driver/internal/csi/core/lvm"
+	lvmMgr "local-csi-driver/internal/pkg/lvm"
+)
+
+// TestDeleteQuarantinesInsteadOfRemoving is the core regression test for
+// deletion-time sanitization.
+//
+// Removing a logical volume returns its extents to the volume group's free
+// pool with the tenant's data still on them, where the next volume created in
+// that group can read them back. Delete must therefore hand the volume to the
+// wipe reaper rather than removing it.
+func TestDeleteQuarantinesInsteadOfRemoving(t *testing.T) {
+	t.Parallel()
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+				if len(opts.AddTags) != 1 || opts.AddTags[0] != lvm.WipePendingTag {
+					t.Errorf("added tags %v, want [%s]", opts.AddTags, lvm.WipePendingTag)
+				}
+				return nil
+			})
+		m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+
+		// The absence of a RemoveLogicalVolume expectation is the assertion:
+		// gomock fails the test if the volume is removed here.
+	})
+
+	err := l.Delete(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: testVolumeGroup + "#" + testLogicalVolume,
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+}
+
+// TestDeleteIsIdempotent checks that deleting a volume that is already gone
+// succeeds.
+//
+// The CSI specification requires DeleteVolume to return OK when the volume
+// does not exist, and the sidecar retries deletions, so this is the common
+// case on a retry rather than an edge case.
+func TestDeleteIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			Return(lvmMgr.ErrNotFound)
+	})
+
+	err := l.Delete(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: testVolumeGroup + "#" + testLogicalVolume,
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v, want nil for a volume that is already gone", err)
+	}
+}
+
+// TestDeleteReturnsErrorWhenQuarantineFails checks that a volume which could
+// not be quarantined is reported as a failed deletion.
+//
+// Reporting success would let the provisioner delete the PersistentVolume
+// while the logical volume is still live and unsanitized, leaving it to be
+// collected later by a path that may not zero it.
+func TestDeleteReturnsErrorWhenQuarantineFails(t *testing.T) {
+	t.Parallel()
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			Return(errors.New("metadata write failed"))
+	})
+
+	err := l.Delete(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: testVolumeGroup + "#" + testLogicalVolume,
+	})
+	if err == nil {
+		t.Fatal("Delete() error = nil, want an error when the volume could not be quarantined")
+	}
+}
+
+// TestDeleteIgnoresUnparseableVolumeID checks that an ID this driver could not
+// have issued is treated as already deleted, since by definition no such
+// volume exists.
+func TestDeleteIgnoresUnparseableVolumeID(t *testing.T) {
+	t.Parallel()
+
+	// No LVM calls may be made at all.
+	l := newQuarantineTestLVM(t, nil)
+
+	err := l.Delete(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: "not-a-valid-volume-id",
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+}
+
+// TestDeleteFailsClosedWhenVolumeGroupIsInvisible checks that an invisible
+// volume group is not mistaken for a deleted volume.
+//
+// DeleteVolume must be idempotent, but the evidence for "already gone" has to
+// be about the volume itself. LVM reports a missing group with the same
+// not-found wording, and that condition is usually temporary, for example
+// before device scanning has finished after a reboot. Reporting success would
+// let the PersistentVolume be removed while a populated logical volume
+// survives on disk with nothing left referencing it.
+func TestDeleteFailsClosedWhenVolumeGroupIsInvisible(t *testing.T) {
+	t.Parallel()
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			Return(fmt.Errorf("%w: Volume group %q not found", lvmMgr.ErrVolumeGroupNotFound, testVolumeGroup))
+	})
+
+	err := l.Delete(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: testVolumeGroup + "#" + testLogicalVolume,
+	})
+	if err == nil {
+		t.Fatal("expected an error when the volume group cannot be seen, got nil")
+	}
+}

--- a/internal/csi/core/lvm/id.go
+++ b/internal/csi/core/lvm/id.go
@@ -52,6 +52,13 @@ func newIdFromString(id string) (*volumeId, error) {
 	if len(lv) == 0 {
 		return nil, fmt.Errorf("error parsing volume id: %q, logical volume name is empty", id)
 	}
+	// The quarantine namespace is reserved for volumes the driver has taken
+	// out of service. A volume handle is operator-supplied for a
+	// pre-provisioned PersistentVolume, and one naming itself into that
+	// namespace would be treated as awaiting destruction and zeroed.
+	if isQuarantineName(lv) {
+		return nil, fmt.Errorf("error parsing volume id: %q, logical volume name is reserved", id)
+	}
 	return &volumeId{
 		VolumeGroup:   vg,
 		LogicalVolume: lv,

--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"go.opentelemetry.io/otel/attribute"
@@ -64,8 +63,9 @@ const (
 	provisioningLogicalVolumeFailed      = "ProvisioningLogicalVolumeFailed"
 	provisionedLogicalVolumeSizeMismatch = "ProvisionedLogicalVolumeSizeMismatch"
 	provisionedEmptyVolume               = "ProvisionedEmptyVolume"
-	removedCorruptedLogicalVolume        = "RemovedCorruptedLogicalVolume"
-	failedToRemoveCorruptedLogicalVolume = "FailedToRemoveCorruptedLogicalVolume"
+	activatedLogicalVolume               = "ActivatedLogicalVolume"
+	quarantinedLogicalVolume             = "QuarantinedLogicalVolume"
+	failedToQuarantineLogicalVolume      = "FailedToQuarantineLogicalVolume"
 )
 
 // Volume context parameters.
@@ -89,13 +89,10 @@ var (
 	// provisioning.
 	ErrNoDisksFound = fmt.Errorf("no disks found")
 
-	// removeVolumeRetryPoll is the time to wait between retries when removing
-	// a volume.
-	removeVolumeRetryPoll = 500 * time.Millisecond
-
-	// removeVolumeRetryTimeout is the time to wait before giving up on
-	// removing a volume.
-	removeVolumeRetryTimeout = 10 * time.Second
+	// ErrVolumeUnusable is returned when a logical volume exists but cannot be
+	// brought online, so it can neither be served to the caller nor have its
+	// extents cleared for reuse.
+	ErrVolumeUnusable = fmt.Errorf("logical volume is unusable")
 )
 
 // csiDriver is the CSI driver object that is registered with the Kubernetes API
@@ -169,6 +166,14 @@ type LVM struct {
 	// vgGroup deduplicates concurrent EnsureVolumeGroup calls for the same
 	// volume group so that only one goroutine provisions it at a time.
 	vgGroup singleflight.Group
+
+	// wipeSignal wakes the wipe reaper when a volume is quarantined.
+	//
+	// The channel is owned here rather than by the reaper so that the deletion
+	// path has nothing to look up and no back-pointer to a component that may
+	// not be running: signalling is always safe, and is simply not observed if
+	// no reaper has started.
+	wipeSignal chan struct{}
 }
 
 // New creates a new LVM volume manager.
@@ -190,6 +195,10 @@ func New(podName, nodeName, releaseNamespace string, enableCleanup bool, probe p
 		probe:            probe,
 		lvm:              lvmMgr,
 		tracer:           tp.Tracer("localdisk.csi.acstor.io/internal/csi/api/volume/lvm"),
+		// Buffered with a single slot. A pending wakeup already covers any
+		// number of subsequent quarantines, because each sweep processes
+		// everything it finds.
+		wipeSignal: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -485,38 +494,11 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity int64,
 		return 0, err
 	}
 
-	// Check if the logical volume is corrupted
 	if lv != nil {
-		corrupted, err := l.lvm.IsLogicalVolumeCorrupted(ctx, id.VolumeGroup, id.LogicalVolume)
-		if err != nil {
-			log.Error(err, "failed to check if logical volume is corrupted")
-			span.SetStatus(codes.Error, "failed to check if logical volume is corrupted")
-			span.RecordError(err)
-			return 0, fmt.Errorf("failed to check if logical volume is corrupted: %w", err)
-		}
-
-		if corrupted {
-			log.V(1).Info("found corrupted logical volume, removing it", "vg", id.VolumeGroup, "lv", id.LogicalVolume) // Remove the corrupted LV
-			opts := lvm.RemoveLVOptions{
-				Name: fmt.Sprintf("%s/%s", id.VolumeGroup, id.LogicalVolume),
-			}
-			if err := l.lvm.RemoveLogicalVolume(ctx, opts); err != nil {
-				log.Error(err, "failed to remove corrupted logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
-				span.SetStatus(codes.Error, "failed to remove corrupted logical volume")
-				span.RecordError(err)
-				recorder.Eventf(corev1.EventTypeWarning, failedToRemoveCorruptedLogicalVolume,
-					"Failed to remove corrupted logical volume %s/%s: %s",
-					id.VolumeGroup, id.LogicalVolume, err.Error())
-				return 0, fmt.Errorf("failed to remove corrupted logical volume %s/%s: %w", id.VolumeGroup, id.LogicalVolume, err)
-			}
-
-			log.V(1).Info("removed corrupted logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
-			recorder.Eventf(corev1.EventTypeNormal, removedCorruptedLogicalVolume,
-				"Successfully removed corrupted logical volume %s/%s",
-				id.VolumeGroup, id.LogicalVolume)
-
-			// Set lv to nil so it will be recreated below
-			lv = nil
+		if prepErr := l.prepareExistingVolume(ctx, id, lv); prepErr != nil {
+			span.SetStatus(codes.Error, "failed to prepare existing logical volume")
+			span.RecordError(prepErr)
+			return 0, prepErr
 		}
 	}
 
@@ -606,6 +588,118 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity int64,
 // The CSI volume context contains the volume group but it's not passed to all
 // CSI operations. Instead, since the volumeId (lv name) is unique across
 // vgs, we can look it up from the lv.
+
+// prepareExistingVolume readies an existing logical volume for reuse.
+//
+// It clears an uncommitted wipe tag, and repairs a volume that exists in LVM
+// metadata but has no device node. It reports an error if the volume cannot be
+// returned to service, in which case the volume has been quarantined and must
+// not be recreated over.
+func (l *LVM) prepareExistingVolume(ctx context.Context, id *volumeId, lv *lvm.LogicalVolume) error {
+	ctx, span := l.tracer.Start(ctx, "volume.lvm.csi/prepareExistingVolume", trace.WithAttributes(
+		attribute.String("vol.group", id.VolumeGroup),
+		attribute.String("vol.name", id.LogicalVolume),
+	))
+	defer span.End()
+
+	log := log.FromContext(ctx).WithValues("vg", id.VolumeGroup, "lv", id.LogicalVolume)
+	recorder := events.FromContext(ctx)
+
+	// Reinstate a volume whose quarantine was started but never committed.
+	//
+	// Destruction is committed by the rename, so a tagged volume still
+	// under its original name was never taken out of service. It cannot be
+	// served while tagged, though: the tag is what the orphan scanner uses
+	// to skip it, and leaving it in place on a live volume would keep the
+	// volume permanently invisible to that safety check.
+	if IsQuarantined(*lv) {
+		log.V(1).Info("clearing uncommitted wipe tag from existing logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
+		if err := l.ClearQuarantineTag(ctx, id.VolumeGroup, id.LogicalVolume); err != nil {
+			log.Error(err, "failed to clear uncommitted wipe tag")
+			span.SetStatus(codes.Error, "failed to clear uncommitted wipe tag")
+			span.RecordError(err)
+			return err
+		}
+		lv.Tags = ""
+	}
+
+	corrupted, err := l.lvm.IsLogicalVolumeCorrupted(ctx, id.VolumeGroup, id.LogicalVolume)
+	if err != nil {
+		log.Error(err, "failed to check if logical volume is corrupted")
+		span.SetStatus(codes.Error, "failed to check if logical volume is corrupted")
+		span.RecordError(err)
+		return fmt.Errorf("failed to check if logical volume is corrupted: %w", err)
+	}
+
+	if corrupted {
+		// A "corrupted" volume here is one that exists in LVM metadata but
+		// has no device node under /dev/<vg>/<lv>. That is rarely
+		// corruption: it is usually a deactivated volume, most often after
+		// a reboot where autoactivation did not run.
+		//
+		// The extents are intact and still hold the previous contents, so
+		// removing the volume would return populated extents to the volume
+		// group's free pool where the next volume created in the group
+		// could read them back. Activation is attempted first, both
+		// because it is almost always the correct repair and because it is
+		// the only way to reach the data in order to clear it.
+		fullName := fmt.Sprintf("%s/%s", id.VolumeGroup, id.LogicalVolume)
+		log.V(1).Info("logical volume has no device node, attempting to activate", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
+
+		activateErr := l.lvm.UpdateLogicalVolume(ctx, lvm.UpdateLVOptions{
+			Name:     fullName,
+			Activate: lvm.Yes,
+		})
+		if activateErr == nil {
+			// Confirm the device node actually appeared. lvchange can
+			// report success while the node is still missing, and treating
+			// that as recovered would hand the caller a volume it cannot
+			// open.
+			corrupted, err = l.lvm.IsLogicalVolumeCorrupted(ctx, id.VolumeGroup, id.LogicalVolume)
+			if err != nil {
+				log.Error(err, "failed to re-check logical volume after activation")
+				span.RecordError(err)
+				return fmt.Errorf("failed to check if logical volume is corrupted: %w", err)
+			}
+		}
+
+		if corrupted {
+			// The volume cannot be brought online, so its extents cannot be
+			// cleared. Quarantine it and fail: the wipe reaper retries
+			// activation, and the volume is only removed once it has been
+			// zeroed. Recreating over these extents instead would expose
+			// the previous contents through the new volume.
+			if _, qErr := l.Quarantine(ctx, id.VolumeGroup, id.LogicalVolume); qErr != nil {
+				log.Error(qErr, "failed to quarantine unusable logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
+				span.SetStatus(codes.Error, "failed to quarantine unusable logical volume")
+				span.RecordError(qErr)
+				recorder.Eventf(corev1.EventTypeWarning, failedToQuarantineLogicalVolume,
+					"Failed to quarantine unusable logical volume %s: %s", fullName, qErr.Error())
+				return fmt.Errorf("failed to quarantine unusable logical volume %s: %w", fullName, qErr)
+			}
+
+			// errors.Join drops a nil activateErr, which is the case
+			// where lvchange reported success but the device node is
+			// still missing.
+			err := fmt.Errorf("logical volume %s could not be activated and has been quarantined for sanitization: %w",
+				fullName, errors.Join(ErrVolumeUnusable, activateErr))
+			log.Error(err, "quarantined unusable logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
+			span.SetStatus(codes.Error, "quarantined unusable logical volume")
+			span.RecordError(err)
+			recorder.Eventf(corev1.EventTypeWarning, quarantinedLogicalVolume,
+				"Logical volume %s could not be activated and has been quarantined for sanitization; "+
+					"it will not be reused until its contents have been cleared", fullName)
+			return err
+		}
+
+		log.V(1).Info("activated logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
+		recorder.Eventf(corev1.EventTypeNormal, activatedLogicalVolume,
+			"Activated logical volume %s", fullName)
+	}
+
+	return nil
+}
+
 func (l *LVM) GetNodeDevicePath(volumeId string) (string, error) {
 	id, err := newIdFromString(volumeId)
 	if err != nil {

--- a/internal/csi/core/lvm/lvm.go
+++ b/internal/csi/core/lvm/lvm.go
@@ -64,8 +64,7 @@ const (
 	provisionedLogicalVolumeSizeMismatch = "ProvisionedLogicalVolumeSizeMismatch"
 	provisionedEmptyVolume               = "ProvisionedEmptyVolume"
 	activatedLogicalVolume               = "ActivatedLogicalVolume"
-	quarantinedLogicalVolume             = "QuarantinedLogicalVolume"
-	failedToQuarantineLogicalVolume      = "FailedToQuarantineLogicalVolume"
+	logicalVolumeUnusable                = "LogicalVolumeUnusable"
 )
 
 // Volume context parameters.
@@ -583,18 +582,18 @@ func (l *LVM) EnsureVolume(ctx context.Context, volumeId string, capacity int64,
 	return allocatedSize, nil
 }
 
-// GetNodeDevicePath returns the device path for the given volume ID.
-//
-// The CSI volume context contains the volume group but it's not passed to all
-// CSI operations. Instead, since the volumeId (lv name) is unique across
-// vgs, we can look it up from the lv.
-
 // prepareExistingVolume readies an existing logical volume for reuse.
 //
 // It clears an uncommitted wipe tag, and repairs a volume that exists in LVM
 // metadata but has no device node. It reports an error if the volume cannot be
-// returned to service, in which case the volume has been quarantined and must
-// not be recreated over.
+// returned to service. That volume is left untouched, not quarantined: unlike
+// a CSI DeleteVolume request, "unusable" here is the driver's own inference,
+// and that inference can be wrong, for example due to reboot-timing races in
+// device node creation. Destroying data on a guess is worse than failing the
+// request and letting the caller retry; an operator who has independently
+// confirmed the volume is truly gone can still reclaim it by deleting the
+// PersistentVolume, which quarantines and wipes it through the normal
+// DeleteVolume path regardless of activation state.
 func (l *LVM) prepareExistingVolume(ctx context.Context, id *volumeId, lv *lvm.LogicalVolume) error {
 	ctx, span := l.tracer.Start(ctx, "volume.lvm.csi/prepareExistingVolume", trace.WithAttributes(
 		attribute.String("vol.group", id.VolumeGroup),
@@ -651,10 +650,22 @@ func (l *LVM) prepareExistingVolume(ctx context.Context, id *volumeId, lv *lvm.L
 			Activate: lvm.Yes,
 		})
 		if activateErr == nil {
-			// Confirm the device node actually appeared. lvchange can
-			// report success while the node is still missing, and treating
-			// that as recovered would hand the caller a volume it cannot
-			// open.
+			// lvchange can report success while the node is still missing.
+			// Force LVM to reconcile device nodes for this VG against its
+			// metadata before re-checking, rather than racing whatever
+			// mechanism would otherwise create it: vgmknodes is synchronous,
+			// so if activation truly succeeded this closes the gap instead
+			// of narrowing it.
+			if mkErr := l.lvm.MakeVolumeGroupDeviceNodes(ctx, lvm.MakeVGDeviceNodesOptions{
+				Name: id.VolumeGroup,
+			}); mkErr != nil {
+				log.Error(mkErr, "failed to reconcile device nodes after activation", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
+				span.RecordError(mkErr)
+				// Fall through to the re-check below: it is the actual
+				// safety net, and a device that is genuinely still missing
+				// will be reported as such regardless of this error.
+			}
+
 			corrupted, err = l.lvm.IsLogicalVolumeCorrupted(ctx, id.VolumeGroup, id.LogicalVolume)
 			if err != nil {
 				log.Error(err, "failed to re-check logical volume after activation")
@@ -665,30 +676,29 @@ func (l *LVM) prepareExistingVolume(ctx context.Context, id *volumeId, lv *lvm.L
 
 		if corrupted {
 			// The volume cannot be brought online, so its extents cannot be
-			// cleared. Quarantine it and fail: the wipe reaper retries
-			// activation, and the volume is only removed once it has been
-			// zeroed. Recreating over these extents instead would expose
-			// the previous contents through the new volume.
-			if _, qErr := l.Quarantine(ctx, id.VolumeGroup, id.LogicalVolume); qErr != nil {
-				log.Error(qErr, "failed to quarantine unusable logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
-				span.SetStatus(codes.Error, "failed to quarantine unusable logical volume")
-				span.RecordError(qErr)
-				recorder.Eventf(corev1.EventTypeWarning, failedToQuarantineLogicalVolume,
-					"Failed to quarantine unusable logical volume %s: %s", fullName, qErr.Error())
-				return fmt.Errorf("failed to quarantine unusable logical volume %s: %w", fullName, qErr)
-			}
-
-			// errors.Join drops a nil activateErr, which is the case
-			// where lvchange reported success but the device node is
-			// still missing.
-			err := fmt.Errorf("logical volume %s could not be activated and has been quarantined for sanitization: %w",
+			// cleared, but that does not mean they are gone: this is the
+			// driver's own inference, not a user request to delete, and it
+			// can be wrong (for example, a device that is merely slow to
+			// settle). Quarantining on that guess would destroy a volume the
+			// caller never asked to delete, so the request fails instead and
+			// the volume is left exactly as it is. The CSI caller retries
+			// this on its own schedule; if the volume is confirmed truly
+			// unrecoverable, an operator can reclaim it by deleting the
+			// PersistentVolume, which quarantines and wipes it through the
+			// normal DeleteVolume path regardless of activation state.
+			//
+			// errors.Join drops a nil activateErr, which is the case where
+			// lvchange reported success but the device node is still
+			// missing.
+			err := fmt.Errorf("logical volume %s could not be activated: %w",
 				fullName, errors.Join(ErrVolumeUnusable, activateErr))
-			log.Error(err, "quarantined unusable logical volume", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
-			span.SetStatus(codes.Error, "quarantined unusable logical volume")
+			log.Error(err, "logical volume is unusable", "vg", id.VolumeGroup, "lv", id.LogicalVolume)
+			span.SetStatus(codes.Error, "logical volume is unusable")
 			span.RecordError(err)
-			recorder.Eventf(corev1.EventTypeWarning, quarantinedLogicalVolume,
-				"Logical volume %s could not be activated and has been quarantined for sanitization; "+
-					"it will not be reused until its contents have been cleared", fullName)
+			recorder.Eventf(corev1.EventTypeWarning, logicalVolumeUnusable,
+				"Logical volume %s could not be activated; the request will fail and be retried. "+
+					"Its contents have not been touched. If this volume is confirmed to be permanently "+
+					"unrecoverable, delete its PersistentVolume to reclaim the capacity", fullName)
 			return err
 		}
 
@@ -700,6 +710,11 @@ func (l *LVM) prepareExistingVolume(ctx context.Context, id *volumeId, lv *lvm.L
 	return nil
 }
 
+// GetNodeDevicePath returns the device path for the given volume ID.
+//
+// The CSI volume context contains the volume group but it's not passed to all
+// CSI operations. Instead, since the volumeId (lv name) is unique across
+// vgs, we can look it up from the lv.
 func (l *LVM) GetNodeDevicePath(volumeId string) (string, error) {
 	id, err := newIdFromString(volumeId)
 	if err != nil {

--- a/internal/csi/core/lvm/lvm_test.go
+++ b/internal/csi/core/lvm/lvm_test.go
@@ -717,23 +717,58 @@ func TestEnsureVolume(t *testing.T) {
 			expectedErr: errTestInternal,
 		},
 		{
-			name:     "corrupted lv detected and removed successfully",
+			// A volume with no device node is almost always deactivated
+			// rather than damaged, so it is reactivated and reused. Removing
+			// and recreating it would both destroy a recoverable volume and
+			// return extents still holding its data to the free pool.
+			name:     "lv without device node is activated and reused",
 			volumeId: "vg#lv",
 			request:  convert.MiBToBytes(1024),
 			expectLvm: func(m *lvmMgr.MockManager) {
-				// First, GetLogicalVolume returns existing LV
 				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(testLv1GiB, nil)
-				// IsLogicalVolumeCorrupted detects corruption
 				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
-				// Remove the corrupted LV
-				m.EXPECT().RemoveLogicalVolume(gomock.Any(), lvmMgr.RemoveLVOptions{
-					Name: "vg/lv",
-				}).Return(nil)
-				// After removal, proceed with creating new volume
-				m.EXPECT().GetVolumeGroup(gomock.Any(), "vg").Return(testVg, nil)
-				m.EXPECT().CreateLogicalVolume(gomock.Any(), gomock.Any()).Return(convert.MiBToBytes(1024), nil)
+				// Activation brings the device node back.
+				m.EXPECT().
+					UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+						if opts.Name != "vg/lv" {
+							t.Errorf("activated %q, want %q", opts.Name, "vg/lv")
+						}
+						if opts.Activate == nil || !bool(*opts.Activate) {
+							t.Error("expected the volume to be activated")
+						}
+						return nil
+					})
+				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(false, nil)
+				// The existing volume is returned as-is: no removal, and no
+				// recreation over its extents.
 			},
 			expectedErr: nil,
+		},
+		{
+			// Activation can report success while the device node is still
+			// missing. Treating that as recovered would hand the caller a
+			// volume it cannot open, so it is quarantined instead.
+			name:     "lv still without device node after activation is quarantined",
+			volumeId: "vg#lv",
+			request:  convert.MiBToBytes(1024),
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(testLv1GiB, nil)
+				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
+				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
+				// Quarantine: tag then rename. No RemoveLogicalVolume.
+				m.EXPECT().
+					UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+						if len(opts.AddTags) != 1 || opts.AddTags[0] != lvm.WipePendingTag {
+							t.Errorf("added tags %v, want [%s]", opts.AddTags, lvm.WipePendingTag)
+						}
+						return nil
+					})
+				m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expectedErr: lvm.ErrVolumeUnusable,
 		},
 		{
 			name:     "corrupted lv detection fails",
@@ -748,18 +783,73 @@ func TestEnsureVolume(t *testing.T) {
 			expectedErr: errTestInternal,
 		},
 		{
-			name:     "corrupted lv removal fails",
+			// Provisioning fails closed rather than recycling extents that
+			// could not be cleared.
+			name:     "lv that cannot be activated is quarantined",
 			volumeId: "vg#lv",
 			request:  convert.MiBToBytes(1024),
 			expectLvm: func(m *lvmMgr.MockManager) {
-				// GetLogicalVolume returns existing LV
 				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(testLv1GiB, nil)
-				// IsLogicalVolumeCorrupted detects corruption
 				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
-				// Remove the corrupted LV fails
-				m.EXPECT().RemoveLogicalVolume(gomock.Any(), lvmMgr.RemoveLVOptions{
-					Name: "vg/lv",
-				}).Return(errTestInternal)
+				// Activation fails.
+				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(errTestInternal)
+				// Quarantine: tag then rename. No RemoveLogicalVolume.
+				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expectedErr: errTestInternal,
+		},
+		{
+			// If the volume cannot even be quarantined it is still not
+			// removed, and the caller is told provisioning failed.
+			name:     "lv that cannot be quarantined fails provisioning",
+			volumeId: "vg#lv",
+			request:  convert.MiBToBytes(1024),
+			expectLvm: func(m *lvmMgr.MockManager) {
+				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(testLv1GiB, nil)
+				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
+				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(errTestInternal)
+				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(errTestInternal)
+			},
+			expectedErr: errTestInternal,
+		},
+		{
+			// A tagged volume still under its original name was never
+			// committed to destruction, so it belongs to the workload asking
+			// for it. The tag must be cleared before it is served, because the
+			// tag is what makes the orphan scanner skip it.
+			name:     "uncommitted quarantine tag is cleared and the volume is served",
+			volumeId: "vg#lv",
+			request:  convert.MiBToBytes(1024),
+			expectLvm: func(m *lvmMgr.MockManager) {
+				tagged := *testLv1GiB
+				tagged.Tags = lvm.WipePendingTag
+				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(&tagged, nil)
+				m.EXPECT().
+					UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+						if len(opts.DelTags) != 1 || opts.DelTags[0] != lvm.WipePendingTag {
+							t.Errorf("removed tags %v, want [%s]", opts.DelTags, lvm.WipePendingTag)
+						}
+						return nil
+					})
+				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(false, nil)
+				// No RenameLogicalVolume and no RemoveLogicalVolume: gomock
+				// fails the test if the volume is destroyed.
+			},
+			expectedErr: nil,
+		},
+		{
+			// If the tag cannot be cleared the volume is not served, rather
+			// than served while still marked for destruction.
+			name:     "uncommitted quarantine tag that cannot be cleared fails provisioning",
+			volumeId: "vg#lv",
+			request:  convert.MiBToBytes(1024),
+			expectLvm: func(m *lvmMgr.MockManager) {
+				tagged := *testLv1GiB
+				tagged.Tags = lvm.WipePendingTag
+				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(&tagged, nil)
+				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(errTestInternal)
 			},
 			expectedErr: errTestInternal,
 		},

--- a/internal/csi/core/lvm/lvm_test.go
+++ b/internal/csi/core/lvm/lvm_test.go
@@ -739,6 +739,7 @@ func TestEnsureVolume(t *testing.T) {
 						}
 						return nil
 					})
+				m.EXPECT().MakeVolumeGroupDeviceNodes(gomock.Any(), lvmMgr.MakeVGDeviceNodesOptions{Name: "vg"}).Return(nil)
 				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(false, nil)
 				// The existing volume is returned as-is: no removal, and no
 				// recreation over its extents.
@@ -747,26 +748,24 @@ func TestEnsureVolume(t *testing.T) {
 		},
 		{
 			// Activation can report success while the device node is still
-			// missing. Treating that as recovered would hand the caller a
-			// volume it cannot open, so it is quarantined instead.
-			name:     "lv still without device node after activation is quarantined",
+			// missing. vgmknodes is used to force LVM to reconcile nodes
+			// before the re-check, but if the volume is still not there
+			// after that, the request fails without quarantining: this is
+			// the driver's own guess that the volume is unusable, not a user
+			// delete request, and the guess can be wrong. Destroying data on
+			// that guess would be worse than failing and letting the caller
+			// retry.
+			name:     "lv still without device node after activation fails without quarantining",
 			volumeId: "vg#lv",
 			request:  convert.MiBToBytes(1024),
 			expectLvm: func(m *lvmMgr.MockManager) {
 				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(testLv1GiB, nil)
 				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
 				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().MakeVolumeGroupDeviceNodes(gomock.Any(), lvmMgr.MakeVGDeviceNodesOptions{Name: "vg"}).Return(nil)
 				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
-				// Quarantine: tag then rename. No RemoveLogicalVolume.
-				m.EXPECT().
-					UpdateLogicalVolume(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
-						if len(opts.AddTags) != 1 || opts.AddTags[0] != lvm.WipePendingTag {
-							t.Errorf("added tags %v, want [%s]", opts.AddTags, lvm.WipePendingTag)
-						}
-						return nil
-					})
-				m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+				// No quarantine: no AddTags, no RenameLogicalVolume, no
+				// RemoveLogicalVolume. The volume is left exactly as it is.
 			},
 			expectedErr: lvm.ErrVolumeUnusable,
 		},
@@ -784,31 +783,18 @@ func TestEnsureVolume(t *testing.T) {
 		},
 		{
 			// Provisioning fails closed rather than recycling extents that
-			// could not be cleared.
-			name:     "lv that cannot be activated is quarantined",
+			// could not be cleared, but it does not quarantine on an
+			// activation failure either: that is still just the driver's
+			// inference, and the volume is left untouched for the caller to
+			// retry.
+			name:     "lv that cannot be activated fails without quarantining",
 			volumeId: "vg#lv",
 			request:  convert.MiBToBytes(1024),
 			expectLvm: func(m *lvmMgr.MockManager) {
 				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(testLv1GiB, nil)
 				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
-				// Activation fails.
-				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(errTestInternal)
-				// Quarantine: tag then rename. No RemoveLogicalVolume.
-				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
-			},
-			expectedErr: errTestInternal,
-		},
-		{
-			// If the volume cannot even be quarantined it is still not
-			// removed, and the caller is told provisioning failed.
-			name:     "lv that cannot be quarantined fails provisioning",
-			volumeId: "vg#lv",
-			request:  convert.MiBToBytes(1024),
-			expectLvm: func(m *lvmMgr.MockManager) {
-				m.EXPECT().GetLogicalVolume(gomock.Any(), "vg", "lv").Return(testLv1GiB, nil)
-				m.EXPECT().IsLogicalVolumeCorrupted(gomock.Any(), "vg", "lv").Return(true, nil)
-				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(errTestInternal)
+				// Activation fails. No re-check, no vgmknodes, no
+				// quarantine: the volume is left exactly as it is.
 				m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(errTestInternal)
 			},
 			expectedErr: errTestInternal,

--- a/internal/csi/core/lvm/quarantine.go
+++ b/internal/csi/core/lvm/quarantine.go
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"local-csi-driver/internal/pkg/lvm"
+)
+
+const (
+	// WipePendingTag marks a logical volume that has been taken out of service
+	// and is waiting to be sanitized.
+	//
+	// The tag is what makes quarantine recoverable: it is written to LVM
+	// metadata, so it survives a driver restart or a node reboot and lets the
+	// reaper find volumes abandoned by a previous process.
+	//
+	// It follows the short-tag convention set by DefaultVolumeGroupTag. LVM
+	// restricts tags to a limited character set that excludes "/", so the full
+	// driver name cannot be used directly.
+	WipePendingTag = "local-csi-wipe-pending"
+
+	// quarantineNamePrefix is applied to a logical volume when it is
+	// quarantined, to move it out of the namespace used for live volumes.
+	//
+	// It is driver-specific rather than generic, because the name is the sole
+	// marker of a volume that is committed to destruction. A generic prefix
+	// would let an unrelated logical volume that happened to be named that way
+	// be zeroed by the reaper.
+	quarantineNamePrefix = "local-csi-wipe-"
+)
+
+// Quarantine takes a logical volume out of service pending sanitization, and
+// returns the name it was renamed to.
+//
+// Deletion cannot zero a volume synchronously: DeleteVolume is called by the
+// csi-provisioner sidecar under a timeout measured in seconds, while zeroing a
+// volume is measured in minutes. Quarantine is what makes the split safe. The
+// extents stay allocated to the renamed volume, so LVM cannot hand them to
+// another tenant, and the reaper zeroes and removes the volume afterwards
+// without a deadline.
+//
+// The rename alone is the commit point for destruction. The reaper wipes a
+// volume if and only if its name is in the quarantine namespace, and the tag
+// is not part of that test. Keying destruction on the name is what makes the
+// two writes independently survivable: a committed volume may legitimately
+// lose its tag, but a volume that is tagged while still under its own name has
+// not been taken out of service, may still be referenced by a
+// PersistentVolume, and must never be zeroed.
+//
+// The tag is nevertheless written first. Its only remaining consumer is the
+// orphan scanner, which leaves a tagged volume alone so that a quarantine in
+// progress is not concurrently reclaimed by another path. Writing it first
+// means a crash between the two writes leaves a volume that is still in
+// service and still protected. If the rename fails the tag is rolled back and
+// the caller retries the whole operation.
+//
+// Renaming also frees the original name, so that a subsequent CreateVolume for
+// the same volume ID cannot collide with a volume that is still waiting to be
+// wiped.
+func (l *LVM) Quarantine(ctx context.Context, vgName, lvName string) (string, error) {
+	ctx, span := l.tracer.Start(ctx, "volume.lvm.csi/Quarantine", trace.WithAttributes(
+		attribute.String("vol.group", vgName),
+		attribute.String("vol.name", lvName),
+	))
+	defer span.End()
+
+	if vgName == "" || lvName == "" {
+		return "", fmt.Errorf("volume group and logical volume names cannot be empty")
+	}
+
+	fullName := vgName + "/" + lvName
+
+	// Tag first, so a crash before the rename still leaves the volume
+	// protected from the orphan scanner while it is in service.
+	err := l.lvm.UpdateLogicalVolume(ctx, lvm.UpdateLVOptions{
+		Name:    fullName,
+		AddTags: []string{WipePendingTag},
+	})
+	if err != nil {
+		span.RecordError(err)
+		return "", fmt.Errorf("failed to tag logical volume %s for wiping: %w", fullName, err)
+	}
+
+	quarantinedName := quarantineNamePrefix + uuid.NewString()
+	span.SetAttributes(attribute.String("vol.quarantined_name", quarantinedName))
+
+	err = l.lvm.RenameLogicalVolume(ctx, lvm.RenameLVOptions{
+		From: fullName,
+		To:   vgName + "/" + quarantinedName,
+	})
+	if err != nil {
+		span.RecordError(err)
+		// Roll the tag back. Destruction is committed by the rename, so this
+		// volume is still in service under its original name and must not be
+		// left carrying a tag that suggests otherwise.
+		if delErr := l.ClearQuarantineTag(ctx, vgName, lvName); delErr != nil {
+			// The volume is still safe: it was never renamed, so the reaper
+			// will not touch it. It is now hidden from the orphan scanner
+			// though, so surface this rather than leaving it only on the span.
+			log.FromContext(ctx).Error(delErr, "failed to roll back the wipe tag after a failed rename; "+
+				"the volume remains in service but is hidden from orphan cleanup until the tag is cleared",
+				"vg", vgName, "lv", lvName)
+			span.RecordError(delErr)
+		}
+		return "", fmt.Errorf("failed to rename logical volume %s for wiping: %w", fullName, err)
+	}
+
+	span.AddEvent("quarantined logical volume")
+	l.SignalWipe()
+	return quarantinedName, nil
+}
+
+// ClearQuarantineTag removes the wipe-pending tag from a logical volume that
+// is still under its original name.
+//
+// This reinstates a volume whose quarantine was started but never committed,
+// which happens if the driver dies between tagging and renaming, or if the
+// rename fails. Such a volume was never taken out of service and is still
+// owned by the workload that created it, so returning it to service exposes
+// nothing: it is the same volume, for the same volume ID, to the same tenant.
+//
+// It deliberately refuses to act on a volume that has already been renamed,
+// because that volume is committed to destruction and must not be reinstated.
+func (l *LVM) ClearQuarantineTag(ctx context.Context, vgName, lvName string) error {
+	ctx, span := l.tracer.Start(ctx, "volume.lvm.csi/ClearQuarantineTag", trace.WithAttributes(
+		attribute.String("vol.group", vgName),
+		attribute.String("vol.name", lvName),
+	))
+	defer span.End()
+
+	// The refusal set is exactly the committed set, so that a volume this
+	// driver never committed cannot be made permanently unreinstateable by
+	// merely resembling one.
+	if isQuarantineName(lvName) {
+		return fmt.Errorf("refusing to clear the wipe tag from quarantined logical volume %s/%s", vgName, lvName)
+	}
+
+	err := l.lvm.UpdateLogicalVolume(ctx, lvm.UpdateLVOptions{
+		Name:    vgName + "/" + lvName,
+		DelTags: []string{WipePendingTag},
+	})
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to clear the wipe tag from logical volume %s/%s: %w", vgName, lvName, err)
+	}
+	return nil
+}
+
+// SignalWipe asks the wipe reaper to sweep as soon as it can.
+//
+// It never blocks. Callers are on the deletion path, holding a CSI request
+// under a sidecar timeout, and must not be held up behind a wipe that is
+// already running. It is also safe to call when no reaper is running: the
+// signal is simply never observed, and the periodic sweep would pick the
+// volume up anyway.
+func (l *LVM) SignalWipe() {
+	select {
+	case l.wipeSignal <- struct{}{}:
+	default:
+	}
+}
+
+// ListQuarantined returns the logical volumes in a volume group that are
+// committed to destruction and waiting to be sanitized.
+//
+// Discovery deliberately does not use the tag as a server-side selector. The
+// tag can be absent from a committed volume: EnsureVolume clears the tag to
+// reinstate an uncommitted quarantine, and if that lands between Quarantine's
+// tag and rename the result is a renamed volume with no tag. Selecting on the
+// tag would leave such a volume invisible forever, holding extents that still
+// carry the tenant's data. The generated name is the durable marker, so the
+// group is listed in full and filtered on that.
+func (l *LVM) ListQuarantined(ctx context.Context, vgName string) ([]lvm.LogicalVolume, error) {
+	ctx, span := l.tracer.Start(ctx, "volume.lvm.csi/ListQuarantined", trace.WithAttributes(
+		attribute.String("vol.group", vgName),
+	))
+	defer span.End()
+
+	lvs, err := l.lvm.ListLogicalVolumes(ctx, &lvm.ListLVOptions{
+		Names: []string{vgName},
+	})
+	if err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("failed to list quarantined logical volumes in %s: %w", vgName, err)
+	}
+
+	quarantined := make([]lvm.LogicalVolume, 0, len(lvs))
+	for _, lv := range lvs {
+		if IsQuarantineCommitted(lv) {
+			quarantined = append(quarantined, lv)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("vol.quarantined_count", len(quarantined)))
+	return quarantined, nil
+}
+
+// IsQuarantineCommitted reports whether a logical volume has been committed to
+// destruction and may therefore be zeroed and removed.
+//
+// This is the only predicate a caller may use to decide to destroy a volume.
+// It tests the name, not the tag, because the rename is the commit point: a
+// volume that was tagged but never taken out of service is not a wipe target,
+// and a volume that was renamed but lost its tag still is. Relying on the tag
+// here would make the latter invisible to the reaper, stranding its extents
+// with the tenant's data still on them.
+//
+// The name is trustworthy because only Quarantine produces it, and the CSI
+// layer rejects volume handles that name themselves into this namespace.
+func IsQuarantineCommitted(lv lvm.LogicalVolume) bool {
+	return isQuarantineName(lv.Name)
+}
+
+// isQuarantineName reports whether a logical volume name was generated by
+// Quarantine.
+//
+// The full generated shape is required, prefix and UUID both, so that an
+// arbitrary name merely beginning with the prefix is not mistaken for a volume
+// the driver committed to destroying.
+func isQuarantineName(name string) bool {
+	suffix, ok := strings.CutPrefix(name, quarantineNamePrefix)
+	if !ok {
+		return false
+	}
+	_, err := uuid.Parse(suffix)
+	return err == nil
+}
+
+// IsQuarantined reports whether a logical volume has been tagged for
+// sanitization, whether or not that quarantine was committed.
+//
+// Callers that delete logical volumes must use this to skip tagged volumes.
+// The orphan scanner in particular would otherwise treat every quarantined
+// volume as an orphan, since by construction none of them has a corresponding
+// PersistentVolume, and race the reaper to remove them without zeroing. Use
+// IsQuarantineCommitted, not this, to decide whether a volume may be
+// destroyed.
+func IsQuarantined(lv lvm.LogicalVolume) bool {
+	for _, tag := range strings.Split(lv.Tags, ",") {
+		if strings.TrimSpace(tag) == WipePendingTag {
+			return true
+		}
+	}
+	return false
+}
+
+// VolumeGroupLister lists volume groups. It is the subset of lvm.Manager
+// needed to discover the groups this driver manages.
+type VolumeGroupLister interface {
+	ListVolumeGroups(ctx context.Context, opts *lvm.ListVGOptions) ([]lvm.VolumeGroup, error)
+}
+
+// ManagedVolumeGroups returns the volume groups this driver is responsible
+// for on the local node.
+//
+// Groups are found by tag. When none carry the tag the default group is
+// returned anyway, so that groups created before the tag convention are still
+// swept rather than silently ignored: a component that skipped them would
+// leave quarantined volumes in them stranded forever.
+func ManagedVolumeGroups(ctx context.Context, lister VolumeGroupLister) ([]string, error) {
+	vgs, err := lister.ListVolumeGroups(ctx, &lvm.ListVGOptions{
+		Select: fmt.Sprintf("vg_tags=%s", DefaultVolumeGroupTag),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list volume groups with tag %s: %w", DefaultVolumeGroupTag, err)
+	}
+
+	if len(vgs) == 0 {
+		return []string{DefaultVolumeGroup}, nil
+	}
+
+	names := make([]string, 0, len(vgs))
+	for _, vg := range vgs {
+		names = append(names, vg.Name)
+	}
+	return names, nil
+}

--- a/internal/csi/core/lvm/quarantine_test.go
+++ b/internal/csi/core/lvm/quarantine_test.go
@@ -1,0 +1,478 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/google/uuid"
+	"go.uber.org/mock/gomock"
+
+	"local-csi-driver/internal/csi/core/lvm"
+	lvmMgr "local-csi-driver/internal/pkg/lvm"
+	"local-csi-driver/internal/pkg/probe"
+	"local-csi-driver/internal/pkg/telemetry"
+)
+
+const testLogicalVolume = "test-lv"
+
+// newQuarantineTestLVM builds an LVM core backed by a mock manager.
+func newQuarantineTestLVM(t *testing.T, expect func(*lvmMgr.MockManager)) *lvm.LVM {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockLVM := lvmMgr.NewMockManager(ctrl)
+	if expect != nil {
+		expect(mockLVM)
+	}
+
+	l, err := lvm.New(
+		"test-pod", "test-node", "test-namespace", false,
+		probe.NewFake([]string{"device1"}, nil), mockLVM,
+		telemetry.NewNoopTracerProvider(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return l
+}
+
+// TestQuarantineTagsBeforeRenaming pins the ordering that makes quarantine
+// recoverable.
+//
+// The reaper finds volumes by tag. If a volume were renamed before it was
+// tagged and the process died in between, the volume would be invisible to the
+// reaper and would hold its extents indefinitely. Tagging first means a crash
+// at any point leaves a volume that is still found and still wiped.
+func TestQuarantineTagsBeforeRenaming(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+				calls = append(calls, "tag")
+				if got, want := opts.Name, testVolumeGroup+"/"+testLogicalVolume; got != want {
+					t.Errorf("tagged %q, want %q", got, want)
+				}
+				if len(opts.AddTags) != 1 || opts.AddTags[0] != lvm.WipePendingTag {
+					t.Errorf("added tags %v, want [%s]", opts.AddTags, lvm.WipePendingTag)
+				}
+				return nil
+			})
+
+		m.EXPECT().
+			RenameLogicalVolume(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts lvmMgr.RenameLVOptions) error {
+				calls = append(calls, "rename")
+				if got, want := opts.From, testVolumeGroup+"/"+testLogicalVolume; got != want {
+					t.Errorf("renamed from %q, want %q", got, want)
+				}
+				if !strings.HasPrefix(opts.To, testVolumeGroup+"/local-csi-wipe-") {
+					t.Errorf("renamed to %q, want the local-csi-wipe- prefix in %s", opts.To, testVolumeGroup)
+				}
+				return nil
+			})
+	})
+
+	name, err := l.Quarantine(context.Background(), testVolumeGroup, testLogicalVolume)
+	if err != nil {
+		t.Fatalf("Quarantine returned error: %v", err)
+	}
+
+	if !strings.HasPrefix(name, "local-csi-wipe-") {
+		t.Errorf("quarantined name %q does not carry the local-csi-wipe- prefix", name)
+	}
+	if want := []string{"tag", "rename"}; !equalStrings(calls, want) {
+		t.Errorf("call order was %v, want %v", calls, want)
+	}
+}
+
+// TestQuarantineNamesAreUnique verifies that two quarantined volumes cannot
+// collide.
+//
+// Names are generated rather than derived from the volume, because the same
+// volume ID can be created and deleted repeatedly and an earlier quarantined
+// volume may still be waiting to be wiped.
+func TestQuarantineNamesAreUnique(t *testing.T) {
+	t.Parallel()
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	})
+
+	first, err := l.Quarantine(context.Background(), testVolumeGroup, testLogicalVolume)
+	if err != nil {
+		t.Fatalf("first Quarantine returned error: %v", err)
+	}
+	second, err := l.Quarantine(context.Background(), testVolumeGroup, testLogicalVolume)
+	if err != nil {
+		t.Fatalf("second Quarantine returned error: %v", err)
+	}
+
+	if first == second {
+		t.Errorf("expected distinct quarantine names, got %q twice", first)
+	}
+}
+
+// TestQuarantineDoesNotRenameWhenTaggingFails verifies that a failed tag stops
+// the operation.
+//
+// Renaming an untagged volume would hide it from both the driver and the
+// reaper, so the volume must be left exactly as it was for the caller to
+// retry.
+func TestQuarantineDoesNotRenameWhenTaggingFails(t *testing.T) {
+	t.Parallel()
+
+	tagErr := errors.New("tag failed")
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(tagErr)
+		// No RenameLogicalVolume expectation: the controller fails the test if
+		// it is called.
+	})
+
+	if _, err := l.Quarantine(context.Background(), testVolumeGroup, testLogicalVolume); err == nil {
+		t.Fatal("expected an error when tagging fails, got nil")
+	}
+}
+
+// TestQuarantineRollsBackTagOnRenameFailure pins the commit-point contract.
+//
+// Destruction is committed by the rename, not by the tag. If the rename fails
+// the volume is still in service under its original name, so the tag must be
+// rolled back: leaving it in place would mark a live volume as pending
+// destruction and hide it from the orphan scanner.
+func TestQuarantineRollsBackTagOnRenameFailure(t *testing.T) {
+	t.Parallel()
+
+	var deltagged bool
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+				if len(opts.AddTags) == 1 && opts.AddTags[0] == lvm.WipePendingTag {
+					return nil
+				}
+				if len(opts.DelTags) == 1 && opts.DelTags[0] == lvm.WipePendingTag {
+					deltagged = true
+					return nil
+				}
+				t.Errorf("unexpected tag update: %+v", opts)
+				return nil
+			}).
+			Times(2)
+		m.EXPECT().RenameLogicalVolume(gomock.Any(), gomock.Any()).Return(errors.New("rename failed"))
+	})
+
+	name, err := l.Quarantine(context.Background(), testVolumeGroup, testLogicalVolume)
+	if err == nil {
+		t.Fatal("expected an error when renaming fails, got nil")
+	}
+	if name != "" {
+		t.Errorf("expected no quarantine name on failure, got %q", name)
+	}
+	if !deltagged {
+		t.Error("expected the wipe tag to be rolled back after a failed rename")
+	}
+}
+
+// TestReaperIgnoresUncommittedQuarantine is the counterpart safety property: a
+// volume that carries the tag but was never renamed out of the live namespace
+// must never be treated as a wipe target, because it may still be in service
+// and referenced by a PersistentVolume.
+func TestReaperIgnoresUncommittedQuarantine(t *testing.T) {
+	t.Parallel()
+
+	tagged := lvmMgr.LogicalVolume{
+		Name:   testLogicalVolume,
+		VGName: testVolumeGroup,
+		Tags:   lvm.WipePendingTag,
+	}
+
+	if lvm.IsQuarantineCommitted(tagged) {
+		t.Fatal("a tagged but unrenamed volume must not be considered committed")
+	}
+	if !lvm.IsQuarantined(tagged) {
+		t.Fatal("a tagged volume must still be skipped by callers that delete volumes")
+	}
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, tagged)
+
+		// The absence of Sanitize/Remove expectations is the assertion.
+	})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}
+
+// TestReaperDefersToOpenVolume covers raw block volumes.
+//
+// The exclusive open in the sanitizer conflicts with a mount, but a raw block
+// volume is published as a device node and a pod holding it open takes no
+// exclusive claim. LVM's own open count is what catches that, and a volume
+// reporting itself open must never be zeroed.
+func TestReaperDefersToOpenVolume(t *testing.T) {
+	t.Parallel()
+
+	open := quarantinedLV(testWipeName)
+	open.DeviceOpen = lvmMgr.BoolString(true)
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, open)
+
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+
+		// No Sanitize or Remove: gomock fails the test if either is called.
+	})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}
+
+// TestQuarantineValidation covers input validation.
+func TestQuarantineValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		vgName string
+		lvName string
+	}{
+		{name: "empty volume group", vgName: "", lvName: testLogicalVolume},
+		{name: "empty logical volume", vgName: testVolumeGroup, lvName: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// No manager expectations: validation must happen before any LVM
+			// call, so that invalid input cannot mutate anything.
+			l := newQuarantineTestLVM(t, nil)
+
+			if _, err := l.Quarantine(context.Background(), tt.vgName, tt.lvName); err == nil {
+				t.Fatal("expected a validation error, got nil")
+			}
+		})
+	}
+}
+
+// TestIsQuarantined covers tag matching against the comma-separated list LVM
+// reports, including names that merely contain the tag.
+func TestIsQuarantined(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tags string
+		want bool
+	}{
+		{name: "no tags", tags: "", want: false},
+		{name: "only the wipe tag", tags: lvm.WipePendingTag, want: true},
+		{name: "wipe tag first", tags: lvm.WipePendingTag + ",local-csi", want: true},
+		{name: "wipe tag last", tags: "local-csi," + lvm.WipePendingTag, want: true},
+		{name: "wipe tag in the middle", tags: "a," + lvm.WipePendingTag + ",b", want: true},
+		{name: "unrelated tags", tags: "local-csi,other", want: false},
+		{name: "tag with a common prefix", tags: "local-csi-wipe-pending-2", want: false},
+		{name: "tag with a common suffix", tags: "x-local-csi-wipe-pending", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := lvm.IsQuarantined(lvmMgr.LogicalVolume{Tags: tt.tags})
+			if got != tt.want {
+				t.Errorf("IsQuarantined(%q) = %v, want %v", tt.tags, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestListQuarantinedSelectsCommittedVolumes verifies which volumes the reaper
+// is offered.
+//
+// Discovery must not depend on the tag. A committed volume can legitimately
+// have lost its tag, if EnsureVolume's reinstatement landed between the tag
+// and the rename, and selecting on the tag would hide it from the reaper
+// forever while it still held the tenant's data. Equally, a tagged volume that
+// was never renamed is still in service and must not be offered. A name that
+// merely starts with the prefix is not a commit marker either.
+func TestListQuarantinedSelectsCommittedVolumes(t *testing.T) {
+	t.Parallel()
+
+	committed := "local-csi-wipe-" + uuid.NewString()
+	untaggedCommitted := "local-csi-wipe-" + uuid.NewString()
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			ListLogicalVolumes(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts *lvmMgr.ListLVOptions) ([]lvmMgr.LogicalVolume, error) {
+				if opts.Select != "" {
+					t.Errorf("selector was %q, want no tag selector", opts.Select)
+				}
+				return []lvmMgr.LogicalVolume{
+					{Name: committed, Tags: lvm.WipePendingTag},
+					// Committed but untagged: still a wipe target.
+					{Name: untaggedCommitted},
+					// Tagged but never renamed: still in service.
+					{Name: "live-volume", Tags: lvm.WipePendingTag},
+					// Prefix without a generated UUID: not a commit marker.
+					{Name: "local-csi-wipe-anything", Tags: lvm.WipePendingTag},
+					{Name: "other-volume", Tags: "local-csi"},
+				}, nil
+			})
+	})
+
+	got, err := l.ListQuarantined(context.Background(), testVolumeGroup)
+	if err != nil {
+		t.Fatalf("ListQuarantined returned error: %v", err)
+	}
+
+	names := make(map[string]bool, len(got))
+	for _, lv := range got {
+		names[lv.Name] = true
+	}
+
+	if len(got) != 2 || !names[committed] || !names[untaggedCommitted] {
+		t.Fatalf("returned %+v, want exactly the two committed volumes", got)
+	}
+}
+
+// TestListQuarantinedPropagatesError verifies that a listing failure is not
+// reported as an empty list.
+//
+// Returning no volumes on error would make the reaper believe there is nothing
+// to wipe.
+func TestListQuarantinedPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	l := newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			ListLogicalVolumes(gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("list failed"))
+	})
+
+	if _, err := l.ListQuarantined(context.Background(), testVolumeGroup); err == nil {
+		t.Fatal("expected the listing error to be propagated, got nil")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestReaperFailsClosedOnUnknownOpenState covers the decode of LVM's open
+// state.
+//
+// lv_device_open decodes to false both when the device is closed and when the
+// field is missing or unparsable, so on its own a renamed or dropped field
+// would silently degrade into "safe to wipe". An lv_attr too short to carry
+// the open indicator must therefore be treated as open.
+func TestReaperFailsClosedOnUnknownOpenState(t *testing.T) {
+	t.Parallel()
+
+	unknown := quarantinedLV(testWipeName)
+	unknown.Attributes = ""
+	unknown.DeviceOpen = lvmMgr.BoolString(false)
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, unknown)
+
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+
+		// No Sanitize or Remove: gomock fails the test if either is called.
+	})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}
+
+// TestQuarantineNamespaceIsReserved verifies that a volume handle cannot name
+// itself into the quarantine namespace.
+//
+// The generated name is the commit marker the reaper acts on, and the logical
+// volume name comes from the CSI volume handle, which is operator-supplied for
+// a pre-provisioned PersistentVolume. A handle inside that namespace would be
+// treated as awaiting destruction and zeroed.
+func TestQuarantineNamespaceIsReserved(t *testing.T) {
+	t.Parallel()
+
+	l := newQuarantineTestLVM(t, nil)
+
+	reserved := testVolumeGroup + "#local-csi-wipe-" + uuid.NewString()
+
+	// Delete reports success for an unparsable ID, so the assertion is that
+	// nothing is quarantined: the mock has no expectations, so any LVM call
+	// fails the test.
+	if err := l.Delete(context.Background(), &csi.DeleteVolumeRequest{VolumeId: reserved}); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if _, err := l.EnsureVolume(context.Background(), reserved, 1<<30, 0, true); err == nil {
+		t.Error("expected EnsureVolume to reject a volume id in the quarantine namespace")
+	}
+}
+
+// TestClearQuarantineTagRefusalMatchesCommitSet verifies that the reinstate
+// path refuses exactly the volumes the reaper acts on, and no more.
+//
+// If the refusal set were wider than the commit set, a volume that merely
+// resembled a quarantined one could never be reinstated by EnsureVolume nor
+// reclaimed by the reaper, leaving it permanently stuck.
+func TestClearQuarantineTagRefusalMatchesCommitSet(t *testing.T) {
+	t.Parallel()
+
+	committed := "local-csi-wipe-" + uuid.NewString()
+
+	l := newQuarantineTestLVM(t, nil)
+	if err := l.ClearQuarantineTag(context.Background(), testVolumeGroup, committed); err == nil {
+		t.Error("expected ClearQuarantineTag to refuse a committed volume")
+	}
+
+	// Same prefix, but no generated UUID, so it was never committed and is a
+	// legal volume name that must remain reinstateable.
+	lookalike := "local-csi-wipe-notauuid"
+
+	l = newQuarantineTestLVM(t, func(m *lvmMgr.MockManager) {
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+				if got, want := opts.Name, testVolumeGroup+"/"+lookalike; got != want {
+					t.Errorf("cleared tag on %q, want %q", got, want)
+				}
+				return nil
+			})
+	})
+	if err := l.ClearQuarantineTag(context.Background(), testVolumeGroup, lookalike); err != nil {
+		t.Errorf("ClearQuarantineTag() error = %v", err)
+	}
+}

--- a/internal/csi/core/lvm/reaper.go
+++ b/internal/csi/core/lvm/reaper.go
@@ -1,0 +1,432 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kevents "k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"local-csi-driver/internal/pkg/lvm"
+)
+
+const (
+	// DefaultReaperInterval is how often the reaper sweeps for quarantined
+	// volumes when it has not been signalled.
+	//
+	// Deletions signal the reaper directly, so the timer only has to cover
+	// dropped signals and volumes inherited from a previous process. Sweeps
+	// are local lvs calls with no API server traffic, so the interval can be
+	// short without needing jitter.
+	DefaultReaperInterval = 60 * time.Second
+
+	// DefaultReaperConcurrency is how many volumes are wiped at once.
+	//
+	// Zeroing is bound by device write bandwidth, so wiping volumes
+	// concurrently does not increase aggregate throughput; it only multiplies
+	// interference with foreground I/O on a node that is still serving
+	// workloads.
+	DefaultReaperConcurrency = 1
+
+	// reaperBackoffBase and reaperBackoffMax bound the retry delay for a
+	// volume that fails to wipe, so that a persistently failing device does
+	// not spin.
+	reaperBackoffBase = 30 * time.Second
+	reaperBackoffMax  = 30 * time.Minute
+
+	// Event reasons for the wipe reaper.
+	wipedLogicalVolume    = "WipedLogicalVolume"
+	wipeLogicalVolumeFail = "WipeLogicalVolumeFailed"
+)
+
+// ReaperConfig configures the wipe reaper.
+type ReaperConfig struct {
+	// Interval is the backstop sweep interval.
+	Interval time.Duration
+	// Concurrency is the number of volumes wiped at once.
+	Concurrency int
+}
+
+// Reaper zeroes and removes quarantined logical volumes.
+//
+// Quarantine and wiping are split because DeleteVolume runs under the
+// csi-provisioner sidecar's timeout, which is measured in seconds, while
+// zeroing a volume is measured in minutes. Quarantine keeps the extents
+// allocated so they cannot be handed to another tenant; the reaper does the
+// slow part afterwards, with no deadline.
+//
+// The reaper is node-local: it acts on the LVM state of the node it runs on
+// and never talks to the API server, so it must not take part in leader
+// election.
+type Reaper struct {
+	core        *LVM
+	recorder    kevents.EventRecorder
+	interval    time.Duration
+	concurrency int
+
+	// mu guards backoff.
+	mu sync.Mutex
+	// backoff records when a volume that failed to wipe may next be retried,
+	// keyed by "vg/lv".
+	backoff map[string]*backoffEntry
+}
+
+// backoffEntry tracks retry state for a single failing volume.
+type backoffEntry struct {
+	failures int
+	next     time.Time
+}
+
+// NewReaper creates a wipe reaper for the given LVM core.
+func NewReaper(core *LVM, recorder kevents.EventRecorder, config ReaperConfig) (*Reaper, error) {
+	if core == nil {
+		return nil, fmt.Errorf("lvm core must not be nil")
+	}
+	if recorder == nil {
+		return nil, fmt.Errorf("recorder must not be nil")
+	}
+	if config.Interval <= 0 {
+		config.Interval = DefaultReaperInterval
+	}
+	if config.Concurrency <= 0 {
+		config.Concurrency = DefaultReaperConcurrency
+	}
+	return &Reaper{
+		core:        core,
+		recorder:    recorder,
+		interval:    config.Interval,
+		concurrency: config.Concurrency,
+		backoff:     make(map[string]*backoffEntry),
+	}, nil
+}
+
+// Signal asks the reaper to sweep as soon as it can.
+//
+// The signal is owned by the LVM core rather than the reaper, so that the
+// deletion path can signal unconditionally without knowing whether a reaper
+// exists.
+func (r *Reaper) Signal() {
+	r.core.SignalWipe()
+}
+
+// Start runs the reaper until the context is cancelled, implementing
+// manager.Runnable.
+func (r *Reaper) Start(ctx context.Context) error {
+	log := log.FromContext(ctx).WithName("lvm-wipe-reaper")
+	log.V(2).Info("starting wipe reaper", "interval", r.interval, "concurrency", r.concurrency)
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	// Sweep unconditionally at startup. This is what makes quarantine
+	// crash-safe: volumes tagged by a previous process, which will never be
+	// signalled, are picked up here.
+	if err := r.Reconcile(ctx); err != nil {
+		log.Error(err, "initial wipe sweep failed")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.V(2).Info("stopping wipe reaper")
+			return nil
+		case <-ticker.C:
+		case <-r.core.wipeSignal:
+		}
+
+		if err := r.Reconcile(ctx); err != nil {
+			log.Error(err, "wipe sweep failed")
+		}
+	}
+}
+
+// NeedLeaderElection returns false because the reaper acts only on node-local
+// LVM state.
+func (r *Reaper) NeedLeaderElection() bool {
+	return false
+}
+
+// SetupWithManager registers the reaper with the controller manager.
+func (r *Reaper) SetupWithManager(mgr ctrl.Manager) error {
+	return mgr.Add(r)
+}
+
+// Reconcile wipes every quarantined volume that is due an attempt.
+//
+// It returns an error only when the sweep itself could not be performed.
+// Failures to wipe an individual volume are recorded and retried with backoff,
+// and do not fail the sweep, because one bad volume must not stop the others
+// from being cleared.
+func (r *Reaper) Reconcile(ctx context.Context) error {
+	ctx, span := r.core.tracer.Start(ctx, "volume.lvm.csi/Reaper.Reconcile")
+	defer span.End()
+
+	log := log.FromContext(ctx).WithName("lvm-wipe-reaper")
+
+	vgNames, err := r.volumeGroups(ctx)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	var pending []lvm.LogicalVolume
+	swept := make([]string, 0, len(vgNames))
+	for _, vgName := range vgNames {
+		lvs, err := r.core.ListQuarantined(ctx, vgName)
+		if err != nil {
+			// Keep going: a group that cannot be read now is picked up by the
+			// next sweep, and the others still get cleared.
+			log.Error(err, "failed to list quarantined volumes", "vg", vgName)
+			continue
+		}
+		swept = append(swept, vgName)
+		pending = append(pending, lvs...)
+	}
+
+	r.pruneBackoff(pending, swept)
+
+	due := make([]lvm.LogicalVolume, 0, len(pending))
+	for _, lv := range pending {
+		if r.isDue(lv) {
+			due = append(due, lv)
+		}
+	}
+
+	span.SetAttributes(
+		attribute.Int("vol.quarantined_count", len(pending)),
+		attribute.Int("vol.due_count", len(due)),
+	)
+
+	if len(due) == 0 {
+		return nil
+	}
+
+	log.V(2).Info("wiping quarantined volumes", "due", len(due), "quarantined", len(pending))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(r.concurrency)
+	for _, lv := range due {
+		g.Go(func() error {
+			if err := r.wipe(gctx, lv); err != nil {
+				r.recordFailure(lv, err)
+				log.Error(err, "failed to wipe quarantined volume", "vg", lv.VGName, "lv", lv.Name)
+				return nil
+			}
+			r.recordSuccess(lv)
+			log.Info("wiped and removed quarantined volume", "vg", lv.VGName, "lv", lv.Name)
+			return nil
+		})
+	}
+
+	// The goroutines above never return an error, so this only surfaces
+	// context cancellation.
+	return g.Wait()
+}
+
+// wipe clears a single quarantined volume and removes it.
+//
+// The order is activate, sanitize, remove. Activation comes first because a
+// volume can be quarantined while deactivated, and a volume with no device
+// node under /dev/<vg>/<lv> cannot be written to. Removal comes last because
+// once lvremove has run the extents may be reallocated at any time and can no
+// longer be reached, so a volume is only ever removed after it has been
+// zeroed in full.
+func (r *Reaper) wipe(ctx context.Context, lv lvm.LogicalVolume) error {
+	ctx, span := r.core.tracer.Start(ctx, "volume.lvm.csi/Reaper.wipe", trace.WithAttributes(
+		attribute.String("vol.group", lv.VGName),
+		attribute.String("vol.name", lv.Name),
+	))
+	defer span.End()
+
+	fullName := lv.VGName + "/" + lv.Name
+
+	if err := r.core.lvm.UpdateLogicalVolume(ctx, lvm.UpdateLVOptions{
+		Name:     fullName,
+		Activate: lvm.Yes,
+	}); err != nil {
+		if lvm.IgnoreNotFound(err) == nil {
+			// The volume was removed by something else between the listing and
+			// now. There is nothing left to wipe.
+			return nil
+		}
+		span.RecordError(err)
+		return fmt.Errorf("failed to activate logical volume %s for wiping: %w", fullName, err)
+	}
+
+	// Refuse to write to a volume anything still has open.
+	//
+	// The exclusive open in SanitizeLogicalVolume is not sufficient on its
+	// own. It conflicts with a mount, which covers filesystem volumes, but a
+	// raw block volume is bind-mounted as a device node and a pod holding it
+	// open takes no exclusive claim, so the open would succeed and the wipe
+	// would corrupt a running workload. LVM's own open count sees that case.
+	//
+	// The volume is re-read here rather than trusting the listing, both
+	// because the listing is stale by now and because lv_device_open is only
+	// meaningful once the volume is active.
+	current, err := r.core.lvm.GetLogicalVolume(ctx, lv.VGName, lv.Name)
+	if err != nil {
+		if lvm.IgnoreNotFound(err) == nil {
+			return nil
+		}
+		span.RecordError(err)
+		return fmt.Errorf("failed to re-read logical volume %s before wiping: %w", fullName, err)
+	}
+	if current == nil {
+		return nil
+	}
+	if !IsQuarantineCommitted(*current) {
+		// The volume was reinstated, or is not the volume that was listed.
+		span.AddEvent("volume is no longer committed to destruction, skipping")
+		return nil
+	}
+	if isDeviceOpen(*current) {
+		span.AddEvent("volume is still open, deferring wipe")
+		return fmt.Errorf("logical volume %s is still open and cannot be wiped yet", fullName)
+	}
+
+	if err := r.core.lvm.SanitizeLogicalVolume(ctx, lv.VGName, lv.Name); err != nil {
+		span.RecordError(err)
+		// Fail closed: the volume keeps its tag and its extents, and is
+		// retried. It is never removed on a failed or partial wipe.
+		return fmt.Errorf("failed to sanitize logical volume %s: %w", fullName, err)
+	}
+
+	if err := r.core.lvm.RemoveLogicalVolume(ctx, lvm.RemoveLVOptions{Name: fullName}); err != nil {
+		if lvm.IgnoreNotFound(err) == nil {
+			// Already gone, and it was sanitized before it went.
+			return nil
+		}
+		span.RecordError(err)
+		return fmt.Errorf("failed to remove sanitized logical volume %s: %w", fullName, err)
+	}
+
+	r.event(corev1.EventTypeNormal, wipedLogicalVolume,
+		"Sanitized and removed logical volume %s on node %s", fullName, r.core.nodeName)
+
+	return nil
+}
+
+// volumeGroups returns the volume groups to sweep.
+func (r *Reaper) volumeGroups(ctx context.Context) ([]string, error) {
+	return ManagedVolumeGroups(ctx, r.core.lvm)
+}
+
+// isDue reports whether a volume may be attempted now.
+func (r *Reaper) isDue(lv lvm.LogicalVolume) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.backoff[lv.VGName+"/"+lv.Name]
+	return !ok || !time.Now().Before(entry.next)
+}
+
+// recordFailure schedules the next attempt for a volume that failed to wipe.
+func (r *Reaper) recordFailure(lv lvm.LogicalVolume, err error) {
+	key := lv.VGName + "/" + lv.Name
+
+	r.mu.Lock()
+	entry, ok := r.backoff[key]
+	if !ok {
+		entry = &backoffEntry{}
+		r.backoff[key] = entry
+	}
+	entry.failures++
+	delay := reaperBackoffBase << min(entry.failures-1, 16)
+	if delay > reaperBackoffMax || delay <= 0 {
+		delay = reaperBackoffMax
+	}
+	entry.next = time.Now().Add(delay)
+	failures := entry.failures
+	r.mu.Unlock()
+
+	r.event(corev1.EventTypeWarning, wipeLogicalVolumeFail,
+		"Failed to sanitize logical volume %s on node %s (attempt %d, retrying in %s); "+
+			"the volume is retained and its capacity is not reclaimed until it is wiped: %v",
+		key, r.core.nodeName, failures, delay, err)
+}
+
+// recordSuccess clears retry state for a volume that has been wiped.
+func (r *Reaper) recordSuccess(lv lvm.LogicalVolume) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.backoff, lv.VGName+"/"+lv.Name)
+}
+
+// pruneBackoff drops retry state for volumes that are no longer quarantined,
+// so that the map cannot grow without bound over the lifetime of the process.
+//
+// Only volume groups that were listed successfully are pruned. Pruning a group
+// whose listing failed would clear the retry state of every volume in it, so
+// an intermittently unreadable device would reset its own backoff on every
+// sweep and be retried at the base interval forever, which is the spin the
+// backoff exists to prevent.
+func (r *Reaper) pruneBackoff(pending []lvm.LogicalVolume, sweptGroups []string) {
+	live := make(map[string]struct{}, len(pending))
+	for _, lv := range pending {
+		live[lv.VGName+"/"+lv.Name] = struct{}{}
+	}
+	swept := make(map[string]struct{}, len(sweptGroups))
+	for _, vg := range sweptGroups {
+		swept[vg] = struct{}{}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key := range r.backoff {
+		vg, _, ok := strings.Cut(key, "/")
+		if !ok {
+			continue
+		}
+		if _, sweptOK := swept[vg]; !sweptOK {
+			continue
+		}
+		if _, liveOK := live[key]; !liveOK {
+			delete(r.backoff, key)
+		}
+	}
+}
+
+// event records an event against the node the reaper is running on. There is
+// no PersistentVolume to attach to: by the time a volume is quarantined its PV
+// is already gone.
+func (r *Reaper) event(eventType, reason, messageFmt string, args ...any) {
+	r.recorder.Eventf(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: r.core.nodeName}}, nil,
+		eventType, reason, reason, messageFmt, args...,
+	)
+}
+
+// lvAttrOpenIndex is the position of the open indicator in lv_attr.
+const lvAttrOpenIndex = 5
+
+// isDeviceOpen reports whether anything currently has the volume's device
+// open, erring towards "open" when LVM's answer cannot be trusted.
+//
+// Two fields are consulted because each fails differently. lv_device_open
+// decodes to false both when the device is closed and when the field is
+// missing or unparsable, so on its own a renamed or dropped field would
+// silently degrade into "safe to wipe". lv_attr carries the same information
+// positionally, and an attribute string too short to contain it is treated as
+// unknown, and therefore as open.
+func isDeviceOpen(lv lvm.LogicalVolume) bool {
+	if bool(lv.DeviceOpen) {
+		return true
+	}
+	if len(lv.Attributes) <= lvAttrOpenIndex {
+		return true
+	}
+	return lv.Attributes[lvAttrOpenIndex] != '-'
+}

--- a/internal/csi/core/lvm/reaper_test.go
+++ b/internal/csi/core/lvm/reaper_test.go
@@ -1,0 +1,349 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/mock/gomock"
+	kevents "k8s.io/client-go/tools/events"
+
+	"local-csi-driver/internal/csi/core/lvm"
+	lvmMgr "local-csi-driver/internal/pkg/lvm"
+)
+
+// newTestReaper builds a reaper over an LVM core backed by a mock manager.
+func newTestReaper(t *testing.T, expect func(*lvmMgr.MockManager)) *lvm.Reaper {
+	t.Helper()
+
+	l := newQuarantineTestLVM(t, expect)
+
+	r, err := lvm.NewReaper(l, kevents.NewFakeRecorder(16), lvm.ReaperConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return r
+}
+
+// expectVolumeGroup makes the mock report a single tagged volume group.
+func expectVolumeGroup(m *lvmMgr.MockManager) {
+	m.EXPECT().
+		ListVolumeGroups(gomock.Any(), gomock.Any()).
+		Return([]lvmMgr.VolumeGroup{{Name: testVolumeGroup}}, nil).
+		AnyTimes()
+}
+
+// Quarantined volume names must have the shape Quarantine generates, prefix
+// and UUID both, because that generated name is the commit marker the reaper
+// keys off. A name that merely starts with the prefix is deliberately not
+// recognised.
+var (
+	testWipeName          = "local-csi-wipe-" + uuid.NewString()
+	testWipeNameInherited = "local-csi-wipe-" + uuid.NewString()
+)
+
+// quarantinedLV is a logical volume as the reaper sees it after quarantine.
+func quarantinedLV(name string) lvmMgr.LogicalVolume {
+	return lvmMgr.LogicalVolume{
+		Name:   name,
+		VGName: testVolumeGroup,
+		Tags:   lvm.WipePendingTag,
+		// lv_attr for an active linear volume that nothing has open. The
+		// reaper treats an absent or too-short attribute string as "open", so
+		// a realistic value is required for the volume to be wipeable.
+		Attributes: "-wi-a-----",
+	}
+}
+
+// expectQuarantined makes the mock report the given quarantined volumes, both
+// from the sweep listing and from the re-read the reaper performs immediately
+// before wiping each one.
+func expectQuarantined(m *lvmMgr.MockManager, lvs ...lvmMgr.LogicalVolume) {
+	m.EXPECT().
+		ListLogicalVolumes(gomock.Any(), gomock.Any()).
+		Return(lvs, nil).
+		AnyTimes()
+
+	for _, lv := range lvs {
+		m.EXPECT().
+			GetLogicalVolume(gomock.Any(), lv.VGName, lv.Name).
+			Return(&lv, nil).
+			AnyTimes()
+	}
+}
+
+// TestReaperWipesBeforeRemoving pins the ordering that makes the reaper safe.
+//
+// Removal must come last. Once lvremove has run, the extents are back in the
+// volume group's free pool and can be handed to another tenant at any time, so
+// there is no longer anywhere to write the zeroes. Activation must come first,
+// because a volume can be quarantined while deactivated and a volume with no
+// device node cannot be written to at all.
+func TestReaperWipesBeforeRemoving(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, quarantinedLV(testWipeName))
+
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts lvmMgr.UpdateLVOptions) error {
+				calls = append(calls, "activate")
+				if got, want := opts.Name, testVolumeGroup+"/"+testWipeName; got != want {
+					t.Errorf("activated %q, want %q", got, want)
+				}
+				if opts.Activate == nil || !bool(*opts.Activate) {
+					t.Error("expected the volume to be activated")
+				}
+				return nil
+			})
+
+		m.EXPECT().
+			SanitizeLogicalVolume(gomock.Any(), testVolumeGroup, testWipeName).
+			DoAndReturn(func(context.Context, string, string) error {
+				calls = append(calls, "sanitize")
+				return nil
+			})
+
+		m.EXPECT().
+			RemoveLogicalVolume(gomock.Any(), lvmMgr.RemoveLVOptions{Name: testVolumeGroup + "/" + testWipeName}).
+			DoAndReturn(func(context.Context, lvmMgr.RemoveLVOptions) error {
+				calls = append(calls, "remove")
+				return nil
+			})
+	})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	if got, want := strings.Join(calls, ","), "activate,sanitize,remove"; got != want {
+		t.Errorf("call order = %q, want %q", got, want)
+	}
+}
+
+// TestReaperRetainsVolumeOnSanitizeFailure covers the fail-closed contract.
+//
+// A volume that could not be zeroed keeps its extents and its tag. Removing it
+// would return unsanitized extents to the free pool, which is the disclosure
+// this whole mechanism exists to prevent. Losing the capacity is the intended
+// trade: capacity is recoverable by an operator, disclosed data is not.
+func TestReaperRetainsVolumeOnSanitizeFailure(t *testing.T) {
+	t.Parallel()
+
+	errSanitize := errors.New("device write error")
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, quarantinedLV(testWipeName))
+
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+		m.EXPECT().
+			SanitizeLogicalVolume(gomock.Any(), testVolumeGroup, testWipeName).
+			Return(errSanitize)
+
+		// The absence of a RemoveLogicalVolume expectation is the assertion:
+		// gomock fails the test if it is called.
+	})
+
+	// The sweep itself succeeds. One volume that cannot be wiped must not stop
+	// the reaper from clearing the others.
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}
+
+// TestReaperDoesNotSanitizeUnactivatedVolume checks that a volume which cannot
+// be activated is left alone rather than being removed.
+//
+// Sanitizing writes through /dev/<vg>/<lv>. If activation fails that path does
+// not exist, so there is no way to clear the extents and the only safe outcome
+// is to keep holding them.
+func TestReaperDoesNotSanitizeUnactivatedVolume(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, quarantinedLV(testWipeName))
+
+		m.EXPECT().
+			UpdateLogicalVolume(gomock.Any(), gomock.Any()).
+			Return(errors.New("volume group not found"))
+
+		// Neither sanitize nor remove may be called.
+	})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}
+
+// TestReaperSkipsUnquarantinedVolumes checks that the reaper only ever acts on
+// tagged volumes.
+//
+// The tag selector is applied by LVM, but the reaper must not depend on that:
+// if the selector ever stopped being applied, acting on the unfiltered list
+// would destroy live tenant data.
+func TestReaperSkipsUnquarantinedVolumes(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, lvmMgr.LogicalVolume{
+			Name:   "live-volume",
+			VGName: testVolumeGroup,
+		})
+
+		// No activate, sanitize, or remove may be called.
+	})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}
+
+// TestReaperBacksOffAfterFailure checks that a volume that failed to wipe is
+// not retried on the very next sweep.
+//
+// Without this, a persistently failing device would make the reaper spin,
+// re-reading and re-attempting the same volume on every signal and every tick.
+func TestReaperBacksOffAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, quarantinedLV(testWipeName))
+
+		// Exactly one attempt, despite two sweeps.
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		m.EXPECT().
+			SanitizeLogicalVolume(gomock.Any(), testVolumeGroup, testWipeName).
+			Return(errors.New("device write error")).
+			Times(1)
+	})
+
+	ctx := context.Background()
+	for i := range 2 {
+		if err := r.Reconcile(ctx); err != nil {
+			t.Fatalf("Reconcile() %d error = %v", i, err)
+		}
+	}
+}
+
+// TestReaperTreatsMissingVolumeAsRemoved checks idempotency of the removal
+// step.
+//
+// The volume was sanitized before lvremove was attempted, so a volume that has
+// already gone is a success, not a failure to retry.
+func TestReaperTreatsMissingVolumeAsRemoved(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, quarantinedLV(testWipeName))
+
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil)
+		m.EXPECT().SanitizeLogicalVolume(gomock.Any(), testVolumeGroup, testWipeName).Return(nil)
+		m.EXPECT().
+			RemoveLogicalVolume(gomock.Any(), gomock.Any()).
+			Return(lvmMgr.ErrNotFound)
+	})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+}
+
+// TestReaperSweepsOnStartup checks that the reaper wipes volumes it was never
+// signalled about.
+//
+// This is what makes quarantine crash-safe. A volume quarantined by a previous
+// process, or by a process that died before the wipe finished, has no pending
+// signal and must still be found.
+func TestReaperSweepsOnStartup(t *testing.T) {
+	t.Parallel()
+
+	removed := make(chan string, 1)
+
+	r := newTestReaper(t, func(m *lvmMgr.MockManager) {
+		expectVolumeGroup(m)
+		expectQuarantined(m, quarantinedLV(testWipeNameInherited))
+
+		m.EXPECT().UpdateLogicalVolume(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		m.EXPECT().SanitizeLogicalVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		m.EXPECT().
+			RemoveLogicalVolume(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts lvmMgr.RemoveLVOptions) error {
+				select {
+				case removed <- opts.Name:
+				default:
+				}
+				return nil
+			}).
+			AnyTimes()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	select {
+	case name := <-removed:
+		if got, want := name, testVolumeGroup+"/"+testWipeNameInherited; got != want {
+			t.Errorf("removed %q, want %q", got, want)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reaper did not sweep on startup")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() error = %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reaper did not stop on context cancellation")
+	}
+}
+
+// TestReaperSignalDoesNotBlock checks that signalling is safe from the
+// deletion path.
+//
+// DeleteVolume signals the reaper while holding a CSI request under a sidecar
+// timeout. If the signal could block on a wipe that is already running, a
+// deletion would stall behind a multi-minute zeroing operation.
+func TestReaperSignalDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReaper(t, nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// More signals than the channel can hold. Extra signals are dropped
+		// because a pending wakeup already covers them: the next sweep
+		// processes everything it finds.
+		for range 100 {
+			r.Signal()
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Signal() blocked")
+	}
+}

--- a/internal/gc/lvm_orphan_cleanup.go
+++ b/internal/gc/lvm_orphan_cleanup.go
@@ -86,24 +86,10 @@ func (r *LVMOrphanScanner) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// First, list volume groups with the correct tag
 	log.V(3).Info("Listing volume groups with tag", "tag", lvm.DefaultVolumeGroupTag)
 
-	vgs, err := r.lvmManager.ListVolumeGroups(ctx, &lvmMgr.ListVGOptions{
-		Select: fmt.Sprintf("vg_tags=%s", lvm.DefaultVolumeGroupTag),
-	})
+	vgNamesToScan, err := lvm.ManagedVolumeGroups(ctx, r.lvmManager)
 	if err != nil {
 		log.Error(err, "Failed to list volume groups with tag", "tag", lvm.DefaultVolumeGroupTag)
 		return ctrl.Result{}, err
-	}
-
-	// If no volume groups found with the tag, also check the default volume group
-	vgNamesToScan := []string{}
-	if len(vgs) == 0 {
-		log.V(3).Info("No volume groups found with tag, checking default volume group",
-			"tag", lvm.DefaultVolumeGroupTag, "defaultVG", lvm.DefaultVolumeGroup)
-		vgNamesToScan = append(vgNamesToScan, lvm.DefaultVolumeGroup)
-	} else {
-		for _, vg := range vgs {
-			vgNamesToScan = append(vgNamesToScan, vg.Name)
-		}
 	}
 
 	for _, vgName := range vgNamesToScan {
@@ -118,6 +104,27 @@ func (r *LVMOrphanScanner) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		for _, lv := range lvs {
+			// Skip volumes that are already committed to sanitization.
+			//
+			// Such a volume is renamed out of the volume ID namespace and its
+			// PersistentVolume is gone by construction, so it would otherwise
+			// be classified as an orphan on every scan and removed without
+			// being zeroed, which is exactly what quarantine exists to
+			// prevent. The reaper owns it. The check comes before the PV
+			// lookup so that it costs no API traffic.
+			//
+			// A volume that only carries the tag is deliberately *not* skipped.
+			// Its quarantine was never committed, so it is still under its own
+			// name and still has a volume ID: if it has a PersistentVolume the
+			// normal orphan check leaves it alone, and if it does not, it is a
+			// genuine orphan and routing it through quarantine both commits it
+			// and gets it wiped. Skipping it instead would make it
+			// unreclaimable by any component.
+			if lvm.IsQuarantineCommitted(lv) {
+				log.V(4).Info("Skipping volume awaiting sanitization", "vg", vgName, "lv", lv.Name)
+				continue
+			}
+
 			totalVolumes++
 			volumeID := fmt.Sprintf("%s#%s", vgName, lv.Name)
 

--- a/internal/gc/lvm_orphan_cleanup_test.go
+++ b/internal/gc/lvm_orphan_cleanup_test.go
@@ -283,3 +283,71 @@ func TestLVMOrphanScanner_Reconcile(t *testing.T) {
 		}
 	}
 }
+
+// TestLVMOrphanScanner_SkipsQuarantinedVolumes checks that the scanner leaves
+// volumes awaiting sanitization alone.
+//
+// A quarantined volume is renamed out of the volume ID namespace and its
+// PersistentVolume is gone by construction, so it matches the scanner's
+// definition of an orphan on every sweep. Without an explicit exclusion the
+// scanner would remove it, returning extents that still hold a tenant's data
+// to the volume group's free pool and defeating sanitization entirely.
+func TestLVMOrphanScanner_SkipsQuarantinedVolumes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&corev1.PersistentVolume{}, CSIVolumeHandleIndex, func(obj client.Object) []string {
+			pv := obj.(*corev1.PersistentVolume)
+			if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == lvm.DriverName {
+				return []string{pv.Spec.CSI.VolumeHandle}
+			}
+			return nil
+		}).
+		Build()
+
+	ctx := context.Background()
+
+	fakeLVM := lvmMgr.NewFake()
+	if err := fakeLVM.CreateVolumeGroup(ctx, lvmMgr.CreateVGOptions{Name: "containerstorage"}); err != nil {
+		t.Fatalf("Failed to create VG: %v", err)
+	}
+
+	testLVM := NewMockLVMVolumeManager()
+	testLVM.Fake = fakeLVM
+
+	const quarantinedName = "local-csi-wipe-11111111-2222-3333-4444-555555555555"
+	if _, err := testLVM.CreateLogicalVolume(ctx, lvmMgr.CreateLVOptions{
+		VGName: "containerstorage",
+		Name:   quarantinedName,
+		Size:   "1073741824B",
+	}); err != nil {
+		t.Fatalf("Failed to create LV: %v", err)
+	}
+	if err := fakeLVM.UpdateLogicalVolume(ctx, lvmMgr.UpdateLVOptions{
+		Name:    "containerstorage/" + quarantinedName,
+		AddTags: []string{lvm.WipePendingTag},
+	}); err != nil {
+		t.Fatalf("Failed to tag LV: %v", err)
+	}
+
+	scanner := &LVMOrphanScanner{
+		Client:                   client,
+		scheme:                   scheme,
+		recorder:                 kevents.NewFakeRecorder(10),
+		nodeID:                   "node1",
+		selectedNodeAnnotation:   "localdisk.csi.acstor.io/selected-node",
+		selectedInitialNodeParam: "localdisk.csi.acstor.io/selected-initial-node",
+		lvmManager:               testLVM,
+		reconcileInterval:        time.Minute,
+	}
+
+	if _, err := scanner.Reconcile(ctx, ctrl.Request{}); err != nil {
+		t.Fatalf("Reconcile() unexpected error: %v", err)
+	}
+
+	if len(testLVM.DeletedLVs) != 0 {
+		t.Errorf("Expected no volumes to be deleted, got %v", testLVM.DeletedLVs)
+	}
+}

--- a/internal/gc/volume_manager_adapter.go
+++ b/internal/gc/volume_manager_adapter.go
@@ -5,6 +5,7 @@ package gc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"local-csi-driver/internal/csi/core/lvm"
@@ -43,18 +44,21 @@ func (a *lvmVolumeManagerAdapter) DeleteVolume(ctx context.Context, volumeID str
 		return fmt.Errorf("failed to parse volume ID %s: %w", volumeID, err)
 	}
 
-	// Format volume ID for LVM operations (vg/lv format)
-	lvmVolumeID := fmt.Sprintf("%s/%s", vgName, lvName)
-
-	// Use the LVM manager to remove the logical volume directly
-	removeOpts := lvmMgr.RemoveLVOptions{Name: lvmVolumeID}
-
-	if err := a.lvmManager.RemoveLogicalVolume(ctx, removeOpts); err != nil {
-		// If the volume doesn't exist, consider it a success
-		if lvmMgr.IgnoreNotFound(err) == nil {
+	// Take the volume out of service rather than removing it.
+	//
+	// Garbage collection reclaims volumes whose data still belongs to a
+	// tenant, so its extents must be zeroed before they return to the volume
+	// group's free pool, exactly as on the CSI deletion path. Quarantine keeps
+	// them allocated until the wipe reaper has cleared them.
+	if _, err := a.lvmCore.Quarantine(ctx, vgName, lvName); err != nil {
+		// If the volume doesn't exist, consider it a success. A volume group
+		// that cannot currently be seen does not qualify: that is usually
+		// temporary, and treating it as proof of absence would let the caller
+		// drop its record of a volume that still exists on disk.
+		if lvmMgr.IgnoreNotFound(err) == nil && !errors.Is(err, lvmMgr.ErrVolumeGroupNotFound) {
 			return nil
 		}
-		return fmt.Errorf("failed to remove logical volume %s: %w", lvmVolumeID, err)
+		return fmt.Errorf("failed to quarantine logical volume %s/%s: %w", vgName, lvName, err)
 	}
 
 	return nil

--- a/internal/pkg/lvm/errors_internal_test.go
+++ b/internal/pkg/lvm/errors_internal_test.go
@@ -89,3 +89,63 @@ func TestStaleDeviceNodeDistinctFromAlreadyExists(t *testing.T) {
 		t.Fatal("wrapped error should match ErrStaleDeviceNode")
 	}
 }
+
+// TestVolumeGroupNotFoundClassification pins the distinction between a message
+// about a missing volume group and one about a missing logical volume that
+// merely names the group it was looked for in.
+//
+// Deletion depends on this. A missing logical volume is proof that the volume
+// is gone, so DeleteVolume reports success; an invisible volume group is
+// usually temporary, so deletion must retry rather than report success and let
+// the PersistentVolume be removed while a populated volume survives on disk.
+func TestVolumeGroupNotFoundClassification(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantVGAbsent bool
+	}{
+		{
+			name:         "missing volume group",
+			input:        `Volume group "vg0" not found`,
+			wantVGAbsent: true,
+		},
+		{
+			name:         "missing volume group with cannot process",
+			input:        `Volume group "vg0" not found. Cannot process volume group vg0`,
+			wantVGAbsent: true,
+		},
+		{
+			// Names the group, but is about the logical volume.
+			name:         "missing logical volume names its volume group",
+			input:        `Failed to find logical volume 'lv0' in volume group 'vg0'`,
+			wantVGAbsent: false,
+		},
+		{
+			// lvrename's wording for a missing source volume.
+			name:         "missing rename source names its volume group",
+			input:        `Existing logical volume "lv0" not found in volume group "vg0".`,
+			wantVGAbsent: false,
+		},
+		{
+			name:         "missing logical volume by path",
+			input:        `Failed to find logical volume "vg0/lv0"`,
+			wantVGAbsent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := getErrorType(fmt.Errorf("exit status 5: %s", tt.input))
+
+			// Every case is a missing object, so callers that only care about
+			// that must keep working regardless of the distinction.
+			if !errors.Is(err, ErrNotFound) {
+				t.Errorf("getErrorType(%q) is not ErrNotFound", tt.input)
+			}
+
+			if got := errors.Is(err, ErrVolumeGroupNotFound); got != tt.wantVGAbsent {
+				t.Errorf("getErrorType(%q) is ErrVolumeGroupNotFound = %v, want %v", tt.input, got, tt.wantVGAbsent)
+			}
+		})
+	}
+}

--- a/internal/pkg/lvm/fake.go
+++ b/internal/pkg/lvm/fake.go
@@ -5,6 +5,7 @@ package lvm
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -14,6 +15,10 @@ type Fake struct {
 	VGs map[string]VolumeGroup
 	LVs map[string]LogicalVolume
 	Err error
+
+	// Sanitized records the volumes passed to SanitizeLogicalVolume, in call
+	// order, as "vgName/lvName".
+	Sanitized []string
 }
 
 // Construct a new fakelvm2 client.
@@ -126,6 +131,88 @@ func (f *Fake) CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) (i
 func (f *Fake) RemoveLogicalVolume(ctx context.Context, opts RemoveLVOptions) error {
 	delete(f.LVs, opts.Name)
 	return nil
+}
+
+// SanitizeLogicalVolume records the volume as sanitized.
+//
+// The record lets tests assert that extents were zeroed, and that it happened
+// before the volume was removed, which is the ordering the guarantee depends
+// on.
+func (f *Fake) SanitizeLogicalVolume(ctx context.Context, vgName string, lvName string) error {
+	if _, ok := f.LVs[lvName]; !ok {
+		return ErrNotFound
+	}
+	f.Sanitized = append(f.Sanitized, vgName+"/"+lvName)
+	return nil
+}
+
+// UpdateLogicalVolume applies tag changes to a LV.
+func (f *Fake) UpdateLogicalVolume(ctx context.Context, opts UpdateLVOptions) error {
+	key := fakeLVKey(opts.Name)
+	lv, ok := f.LVs[key]
+	if !ok {
+		return ErrNotFound
+	}
+
+	tags := splitTags(lv.Tags)
+	for _, del := range opts.DelTags {
+		delete(tags, del)
+	}
+	for _, add := range opts.AddTags {
+		tags[add] = struct{}{}
+	}
+
+	lv.Tags = joinTags(tags)
+	f.LVs[key] = lv
+	return nil
+}
+
+// RenameLogicalVolume renames a LV within its VG.
+func (f *Fake) RenameLogicalVolume(ctx context.Context, opts RenameLVOptions) error {
+	from, to := fakeLVKey(opts.From), fakeLVKey(opts.To)
+
+	lv, ok := f.LVs[from]
+	if !ok {
+		return ErrNotFound
+	}
+	if _, exists := f.LVs[to]; exists {
+		return ErrAlreadyExists
+	}
+
+	lv.Name = to
+	delete(f.LVs, from)
+	f.LVs[to] = lv
+	return nil
+}
+
+// fakeLVKey normalises a "vgName/lvName" reference to the bare LV name used to
+// key the fake's LV map.
+func fakeLVKey(name string) string {
+	if _, lvName, ok := strings.Cut(name, "/"); ok {
+		return lvName
+	}
+	return name
+}
+
+// splitTags parses the comma-separated tag list that LVM reports.
+func splitTags(tags string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, tag := range strings.Split(tags, ",") {
+		if tag = strings.TrimSpace(tag); tag != "" {
+			set[tag] = struct{}{}
+		}
+	}
+	return set
+}
+
+// joinTags renders a tag set the way LVM reports it.
+func joinTags(tags map[string]struct{}) string {
+	out := make([]string, 0, len(tags))
+	for tag := range tags {
+		out = append(out, tag)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
 }
 
 // ListLogicalVolumes lists the specified LVs.

--- a/internal/pkg/lvm/fake.go
+++ b/internal/pkg/lvm/fake.go
@@ -261,3 +261,8 @@ func (f *Fake) IsLogicalVolumeCorrupted(ctx context.Context, vgName string, lvNa
 func (f *Fake) RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error {
 	return f.Err
 }
+
+// MakeVolumeGroupDeviceNodes is a no-op for the fake implementation.
+func (f *Fake) MakeVolumeGroupDeviceNodes(ctx context.Context, opts MakeVGDeviceNodesOptions) error {
+	return f.Err
+}

--- a/internal/pkg/lvm/lvm.go
+++ b/internal/pkg/lvm/lvm.go
@@ -50,6 +50,21 @@ var (
 	// ErrNotFound is returned when the lvm object is not found.
 	ErrNotFound = errors.New("not found")
 
+	// ErrVolumeGroupNotFound is returned when LVM cannot see the volume group
+	// an operation names.
+	//
+	// It wraps ErrNotFound, so callers that only care that an object is
+	// missing are unaffected. Callers that must not confuse the two can test
+	// for it specifically.
+	//
+	// A missing volume group is ambiguous in a way a missing logical volume is
+	// not: it commonly means the group is only temporarily invisible, for
+	// example before device scanning has completed after a reboot or while a
+	// device filter is hiding its physical volumes. Treating that as proof
+	// that a logical volume is gone would let a deletion report success while
+	// a populated volume survives on disk.
+	ErrVolumeGroupNotFound = fmt.Errorf("volume group %w", ErrNotFound)
+
 	// AlreadyExists is returned when the lvm object already exists.
 	ErrAlreadyExists = errors.New("already exists")
 
@@ -735,8 +750,10 @@ func (c *Client) UpdateLogicalVolume(ctx context.Context, opts UpdateLVOptions) 
 	cmdArgs = append(cmdArgs, "lvchange", "--yes")
 	cmdArgs = append(cmdArgs, marshaledOpts...)
 
-	_, err := c.run(ctx, cmdArgs...)
-	return err
+	if _, err := c.run(ctx, cmdArgs...); err != nil {
+		return getErrorType(err)
+	}
+	return nil
 }
 
 // Remove a logical volume.
@@ -833,7 +850,7 @@ func (c *Client) ReduceLogicalVolume(ctx context.Context, opts ReduceLVOptions) 
 
 // Rename a logical volume.
 func (c *Client) RenameLogicalVolume(ctx context.Context, opts RenameLVOptions) error {
-	ctx, span := c.tracer.Start(ctx, "lvm/ReduceLogicalVolume", trace.WithAttributes(
+	ctx, span := c.tracer.Start(ctx, "lvm/RenameLogicalVolume", trace.WithAttributes(
 		attribute.String("lv.src", opts.From),
 		attribute.String("lv.dst", opts.To),
 	))
@@ -844,8 +861,10 @@ func (c *Client) RenameLogicalVolume(ctx context.Context, opts RenameLVOptions) 
 	cmdArgs = append(cmdArgs, "lvrename", "--yes")
 	cmdArgs = append(cmdArgs, marshaledOpts...)
 
-	_, err := c.run(ctx, cmdArgs...)
-	return err
+	if _, err := c.run(ctx, cmdArgs...); err != nil {
+		return getErrorType(err)
+	}
+	return nil
 }
 
 func (c *Client) run(ctx context.Context, cmdArgs ...string) ([]byte, error) {
@@ -900,6 +919,20 @@ func (c *Client) runCmd(ctx context.Context, spanName, binary string, cmdArgs ..
 // Missing VG: Volume group 'NoVolumeGroup'  not found.
 func getErrorType(err error) error {
 	switch {
+	case containsIgnoreCase(err.Error(), "volume group") &&
+		!containsIgnoreCase(err.Error(), "logical volume") &&
+		(containsIgnoreCase(err.Error(), "not found") || containsIgnoreCase(err.Error(), "failed to find")):
+		// A message about a missing volume group, as distinct from one about a
+		// missing logical volume that merely names the group it was looked for
+		// in ("Failed to find logical volume 'lv' in volume group 'vg'"). The
+		// distinction matters because deletion treats a missing logical volume
+		// as proof the volume is gone, but must retry when a whole group is
+		// invisible.
+		//
+		// Checked before the generic not-found cases below. ErrVolumeGroupNotFound
+		// wraps ErrNotFound, so callers that do not need the distinction are
+		// unaffected.
+		return fmt.Errorf("%w: %s", ErrVolumeGroupNotFound, err.Error())
 	case containsIgnoreCase(err.Error(), "failed to find"),
 		containsIgnoreCase(err.Error(), "not found"):
 		return fmt.Errorf("%w: %s", ErrNotFound, err.Error())

--- a/internal/pkg/lvm/manager.go
+++ b/internal/pkg/lvm/manager.go
@@ -47,6 +47,17 @@ type Manager interface {
 	CreateLogicalVolume(ctx context.Context, opts CreateLVOptions) (int64, error)
 	// RemoveLogicalVolume removes a LV from a VG
 	RemoveLogicalVolume(ctx context.Context, opts RemoveLVOptions) error
+	// UpdateLogicalVolume changes LV attributes, including tags.
+	UpdateLogicalVolume(ctx context.Context, opts UpdateLVOptions) error
+	// RenameLogicalVolume renames a LV within its VG.
+	RenameLogicalVolume(ctx context.Context, opts RenameLVOptions) error
+	// SanitizeLogicalVolume overwrites every byte of a LV with zeroes and
+	// flushes the device, so that its extents carry no residual data when they
+	// are returned to the volume group's free pool.
+	//
+	// It must be called before RemoveLogicalVolume. Once lvremove has run the
+	// extents may be reallocated at any time and can no longer be reached.
+	SanitizeLogicalVolume(ctx context.Context, vgName string, lvName string) error
 	// ListLogicalVolumes lists the specified LVs.
 	ListLogicalVolumes(ctx context.Context, opts *ListLVOptions) ([]LogicalVolume, error)
 	// GetLogicalVolumes returns named LV.

--- a/internal/pkg/lvm/manager.go
+++ b/internal/pkg/lvm/manager.go
@@ -74,4 +74,8 @@ type Manager interface {
 	// It is a no-op when the volume group still exists in LVM metadata (the
 	// nodes are not stale) or when there is nothing to clean up.
 	RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error
+	// MakeVolumeGroupDeviceNodes creates device files for active logical
+	// volumes in the volume group (vgmknodes). It is synchronous: once it
+	// returns, every active LV in the group has its device node.
+	MakeVolumeGroupDeviceNodes(ctx context.Context, opts MakeVGDeviceNodesOptions) error
 }

--- a/internal/pkg/lvm/mock.go
+++ b/internal/pkg/lvm/mock.go
@@ -220,6 +220,20 @@ func (mr *MockManagerMockRecorder) ListVolumeGroups(ctx, opts any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVolumeGroups", reflect.TypeOf((*MockManager)(nil).ListVolumeGroups), ctx, opts)
 }
 
+// MakeVolumeGroupDeviceNodes mocks base method.
+func (m *MockManager) MakeVolumeGroupDeviceNodes(ctx context.Context, opts MakeVGDeviceNodesOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeVolumeGroupDeviceNodes", ctx, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MakeVolumeGroupDeviceNodes indicates an expected call of MakeVolumeGroupDeviceNodes.
+func (mr *MockManagerMockRecorder) MakeVolumeGroupDeviceNodes(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeVolumeGroupDeviceNodes", reflect.TypeOf((*MockManager)(nil).MakeVolumeGroupDeviceNodes), ctx, opts)
+}
+
 // RemoveLogicalVolume mocks base method.
 func (m *MockManager) RemoveLogicalVolume(ctx context.Context, opts RemoveLVOptions) error {
 	m.ctrl.T.Helper()

--- a/internal/pkg/lvm/mock.go
+++ b/internal/pkg/lvm/mock.go
@@ -275,3 +275,45 @@ func (mr *MockManagerMockRecorder) RemoveVolumeGroup(ctx, opts any) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolumeGroup", reflect.TypeOf((*MockManager)(nil).RemoveVolumeGroup), ctx, opts)
 }
+
+// RenameLogicalVolume mocks base method.
+func (m *MockManager) RenameLogicalVolume(ctx context.Context, opts RenameLVOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenameLogicalVolume", ctx, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RenameLogicalVolume indicates an expected call of RenameLogicalVolume.
+func (mr *MockManagerMockRecorder) RenameLogicalVolume(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameLogicalVolume", reflect.TypeOf((*MockManager)(nil).RenameLogicalVolume), ctx, opts)
+}
+
+// SanitizeLogicalVolume mocks base method.
+func (m *MockManager) SanitizeLogicalVolume(ctx context.Context, vgName, lvName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SanitizeLogicalVolume", ctx, vgName, lvName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SanitizeLogicalVolume indicates an expected call of SanitizeLogicalVolume.
+func (mr *MockManagerMockRecorder) SanitizeLogicalVolume(ctx, vgName, lvName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SanitizeLogicalVolume", reflect.TypeOf((*MockManager)(nil).SanitizeLogicalVolume), ctx, vgName, lvName)
+}
+
+// UpdateLogicalVolume mocks base method.
+func (m *MockManager) UpdateLogicalVolume(ctx context.Context, opts UpdateLVOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLogicalVolume", ctx, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLogicalVolume indicates an expected call of UpdateLogicalVolume.
+func (mr *MockManagerMockRecorder) UpdateLogicalVolume(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLogicalVolume", reflect.TypeOf((*MockManager)(nil).UpdateLogicalVolume), ctx, opts)
+}

--- a/internal/pkg/lvm/quarantine_errors_test.go
+++ b/internal/pkg/lvm/quarantine_errors_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"local-csi-driver/internal/pkg/block"
+	"local-csi-driver/internal/pkg/lvm"
+)
+
+// TestQuarantineErrorClassification pins the error contract that the deletion
+// path depends on, against real LVM rather than a mock.
+//
+// Quarantine tags and renames a logical volume instead of removing it, and
+// DeleteVolume decides whether a failure means "already deleted" from the
+// error those two calls return. The unit tests can only assert that the driver
+// reacts correctly to lvm.ErrNotFound; this asserts that the client actually
+// produces it, and that a missing volume group is reported distinguishably so
+// that a temporarily invisible group is never mistaken for a deleted volume.
+func TestQuarantineErrorClassification(t *testing.T) {
+	if !isRoot() {
+		t.Skip("Skipping TestQuarantineErrorClassification as it requires root permissions.")
+	}
+	if _, err := os.Stat("/sbin/lvm"); err != nil {
+		t.Skip("Skipping TestQuarantineErrorClassification as /sbin/lvm is not available.")
+	}
+
+	c := lvm.NewClient(lvm.WithBlockDeviceUtilities(block.New()))
+	ctx := context.Background()
+	vgName := newTestVolumeGroup(t, c)
+
+	missing := vgName + "/" + uniqueName("absent")
+
+	t.Run("TagMissingVolumeIsNotFound", func(t *testing.T) {
+		err := c.UpdateLogicalVolume(ctx, lvm.UpdateLVOptions{
+			Name:    missing,
+			AddTags: []string{"local-csi-wipe-pending"},
+		})
+		if !errors.Is(err, lvm.ErrNotFound) {
+			t.Errorf("UpdateLogicalVolume() error = %v, want ErrNotFound", err)
+		}
+		if errors.Is(err, lvm.ErrVolumeGroupNotFound) {
+			t.Errorf("a missing logical volume must not be reported as a missing volume group: %v", err)
+		}
+	})
+
+	t.Run("RenameMissingVolumeIsNotFound", func(t *testing.T) {
+		err := c.RenameLogicalVolume(ctx, lvm.RenameLVOptions{
+			From: missing,
+			To:   vgName + "/" + uniqueName("wipe"),
+		})
+		if !errors.Is(err, lvm.ErrNotFound) {
+			t.Errorf("RenameLogicalVolume() error = %v, want ErrNotFound", err)
+		}
+		// lvrename reports a missing source as "Existing logical volume "lv"
+		// not found in volume group "vg"", which names the group. It must
+		// still be classified as a missing volume, or deletion would never be
+		// idempotent.
+		if errors.Is(err, lvm.ErrVolumeGroupNotFound) {
+			t.Errorf("a missing logical volume must not be reported as a missing volume group: %v", err)
+		}
+	})
+
+	// An invisible volume group is usually temporary. Deletion must be able to
+	// tell it apart from a genuinely absent volume, or it would report success
+	// and leave a populated volume behind with nothing referencing it.
+	t.Run("MissingVolumeGroupIsDistinguishable", func(t *testing.T) {
+		err := c.UpdateLogicalVolume(ctx, lvm.UpdateLVOptions{
+			Name:    uniqueName("absentvg") + "/lv",
+			AddTags: []string{"local-csi-wipe-pending"},
+		})
+		if !errors.Is(err, lvm.ErrVolumeGroupNotFound) {
+			t.Errorf("UpdateLogicalVolume() error = %v, want ErrVolumeGroupNotFound", err)
+		}
+	})
+}

--- a/internal/pkg/lvm/sanitize.go
+++ b/internal/pkg/lvm/sanitize.go
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// zeroChunkSize bounds the range covered by a single BLKZEROOUT ioctl or
+	// write call.
+	//
+	// Both are uninterruptible once issued, so the chunk size determines how
+	// long cancellation can take to be observed. It also bounds how long a
+	// single operation occupies the device queue ahead of foreground I/O.
+	zeroChunkSize = int64(1) << 30 // 1 GiB.
+
+	// zeroBufferSize is the size of the reusable zero-filled buffer used by
+	// the write fallback.
+	zeroBufferSize = int64(4) << 20 // 4 MiB.
+)
+
+// errZeroOutUnsupported signals that the device cannot service BLKZEROOUT and
+// that the caller should fall back to writing zeroes explicitly.
+//
+// It is internal: callers of SanitizeLogicalVolume never see it, because the
+// fallback always succeeds where the ioctl is merely unsupported.
+var errZeroOutUnsupported = errors.New("BLKZEROOUT not supported")
+
+// SanitizeLogicalVolume overwrites every byte of a logical volume with zeroes
+// and flushes the device before returning.
+//
+// It is the sanitization primitive behind wipe-on-delete: extents must be
+// zeroed while they are still attached to a logical volume, because once
+// lvremove returns them to the volume group's free pool they may be handed to
+// another volume at any time.
+//
+// The device is held open O_EXCL for the whole operation, so a volume that is
+// still mounted or otherwise claimed returns ErrInUse and is left untouched
+// rather than being zeroed underneath its consumer.
+//
+// Zeroing is attempted with the BLKZEROOUT ioctl, which lets the device
+// satisfy the request with a write-zeroes command where it supports one. Where
+// the ioctl is unsupported the whole remaining range is written explicitly.
+// Discard is deliberately never used as a fallback: BLKDISCARD permits, but
+// does not require, a device to return zeroes for discarded blocks, so a
+// discard that reports success can leave the previous contents readable.
+//
+// The volume's actual size is read from LVM rather than taken from the caller,
+// because LVM rounds allocations up to whole extents and the rounding
+// remainder is part of what has to be cleared.
+func (c *Client) SanitizeLogicalVolume(ctx context.Context, vgName, lvName string) error {
+	ctx, span := c.tracer.Start(ctx, "lvm/SanitizeLogicalVolume", trace.WithAttributes(
+		attribute.String("vg.name", vgName),
+		attribute.String("lv.name", lvName),
+	))
+	defer span.End()
+
+	if vgName == "" || lvName == "" {
+		return fmt.Errorf("%w: volume group and logical volume names cannot be empty", ErrInvalidInput)
+	}
+
+	lv, err := c.GetLogicalVolume(ctx, vgName, lvName)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+	if lv == nil {
+		return fmt.Errorf("%w: logical volume %s/%s", ErrNotFound, vgName, lvName)
+	}
+
+	size := int64(lv.Size)
+	if size <= 0 {
+		return fmt.Errorf("%w: logical volume %s/%s has size %d", ErrInvalidInput, vgName, lvName, size)
+	}
+	span.SetAttributes(attribute.Int64("lv.size", size))
+
+	path := ConstructLogicalVolumePath(vgName, lvName)
+
+	// O_EXCL on a block device fails if the device is already claimed, which
+	// is the in-use guard. The descriptor is held for the whole operation so
+	// there is no window between the check and the writes.
+	f, err := os.OpenFile(path, os.O_WRONLY|unix.O_EXCL|unix.O_CLOEXEC, 0)
+	if err != nil {
+		span.RecordError(err)
+		if errors.Is(err, unix.EBUSY) {
+			return fmt.Errorf("%w: logical volume %s/%s is claimed by another process", ErrInUse, vgName, lvName)
+		}
+		return fmt.Errorf("failed to open %s for sanitization: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck // Close errors are surfaced by the explicit Sync below.
+
+	if err := zeroDevice(ctx, f, size); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to zero %s: %w", path, err)
+	}
+
+	// Flush before the caller removes the logical volume. Without this the
+	// zeroes may still be in the device write cache while the extents are
+	// already back in the free pool.
+	if err := f.Sync(); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to flush %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// zeroDevice writes zeroes over the first size bytes of f.
+//
+// It prefers the BLKZEROOUT ioctl and falls back to writing zeroes explicitly
+// from the offset at which the ioctl turned out to be unsupported. Splitting
+// the work at that offset means a device that supports the ioctl for part of
+// its range is not re-zeroed from the beginning.
+func zeroDevice(ctx context.Context, f *os.File, size int64) error {
+	offset, err := zeroDeviceIoctl(ctx, f, size)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, errZeroOutUnsupported) {
+		return err
+	}
+	return zeroDeviceWrite(ctx, f, offset, size)
+}
+
+// zeroDeviceIoctl zeroes f using BLKZEROOUT.
+//
+// It returns the offset reached, so that a caller falling back to explicit
+// writes can resume rather than restart. The returned error wraps
+// errZeroOutUnsupported when the device does not implement the ioctl.
+func zeroDeviceIoctl(ctx context.Context, f *os.File, size int64) (int64, error) {
+	for offset := int64(0); offset < size; {
+		if err := ctx.Err(); err != nil {
+			return offset, err
+		}
+
+		length := min(zeroChunkSize, size-offset)
+
+		// BLKZEROOUT takes a two-element array of uint64: the byte offset and
+		// the byte length, both of which must be aligned to the device's
+		// logical block size. Logical volumes are extent-aligned and the chunk
+		// size is a power of two, so alignment holds for every chunk.
+		rng := [2]uint64{uint64(offset), uint64(length)}
+		_, _, errno := unix.Syscall(
+			unix.SYS_IOCTL,
+			f.Fd(),
+			unix.BLKZEROOUT,
+			uintptr(unsafe.Pointer(&rng[0])),
+		)
+		if errno != 0 {
+			switch errno {
+			case unix.EOPNOTSUPP, unix.ENOTTY, unix.EINVAL:
+				// Not a block device, or a block device whose driver has no
+				// write-zeroes path. Both are expected; fall back.
+				return offset, fmt.Errorf("%w: %w", errZeroOutUnsupported, errno)
+			default:
+				return offset, fmt.Errorf("BLKZEROOUT at offset %d failed: %w", offset, errno)
+			}
+		}
+
+		offset += length
+	}
+
+	return size, nil
+}
+
+// zeroDeviceWrite writes zeroes over f from offset up to size.
+func zeroDeviceWrite(ctx context.Context, f *os.File, offset, size int64) error {
+	if offset >= size {
+		return nil
+	}
+
+	buf := make([]byte, zeroBufferSize)
+
+	for offset < size {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		length := min(int64(len(buf)), size-offset)
+
+		n, err := f.WriteAt(buf[:length], offset)
+		if err != nil {
+			return fmt.Errorf("write at offset %d failed: %w", offset, err)
+		}
+		if int64(n) != length {
+			return fmt.Errorf("short write at offset %d: wrote %d of %d bytes", offset, n, length)
+		}
+
+		offset += length
+	}
+
+	return nil
+}

--- a/internal/pkg/lvm/sanitize.go
+++ b/internal/pkg/lvm/sanitize.go
@@ -51,9 +51,11 @@ var errZeroOutUnsupported = errors.New("BLKZEROOUT not supported")
 // Zeroing is attempted with the BLKZEROOUT ioctl, which lets the device
 // satisfy the request with a write-zeroes command where it supports one. Where
 // the ioctl is unsupported the whole remaining range is written explicitly.
-// Discard is deliberately never used as a fallback: BLKDISCARD permits, but
-// does not require, a device to return zeroes for discarded blocks, so a
-// discard that reports success can leave the previous contents readable.
+// Discard is deliberately never used as a substitute for either: BLKDISCARD
+// permits, but does not require, a device to return zeroes for discarded
+// blocks, so a discard that reports success can leave the previous contents
+// readable. It is issued only afterwards, to release the blocks that zeroing
+// has just allocated.
 //
 // The volume's actual size is read from LVM rather than taken from the caller,
 // because LVM rounds allocations up to whole extents and the rounding
@@ -110,6 +112,59 @@ func (c *Client) SanitizeLogicalVolume(ctx context.Context, vgName, lvName strin
 	if err := f.Sync(); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to flush %s: %w", path, err)
+	}
+
+	// Release the now-zeroed blocks back to the underlying storage.
+	//
+	// BLKZEROOUT is issued with BLKDEV_ZERO_NOUNMAP by the kernel, so it
+	// writes real zeroes rather than unmapping. On thin-provisioned or
+	// file-backed storage that materializes every block the volume ever
+	// covered, so a volume group that was cheap to hold becomes fully
+	// allocated purely as a side effect of deleting volumes from it.
+	//
+	// Discarding afterwards returns that space. It cannot weaken the
+	// guarantee: the zeroes have already been written and flushed, so the
+	// worst a discard can do is leave them in place. This is the reverse of
+	// discarding *instead* of zeroing, which would be unsafe, because discard
+	// permits but does not require a device to return zeroes for discarded
+	// blocks.
+	//
+	// Best effort: a device with no discard support is not a failure, the
+	// volume is already sanitized.
+	if err := discardDevice(ctx, f, size); err != nil {
+		span.AddEvent("failed to discard sanitized blocks", trace.WithAttributes(
+			attribute.String("error", err.Error()),
+		))
+	}
+
+	return nil
+}
+
+// discardDevice discards the first size bytes of f, releasing them on storage
+// that allocates on write.
+//
+// It is called only after the range has been zeroed and flushed, so it is
+// purely a space optimization and its failure is not an error.
+func discardDevice(ctx context.Context, f *os.File, size int64) error {
+	for offset := int64(0); offset < size; {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		length := min(zeroChunkSize, size-offset)
+
+		rng := [2]uint64{uint64(offset), uint64(length)}
+		_, _, errno := unix.Syscall(
+			unix.SYS_IOCTL,
+			f.Fd(),
+			unix.BLKDISCARD,
+			uintptr(unsafe.Pointer(&rng[0])),
+		)
+		if errno != 0 {
+			return fmt.Errorf("BLKDISCARD at offset %d failed: %w", offset, errno)
+		}
+
+		offset += length
 	}
 
 	return nil

--- a/internal/pkg/lvm/sanitize_internal_test.go
+++ b/internal/pkg/lvm/sanitize_internal_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fillPattern writes a recognisable non-zero pattern of length n to path and
+// returns it, so a test can distinguish "zeroed" from "never written".
+//
+// A repeating byte sequence is used rather than a constant so that a partial
+// or misaligned wipe shifts the pattern visibly instead of leaving a plausible
+// looking result.
+func fillPattern(t *testing.T, path string, n int64) []byte {
+	t.Helper()
+
+	pattern := make([]byte, n)
+	for i := range pattern {
+		pattern[i] = byte(i%251 + 1) // Never zero: 251 is prime, offset by 1.
+	}
+
+	if err := os.WriteFile(path, pattern, 0o600); err != nil {
+		t.Fatalf("failed to write pattern file: %v", err)
+	}
+
+	return pattern
+}
+
+// openPatternFile creates a file of size n filled with a non-zero pattern and
+// returns the open file plus the pattern that was written.
+func openPatternFile(t *testing.T, n int64) (*os.File, []byte) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "device.img")
+	pattern := fillPattern(t, path, n)
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("failed to open pattern file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	return f, pattern
+}
+
+// readAll reads the whole contents of f from offset zero.
+func readAll(t *testing.T, f *os.File) []byte {
+	t.Helper()
+
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("failed to stat file: %v", err)
+	}
+
+	buf := make([]byte, info.Size())
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	return buf
+}
+
+// TestZeroDeviceIoctlUnsupported pins the condition that triggers the write
+// fallback.
+//
+// A regular file cannot service BLKZEROOUT, so the ioctl must report
+// errZeroOutUnsupported rather than a generic failure. Without this the
+// fallback would be reached by accident on real devices and the difference
+// between "unsupported" and "broken" would be invisible.
+func TestZeroDeviceIoctlUnsupported(t *testing.T) {
+	f, _ := openPatternFile(t, 8192)
+
+	offset, err := zeroDeviceIoctl(context.Background(), f, 8192)
+	if !errors.Is(err, errZeroOutUnsupported) {
+		t.Fatalf("expected errZeroOutUnsupported for a regular file, got %v", err)
+	}
+	if offset != 0 {
+		t.Fatalf("expected fallback to resume at offset 0, got %d", offset)
+	}
+}
+
+// TestZeroDevice covers the sizes at which the chunking arithmetic is most
+// likely to be wrong.
+func TestZeroDevice(t *testing.T) {
+	tests := []struct {
+		name string
+		size int64
+	}{
+		{name: "single byte", size: 1},
+		{name: "smaller than buffer", size: 1024},
+		{name: "exactly one buffer", size: zeroBufferSize},
+		{name: "one buffer plus a partial tail", size: zeroBufferSize + 512},
+		{name: "several buffers", size: zeroBufferSize * 3},
+		{name: "several buffers plus a partial tail", size: zeroBufferSize*3 + 17},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, _ := openPatternFile(t, tt.size)
+
+			if err := zeroDevice(context.Background(), f, tt.size); err != nil {
+				t.Fatalf("zeroDevice returned error: %v", err)
+			}
+
+			got := readAll(t, f)
+			if len(got) != int(tt.size) {
+				t.Fatalf("expected file to remain %d bytes, got %d", tt.size, len(got))
+			}
+			if idx := bytes.IndexFunc(got, func(r rune) bool { return r != 0 }); idx != -1 {
+				t.Fatalf("found non-zero byte at offset %d after zeroDevice", idx)
+			}
+		})
+	}
+}
+
+// TestZeroDeviceDoesNotOverrun verifies that zeroing stops at the requested
+// size.
+//
+// The size passed in is the logical volume's size as reported by LVM. Writing
+// past it would run into whatever follows on the underlying device, which for
+// a logical volume means another tenant's extents.
+func TestZeroDeviceDoesNotOverrun(t *testing.T) {
+	const total = zeroBufferSize * 2
+	const zeroUpTo = zeroBufferSize
+
+	f, pattern := openPatternFile(t, total)
+
+	if err := zeroDevice(context.Background(), f, zeroUpTo); err != nil {
+		t.Fatalf("zeroDevice returned error: %v", err)
+	}
+
+	got := readAll(t, f)
+
+	if !bytes.Equal(got[:zeroUpTo], make([]byte, zeroUpTo)) {
+		t.Fatal("expected the requested range to be zeroed")
+	}
+	if !bytes.Equal(got[zeroUpTo:], pattern[zeroUpTo:]) {
+		t.Fatal("zeroDevice wrote past the requested size")
+	}
+}
+
+// TestZeroDeviceWriteResumesFromOffset verifies that the write fallback starts
+// where the ioctl path stopped.
+//
+// A device that services BLKZEROOUT for part of its range must not be
+// re-zeroed from the beginning, and more importantly the range before the
+// offset must not be assumed clean by accident.
+func TestZeroDeviceWriteResumesFromOffset(t *testing.T) {
+	const total = zeroBufferSize * 2
+	const resumeAt = zeroBufferSize
+
+	f, pattern := openPatternFile(t, total)
+
+	if err := zeroDeviceWrite(context.Background(), f, resumeAt, total); err != nil {
+		t.Fatalf("zeroDeviceWrite returned error: %v", err)
+	}
+
+	got := readAll(t, f)
+
+	if !bytes.Equal(got[:resumeAt], pattern[:resumeAt]) {
+		t.Fatal("zeroDeviceWrite wrote before the resume offset")
+	}
+	if !bytes.Equal(got[resumeAt:], make([]byte, total-resumeAt)) {
+		t.Fatal("expected the range from the resume offset to be zeroed")
+	}
+}
+
+// TestZeroDeviceWriteNoOpAtOrPastSize covers the case where the ioctl path
+// completed the whole range, so the fallback has nothing left to do.
+func TestZeroDeviceWriteNoOpAtOrPastSize(t *testing.T) {
+	const total = 4096
+
+	f, pattern := openPatternFile(t, total)
+
+	if err := zeroDeviceWrite(context.Background(), f, total, total); err != nil {
+		t.Fatalf("zeroDeviceWrite returned error: %v", err)
+	}
+
+	if !bytes.Equal(readAll(t, f), pattern) {
+		t.Fatal("expected a no-op when the offset is already at the size")
+	}
+}
+
+// TestZeroDeviceCancelled verifies that cancellation is observed and reported.
+//
+// Sanitization must fail closed: a cancelled wipe has to surface an error so
+// the caller leaves the volume in quarantine rather than removing it and
+// releasing partially zeroed extents.
+func TestZeroDeviceCancelled(t *testing.T) {
+	f, pattern := openPatternFile(t, zeroBufferSize*2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := zeroDevice(ctx, f, zeroBufferSize*2)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	// Nothing should have been written, since cancellation is checked before
+	// the first chunk.
+	if !bytes.Equal(readAll(t, f), pattern) {
+		t.Fatal("expected no writes after cancellation before the first chunk")
+	}
+}
+
+// TestSanitizeLogicalVolumeValidation covers the input validation that runs
+// before any device is opened, so it needs neither root nor LVM.
+func TestSanitizeLogicalVolumeValidation(t *testing.T) {
+	c := NewClient()
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		vgName string
+		lvName string
+	}{
+		{name: "empty volume group", vgName: "", lvName: "lv0"},
+		{name: "empty logical volume", vgName: "vg0", lvName: ""},
+		{name: "both empty", vgName: "", lvName: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.SanitizeLogicalVolume(ctx, tt.vgName, tt.lvName)
+			if !errors.Is(err, ErrInvalidInput) {
+				t.Fatalf("expected ErrInvalidInput, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/pkg/lvm/sanitize_test.go
+++ b/internal/pkg/lvm/sanitize_test.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -293,5 +295,98 @@ func TestSanitizePreventsDataRemanence(t *testing.T) {
 	}
 	if idx := firstNonZero(got); idx != -1 {
 		t.Fatalf("newly created volume is not zeroed at offset %d", idx)
+	}
+}
+
+// backingFileUsage returns the number of bytes actually allocated on disk for
+// the file backing a loop device, which is less than its apparent size while
+// the file is still sparse.
+func backingFileUsage(t *testing.T, loopDev string) int64 {
+	t.Helper()
+
+	link := fmt.Sprintf("/sys/block/%s/loop/backing_file", filepath.Base(loopDev))
+	raw, err := os.ReadFile(link) //nolint:gosec // Path is derived from a device name created by this test.
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", link, err)
+	}
+	path := strings.TrimSpace(string(raw))
+
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		t.Fatalf("failed to stat backing file %s: %v", path, err)
+	}
+
+	// st_blocks counts 512-byte units regardless of the filesystem's block
+	// size.
+	return st.Blocks * 512
+}
+
+// TestSanitizeReleasesBackingStore verifies that sanitization does not leave a
+// thin-provisioned or file-backed volume group fully allocated.
+//
+// BLKZEROOUT writes real zeroes rather than unmapping, so zeroing a volume
+// materializes every block it covers. Without the discard that follows,
+// deleting volumes would permanently consume backing capacity for extents that
+// are no longer in use, and a volume group that was cheap to hold would grow to
+// its full size purely through normal create and delete activity.
+//
+// The assertion is deliberately about allocation, not about the contents: that
+// the range still reads back as zeroes is covered by the tests above.
+func TestSanitizeReleasesBackingStore(t *testing.T) {
+	if !isRoot() {
+		t.Skip("Skipping TestSanitizeReleasesBackingStore as it requires root permissions.")
+	}
+	if _, err := os.Stat("/sbin/lvm"); err != nil {
+		t.Skip("Skipping TestSanitizeReleasesBackingStore as /sbin/lvm is not available.")
+	}
+
+	c := lvm.NewClient(lvm.WithBlockDeviceUtilities(block.New()))
+	ctx := context.Background()
+
+	device, cleanupLoopDev, err := testUtils.CreateLoopDevWithSize(int64(GiB))
+	if err != nil {
+		t.Fatalf("failed to create loop device: %v", err)
+	}
+	t.Cleanup(cleanupLoopDev)
+
+	if err := c.CreatePhysicalVolume(ctx, lvm.CreatePVOptions{Name: device}); err != nil {
+		t.Fatalf("failed to create PV: %v", err)
+	}
+	t.Cleanup(func() { _ = c.RemovePhysicalVolume(ctx, lvm.RemovePVOptions{Name: device}) })
+
+	vgName := fmt.Sprintf("sanvg%d", mustRandomInt(100000))
+	if err := c.CreateVolumeGroup(ctx, lvm.CreateVGOptions{Name: vgName, PVNames: []string{device}}); err != nil {
+		t.Fatalf("failed to create VG: %v", err)
+	}
+	t.Cleanup(func() { _ = c.RemoveVolumeGroup(ctx, lvm.RemoveVGOptions{Name: vgName}) })
+
+	lvName := uniqueName("reclaim")
+	if _, err := c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
+		Name:   lvName,
+		VGName: vgName,
+		Size:   fmt.Sprintf("%dB", int64(lvSize)),
+	}); err != nil {
+		t.Fatalf("failed to create LV: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.RemoveLogicalVolume(ctx, lvm.RemoveLVOptions{Name: vgName + "/" + lvName})
+	})
+
+	before := backingFileUsage(t, device)
+
+	if err := c.SanitizeLogicalVolume(ctx, vgName, lvName); err != nil {
+		t.Fatalf("SanitizeLogicalVolume returned error: %v", err)
+	}
+
+	after := backingFileUsage(t, device)
+
+	// Allow for LVM metadata and filesystem overhead, which is orders of
+	// magnitude smaller than the volume. The failure this guards against is
+	// the whole volume being materialized, so half its size is a generous
+	// threshold that still cannot be reached by overhead alone.
+	threshold := before + int64(lvSize)/2
+	if after > threshold {
+		t.Errorf("backing file grew from %d to %d bytes after sanitizing a %d byte volume; "+
+			"expected the zeroed blocks to be released", before, after, int64(lvSize))
 	}
 }

--- a/internal/pkg/lvm/sanitize_test.go
+++ b/internal/pkg/lvm/sanitize_test.go
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lvm_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"local-csi-driver/internal/pkg/block"
+	"local-csi-driver/internal/pkg/lvm"
+	testUtils "local-csi-driver/test/pkg/utils/device"
+)
+
+// lvSize is the size of the logical volumes used by the sanitization tests.
+//
+// It is large enough to span multiple extents and multiple write-fallback
+// buffers, and small enough to keep the tests quick.
+const lvSize = 64 * (1 << 20) // 64 MiB.
+
+// writePattern fills the first n bytes of the device at path with a
+// recognisable non-zero pattern and returns it.
+func writePattern(t *testing.T, path string, n int64) []byte {
+	t.Helper()
+
+	pattern := make([]byte, n)
+	for i := range pattern {
+		pattern[i] = byte(i%251 + 1) // Never zero: 251 is prime, offset by 1.
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("failed to open %s for writing: %v", path, err)
+	}
+	defer f.Close() //nolint:errcheck // Sync below reports any deferred error.
+
+	if _, err := f.WriteAt(pattern, 0); err != nil {
+		t.Fatalf("failed to write pattern to %s: %v", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("failed to flush pattern to %s: %v", path, err)
+	}
+
+	return pattern
+}
+
+// readDevice reads the first n bytes of the device at path, bypassing the page
+// cache where possible so that what is read reflects the device rather than a
+// stale cached copy of it.
+func readDevice(t *testing.T, path string, n int64) []byte {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open %s for reading: %v", path, err)
+	}
+	defer f.Close() //nolint:errcheck // Read-only.
+
+	// Drop any cached pages for this device so the read goes to the backing
+	// store. Without this a test could pass on cache contents alone.
+	if err := unix.IoctlSetInt(int(f.Fd()), unix.BLKFLSBUF, 0); err != nil {
+		t.Logf("BLKFLSBUF on %s failed, continuing: %v", path, err)
+	}
+
+	buf := make([]byte, n)
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+
+	return buf
+}
+
+// firstNonZero returns the offset of the first non-zero byte, or -1.
+func firstNonZero(b []byte) int {
+	return bytes.IndexFunc(b, func(r rune) bool { return r != 0 })
+}
+
+// newTestVolumeGroup creates a loop-backed volume group and registers cleanup.
+func newTestVolumeGroup(t *testing.T, c *lvm.Client) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	device, cleanupLoopDev, err := testUtils.CreateLoopDevWithSize(int64(GiB))
+	if err != nil {
+		t.Fatalf("failed to create loop device: %v", err)
+	}
+	t.Cleanup(cleanupLoopDev)
+
+	if err := c.CreatePhysicalVolume(ctx, lvm.CreatePVOptions{Name: device}); err != nil {
+		t.Fatalf("failed to create PV: %v", err)
+	}
+	t.Cleanup(func() { _ = c.RemovePhysicalVolume(ctx, lvm.RemovePVOptions{Name: device}) })
+
+	vgName := fmt.Sprintf("sanvg%d", mustRandomInt(100000))
+	if err := c.CreateVolumeGroup(ctx, lvm.CreateVGOptions{Name: vgName, PVNames: []string{device}}); err != nil {
+		t.Fatalf("failed to create VG: %v", err)
+	}
+	t.Cleanup(func() { _ = c.RemoveVolumeGroup(ctx, lvm.RemoveVGOptions{Name: vgName}) })
+
+	return vgName
+}
+
+// TestSanitizeLogicalVolume exercises the sanitization primitive against real
+// LVM logical volumes on a loop-backed volume group.
+func TestSanitizeLogicalVolume(t *testing.T) {
+	if !isRoot() {
+		t.Skip("Skipping TestSanitizeLogicalVolume as it requires root permissions.")
+	}
+	if _, err := os.Stat("/sbin/lvm"); err != nil {
+		t.Skip("Skipping TestSanitizeLogicalVolume as /sbin/lvm is not available.")
+	}
+
+	c := lvm.NewClient(lvm.WithBlockDeviceUtilities(block.New()))
+	ctx := context.Background()
+
+	// The whole volume is zeroed, not just the first extent or the first few
+	// kilobytes that lvcreate clears by default.
+	t.Run("ZeroesEntireVolume", func(t *testing.T) {
+		vgName := newTestVolumeGroup(t, c)
+		lvName := uniqueName("lv")
+
+		size, err := c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
+			Name:   lvName,
+			VGName: vgName,
+			Size:   fmt.Sprintf("%db", lvSize),
+		})
+		if err != nil {
+			t.Fatalf("failed to create LV: %v", err)
+		}
+		defer func() {
+			_ = c.RemoveLogicalVolume(ctx, lvm.RemoveLVOptions{Name: vgName + "/" + lvName})
+		}()
+
+		path := lvm.ConstructLogicalVolumePath(vgName, lvName)
+		pattern := writePattern(t, path, size)
+
+		// Confirm the pattern really is on the device, so that an all-zero
+		// result after sanitization cannot be a false pass caused by the write
+		// never landing.
+		if got := readDevice(t, path, size); !bytes.Equal(got, pattern) {
+			t.Fatal("pattern was not written to the volume; test cannot verify sanitization")
+		}
+
+		if err := c.SanitizeLogicalVolume(ctx, vgName, lvName); err != nil {
+			t.Fatalf("SanitizeLogicalVolume returned error: %v", err)
+		}
+
+		if idx := firstNonZero(readDevice(t, path, size)); idx != -1 {
+			t.Fatalf("found non-zero byte at offset %d after sanitization", idx)
+		}
+	})
+
+	// A volume that is claimed by another process must be reported as in use
+	// and left alone, rather than being zeroed underneath its consumer.
+	t.Run("RefusesVolumeInUse", func(t *testing.T) {
+		vgName := newTestVolumeGroup(t, c)
+		lvName := uniqueName("lv")
+
+		size, err := c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
+			Name:   lvName,
+			VGName: vgName,
+			Size:   fmt.Sprintf("%db", lvSize),
+		})
+		if err != nil {
+			t.Fatalf("failed to create LV: %v", err)
+		}
+		defer func() {
+			_ = c.RemoveLogicalVolume(ctx, lvm.RemoveLVOptions{Name: vgName + "/" + lvName})
+		}()
+
+		path := lvm.ConstructLogicalVolumePath(vgName, lvName)
+		pattern := writePattern(t, path, size)
+
+		// Claim the device exclusively, as a mount or an open raw block
+		// consumer would.
+		holder, err := os.OpenFile(path, os.O_RDONLY|unix.O_EXCL, 0)
+		if err != nil {
+			t.Fatalf("failed to claim device exclusively: %v", err)
+		}
+		defer holder.Close() //nolint:errcheck // Test cleanup.
+
+		err = c.SanitizeLogicalVolume(ctx, vgName, lvName)
+		if !errors.Is(err, lvm.ErrInUse) {
+			t.Fatalf("expected ErrInUse for a claimed device, got %v", err)
+		}
+
+		// The data must be untouched, since a refused wipe must not be a
+		// partial wipe.
+		if got := readDevice(t, path, size); !bytes.Equal(got, pattern) {
+			t.Fatal("volume was modified despite being in use")
+		}
+	})
+
+	// Sanitizing a volume that does not exist must report an error rather than
+	// silently succeeding, so a caller cannot mistake it for a completed wipe.
+	//
+	// The assertion is deliberately "an error" rather than ErrNotFound.
+	// GetLogicalVolume documents ErrNotFound for a missing volume, but on LVM
+	// builds that emit the report as JSON the "Failed to find logical volume"
+	// message is written to the log array on stdout and stderr is left empty,
+	// so getErrorType has nothing to match on and the raw exit status is
+	// returned instead. That is a pre-existing classification gap, tracked
+	// separately; what matters here is that the error is not swallowed.
+	t.Run("MissingVolume", func(t *testing.T) {
+		vgName := newTestVolumeGroup(t, c)
+
+		err := c.SanitizeLogicalVolume(ctx, vgName, uniqueName("missing"))
+		if err == nil {
+			t.Fatal("expected an error for a missing logical volume, got nil")
+		}
+	})
+}
+
+// TestSanitizePreventsDataRemanence is the regression test for extent reuse.
+//
+// It reproduces the sequence that exposes residual data: a volume is written
+// to, deleted, and a new volume of the same size is created in the same volume
+// group so that it is allocated the same extents. Without sanitization the new
+// volume returns the previous volume's contents from offset 4096 onward,
+// because lvcreate only clears the first 4 KiB.
+//
+// The new volume is read as a raw block device, which is how a volumeMode:
+// Block consumer sees it. No filesystem is created, so nothing else can mask
+// the residual data.
+func TestSanitizePreventsDataRemanence(t *testing.T) {
+	if !isRoot() {
+		t.Skip("Skipping TestSanitizePreventsDataRemanence as it requires root permissions.")
+	}
+	if _, err := os.Stat("/sbin/lvm"); err != nil {
+		t.Skip("Skipping TestSanitizePreventsDataRemanence as /sbin/lvm is not available.")
+	}
+
+	c := lvm.NewClient(lvm.WithBlockDeviceUtilities(block.New()))
+	ctx := context.Background()
+
+	vgName := newTestVolumeGroup(t, c)
+
+	// First tenant: create a volume and write identifiable data to it.
+	firstLV := uniqueName("first")
+	size, err := c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
+		Name:   firstLV,
+		VGName: vgName,
+		Size:   fmt.Sprintf("%db", lvSize),
+	})
+	if err != nil {
+		t.Fatalf("failed to create first LV: %v", err)
+	}
+
+	firstPath := lvm.ConstructLogicalVolumePath(vgName, firstLV)
+	pattern := writePattern(t, firstPath, size)
+
+	if got := readDevice(t, firstPath, size); !bytes.Equal(got, pattern) {
+		t.Fatal("pattern was not written to the first volume; test cannot detect remanence")
+	}
+
+	// Deletion sanitizes before removing, which is the behaviour under test.
+	if err := c.SanitizeLogicalVolume(ctx, vgName, firstLV); err != nil {
+		t.Fatalf("SanitizeLogicalVolume returned error: %v", err)
+	}
+	if err := c.RemoveLogicalVolume(ctx, lvm.RemoveLVOptions{Name: vgName + "/" + firstLV}); err != nil {
+		t.Fatalf("failed to remove first LV: %v", err)
+	}
+
+	// Second tenant: same volume group, same size, so the allocator hands back
+	// the extents the first volume was using.
+	secondLV := uniqueName("second")
+	secondSize, err := c.CreateLogicalVolume(ctx, lvm.CreateLVOptions{
+		Name:   secondLV,
+		VGName: vgName,
+		Size:   fmt.Sprintf("%db", lvSize),
+	})
+	if err != nil {
+		t.Fatalf("failed to create second LV: %v", err)
+	}
+	defer func() {
+		_ = c.RemoveLogicalVolume(ctx, lvm.RemoveLVOptions{Name: vgName + "/" + secondLV})
+	}()
+
+	secondPath := lvm.ConstructLogicalVolumePath(vgName, secondLV)
+	got := readDevice(t, secondPath, secondSize)
+
+	// The specific failure being guarded against: the previous tenant's data
+	// readable from offset 4096, past the 4 KiB that lvcreate zeroes.
+	if bytes.Contains(got, pattern[:4096]) {
+		t.Fatal("previous volume's data is readable from the newly created volume")
+	}
+	if idx := firstNonZero(got); idx != -1 {
+		t.Fatalf("newly created volume is not zeroed at offset %d", idx)
+	}
+}

--- a/internal/pkg/lvm/unsupported.go
+++ b/internal/pkg/lvm/unsupported.go
@@ -79,6 +79,21 @@ func (l *Noop) RemoveLogicalVolume(ctx context.Context, opts RemoveLVOptions) er
 	return ErrUnsupported
 }
 
+// UpdateLogicalVolume implements Manager.
+func (l *Noop) UpdateLogicalVolume(ctx context.Context, opts UpdateLVOptions) error {
+	return ErrUnsupported
+}
+
+// RenameLogicalVolume implements Manager.
+func (l *Noop) RenameLogicalVolume(ctx context.Context, opts RenameLVOptions) error {
+	return ErrUnsupported
+}
+
+// SanitizeLogicalVolume implements Manager.
+func (l *Noop) SanitizeLogicalVolume(ctx context.Context, vgName string, lvName string) error {
+	return ErrUnsupported
+}
+
 // RemovePhysicalVolume implements Manager.
 func (l *Noop) RemovePhysicalVolume(ctx context.Context, opts RemovePVOptions) error {
 	return ErrUnsupported

--- a/internal/pkg/lvm/unsupported.go
+++ b/internal/pkg/lvm/unsupported.go
@@ -118,3 +118,8 @@ func (l *Noop) IsLogicalVolumeCorrupted(ctx context.Context, vgName string, lvNa
 func (l *Noop) RemoveStaleDeviceMapperNodes(ctx context.Context, vgName string) error {
 	return ErrUnsupported
 }
+
+// MakeVolumeGroupDeviceNodes implements Manager.
+func (l *Noop) MakeVolumeGroupDeviceNodes(ctx context.Context, opts MakeVGDeviceNodesOptions) error {
+	return ErrUnsupported
+}


### PR DESCRIPTION
## What

Overwrite a logical volume's extents with zeroes before they return to the volume group's free pool.

Volumes are currently removed with a plain `lvremove`, which unmaps the extents but does not overwrite them. LVM zeroes only the first 4 KiB of a new logical volume, to clear filesystem signatures, so reissued extents still carry the previous volume's contents. A volume group is shared by every workload on the node, and the driver should not rely on the node hosting a single trust domain.

## How

Zeroing cannot happen inside `DeleteVolume`: it runs under the csi-provisioner timeout, which the chart leaves at the 15s default, while zeroing a volume takes minutes. Deletion is split into a synchronous quarantine and an asynchronous wipe.

**Quarantine** (synchronous, in `DeleteVolume`) tags the volume `local-csi-wipe-pending` and renames it to `local-csi-wipe-<uuid>`. The extents stay allocated, so LVM cannot reissue them, and the original name is freed so a later `CreateVolume` for the same volume ID cannot collide.

The rename is the **commit point** for destruction; the tag only tells orphan cleanup to leave a quarantine in progress alone. Commitment is keyed on the name rather than the tag because each marker can be absent independently and only one of those states is safe to misread: a committed volume can legitimately lose its tag, and would then hold its contents indefinitely, whereas a tagged volume under its own name is simply still in service. The CSI layer rejects volume handles in the reserved namespace, so a pre-provisioned PV cannot forge the marker.

**The reaper** (`internal/csi/core/lvm/reaper.go`) zeroes each quarantined volume with `BLKZEROOUT` on an exclusively-held descriptor, falling back to buffered writes that resume at the failing offset, and removes the volume only once zeroing has succeeded. It sweeps unconditionally at startup, so a crash mid-quarantine is recovered rather than stranded. Defaults: 60s interval, concurrency 1 (zeroing is bandwidth-bound). It runs on the driver DaemonSet and does not depend on the API server.

**`EnsureVolume`'s corrupted-volume path** no longer removes and recreates the volume. That branch is usually reached for a merely deactivated volume, whose extents are intact and still populated. It now reactivates first, forcing LVM to reconcile device nodes (`vgmknodes`) before re-checking so a reboot-timing race can't be mistaken for corruption. If the volume still can't be brought back online, it is left untouched and the request fails rather than being quarantined: the driver only inferred the volume might be unusable, it wasn't told to delete it, so quarantine stays reserved for an explicit `DeleteVolume`. An operator who has independently confirmed a volume is truly dead can still reclaim its capacity by deleting the PV.

## Not covered

Extents already free before this change are not tracked and are not wiped; the guarantee is forward-only. It resolves itself as the free pool turns over. Non-goals (pre-existing free space, forensic erasure below the block interface, operator access, encryption) are enumerated in the design doc.

## No opt-out flag

Deliberate. The beneficiary of a wipe is the *next* volume, so a per-volume or per-StorageClass opt-out is incoherent, and a node-global one is what gets flipped for a benchmark and never restored. Tuning knobs (`--volume-wipe-interval`, `--volume-wipe-concurrency`) are exposed; the behaviour is not.

## Testing

- Unit tests for quarantine, the commit model, reaper scheduling/backoff, the fail-closed in-use checks, and the reserved namespace. Every new guard is mutation-verified.
- Root-gated end-to-end tests against real LVM (`internal/pkg/lvm/sanitize_test.go`, `quarantine_errors_test.go`), including `TestSanitizePreventsDataRemanence`, which writes a marker, deletes, reallocates, and asserts the extents read back as zeroes. Run in a privileged container with `lvm2` and `DM_DISABLE_UDEV=1`.
- CSI conformance re-checked against spec v1.12.0: no capability changes; `DeleteVolume` codes and idempotency unaffected.

## Also fixed

`Client.UpdateLogicalVolume` and `RenameLogicalVolume` returned raw errors without classification, so `lvm.IgnoreNotFound` could never match and repeat deletes were not idempotent. Both now run through `getErrorType`, and a new `ErrVolumeGroupNotFound` distinguishes an absent volume group from an absent volume, so an invisible group fails closed rather than being mistaken for an already-deleted volume.

## Design

`docs/design/volume-sanitization.md`

## Follow-ups (not in this PR)

- Metrics for quarantine depth, wipe throughput and failures.
- A startup diagnostic reporting whether `BLKZEROOUT` is supported on the node's devices.
- A stronger reference check for raw block volumes via `FindMountTargets`, narrowing the window between the `lvs` sample and the exclusive open.
